### PR TITLE
Use layout features instead of fixed sizes

### DIFF
--- a/src/components/footer/z-footer/index.tsx
+++ b/src/components/footer/z-footer/index.tsx
@@ -52,12 +52,13 @@ export class ZFooter {
         <div class="header">
           <h2>{group.title}</h2>
           {this.isMobile && (
-            <z-icon
-              name={this.isOpen[id] ? "chevron-up" : "chevron-down"}
-              width={16}
-              height={16}
-              onClick={() => this.handleOnHeaderClick(id)}
-            />
+            <button onClick={() => this.handleOnHeaderClick(id)}>
+              <z-icon
+                name={this.isOpen[id] ? "chevron-up" : "chevron-down"}
+                width={16}
+                height={16}
+              />
+            </button>
           )}
         </div>
         <div class="content">

--- a/src/components/footer/z-footer/styles.css
+++ b/src/components/footer/z-footer/styles.css
@@ -21,6 +21,7 @@ footer > section {
 footer > section.top > nav {
   display: flex;
   flex-direction: column;
+  justify-items: flex-start;
   overflow: hidden;
   margin: var(--half-x1) 0 var(--half-x1) 0;
   padding: 0;
@@ -48,13 +49,24 @@ footer > section.top > nav > .header > h2 {
 }
 
 footer > section.top > nav > .header {
+  position: relative;
   fill: var(--text-white);
 }
 
-footer > section.top > nav > .header > z-icon {
+footer > section.top > nav > .header > button {
   position: absolute;
-  right: 36px;
-  margin-top: var(--basex1);
+  top: var(--basex1);
+  right: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  appearance: none;
+  cursor: pointer;
+}
+
+footer > section.top > nav > .header > button > z-icon {
+  display: block;
 }
 
 footer > section.top > nav > .content {
@@ -117,10 +129,9 @@ footer > section.bottom {
 }
 
 footer > section.bottom > div.item {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 1fr;
-  grid-column: span 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   height: auto;
   width: auto;
   padding: var(--basex2) 0;
@@ -157,13 +168,16 @@ footer > section.bottom > div.bottom-links {
 }
 
 footer > section.bottom > div.item > p {
-  width: 50%;
+  margin: var(--basex1) 0;
   padding: var(--basex1) 0;
-  margin: 0;
 }
 
-footer > section.bottom > div.item:nth-child(1) > p {
-  width: 253px;
+footer > section.bottom > div.item > p:first-child {
+  margin-top: 0;
+}
+
+footer > section.bottom > div.item > p:last-child {
+  margin-bottom: 0;
 }
 
 footer > section.bottom > div.logo > p > span {
@@ -224,7 +238,6 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.top > nav > .content > ul > li {
-    width: 223px;
     margin: 0 var(--basex1) 0 0;
     padding: var(--half-x1) 0px;
     border: none;
@@ -237,7 +250,7 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.bottom {
-    grid-template-columns: 1fr 1fr 2fr;
+    grid-template-columns: calc(4 * var(--basex8)) 1fr 2fr;
     background-color: var(--bg-grey-900);
     padding: 0 var(--basex2);
   }
@@ -257,7 +270,6 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.bottom > div.item > p {
-    width: 80%;
     padding-top: 0;
   }
 
@@ -325,20 +337,12 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.top > nav > .header {
+    display: inline-flex;
     border-bottom: 1px solid var(--bg-grey-050);
-    width: 120px;
-  }
-
-  footer > section.top > nav > .header > h2 {
-    position: absolute;
   }
 
   footer > section.bottom {
     padding: var(--basex2) var(--basex4);
-  }
-
-  footer > section.bottom > div.item:nth-child(1) > p:nth-of-type(1) {
-    margin-top: var(--basex2);
   }
 
   footer > section.bottom > div.item:nth-child(1) > p:nth-of-type(2) {
@@ -347,7 +351,7 @@ footer > section.bottom > div.logo > p > span {
 
   footer > section.bottom > div.item > p {
     padding-bottom: 0;
-    margin-bottom: var(--basex1);
+    margin-bottom: var(--basex2);
   }
 
   footer > section.bottom > div.item > ul.social {

--- a/src/components/footer/z-footer/styles.css
+++ b/src/components/footer/z-footer/styles.css
@@ -221,16 +221,16 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.top > nav > .content {
+    width: 100%;
     padding: 0;
     margin: 0;
   }
 
   footer > section.top > nav > .content > ul {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 18px;
     height: auto;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
     align-items: stretch;
     align-content: stretch;
     border-bottom: none;
@@ -339,6 +339,13 @@ footer > section.bottom > div.logo > p > span {
   footer > section.top > nav > .header {
     display: inline-flex;
     border-bottom: 1px solid var(--bg-grey-050);
+  }
+
+  footer > section.top > nav > .content > ul {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   footer > section.bottom {

--- a/src/components/footer/z-footer/styles.css
+++ b/src/components/footer/z-footer/styles.css
@@ -198,7 +198,7 @@ footer > section.bottom > div.logo > p > span {
   footer > section.top > nav {
     height: fit-content;
     display: grid;
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: calc((100% - 54px) / 4) auto;
     grid-template-rows: 1fr;
     grid-column-gap: 18px;
     padding: var(--basex2) 0 var(--basex1) 0;
@@ -228,7 +228,7 @@ footer > section.bottom > div.logo > p > span {
 
   footer > section.top > nav > .content > ul {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: calc((100% - 36px) / 3) calc((100% - 36px) / 3) auto;
     grid-column-gap: 18px;
     height: auto;
     align-items: stretch;
@@ -238,7 +238,7 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.top > nav > .content > ul > li {
-    margin: 0 var(--basex1) 0 0;
+    margin: 0;
     padding: var(--half-x1) 0px;
     border: none;
   }
@@ -250,9 +250,10 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.bottom {
-    grid-template-columns: calc(4 * var(--basex8)) 1fr 2fr;
+    grid-template-columns: calc((100% - 54px) / 4) calc((100% - 54px) / 4) auto;
+    grid-column-gap: 18px;
     background-color: var(--bg-grey-900);
-    padding: 0 var(--basex2);
+    padding: 0 var(--basex4);
   }
 
   footer > section.bottom > div.item {
@@ -266,7 +267,6 @@ footer > section.bottom > div.logo > p > span {
   footer > section.bottom > div.item:nth-child(2) {
     order: 2;
     border-bottom: none;
-    margin: 0px var(--basex2) 0px var(--basex2);
   }
 
   footer > section.bottom > div.item > p {
@@ -281,7 +281,7 @@ footer > section.bottom > div.logo > p > span {
 
   footer > section.bottom > div.logo > z-logo {
     height: 39px;
-    width: 220px;
+    width: auto;
   }
 
   footer > section.bottom > div.bottom-links {
@@ -291,9 +291,10 @@ footer > section.bottom > div.logo > p > span {
 
   footer > section.bottom > div.bottom-links > ul {
     display: grid;
-    grid-template-columns: repeat(2, auto);
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 18px;
     height: 54px;
-    margin: 0 var(--half-x1);
+    margin: 0;
     padding: 0;
     font-size: 12px;
   }

--- a/src/components/footer/z-footer/styles.css
+++ b/src/components/footer/z-footer/styles.css
@@ -198,7 +198,7 @@ footer > section.bottom > div.logo > p > span {
   footer > section.top > nav {
     height: fit-content;
     display: grid;
-    grid-template-columns: calc((100% - 54px) / 4) auto;
+    grid-template-columns: repeat(4, 1fr);
     grid-template-rows: 1fr;
     grid-column-gap: 18px;
     padding: var(--basex2) 0 var(--basex1) 0;
@@ -221,6 +221,7 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.top > nav > .content {
+    grid-column: span 3;
     width: 100%;
     padding: 0;
     margin: 0;
@@ -228,7 +229,7 @@ footer > section.bottom > div.logo > p > span {
 
   footer > section.top > nav > .content > ul {
     display: grid;
-    grid-template-columns: calc((100% - 36px) / 3) calc((100% - 36px) / 3) auto;
+    grid-template-columns: repeat(3, 1fr);
     grid-column-gap: 18px;
     height: auto;
     align-items: stretch;
@@ -250,7 +251,7 @@ footer > section.bottom > div.logo > p > span {
   }
 
   footer > section.bottom {
-    grid-template-columns: calc((100% - 54px) / 4) calc((100% - 54px) / 4) auto;
+    grid-template-columns: repeat(4, 1fr);
     grid-column-gap: 18px;
     background-color: var(--bg-grey-900);
     padding: 0 var(--basex4);
@@ -286,6 +287,7 @@ footer > section.bottom > div.logo > p > span {
 
   footer > section.bottom > div.bottom-links {
     display: block;
+    grid-column: span 2;
     order: 3;
   }
 


### PR DESCRIPTION
This PR remove all fixed references in the `z-footer` in order to correctly handle responsiveness.

Fixes #5

Extra: use `<button>`s for menu toggles in mobile viewport