### PR TITLE
Avoid `false` in header element classes

### DIFF
--- a/src/components/navigation/z-header/index.spec.ts
+++ b/src/components/navigation/z-header/index.spec.ts
@@ -22,7 +22,7 @@ describe("Suite test ZHeader", () => {
     <z-header activeintlinkid="" extlinkdata="[]" imagealt="logo zanichelli" intlinkdata="[]" ismyz="true" logolink="https://www.zanichelli.it" logopath="./assets/images/png/zanichelli-logo-2.png">
       <mock:shadow-root>
         <header>
-          <div class="false mobile-header" id="mobile-header">
+          <div class="mobile-header" id="mobile-header">
             <div class="logo">
               <z-logo imagealt="logo zanichelli" height="36" width="144" link="https://www.zanichelli.it" targetblank=""></z-logo>
             </div>
@@ -78,12 +78,12 @@ describe("Suite test ZHeader", () => {
     <z-header activeintlinkid="" extlinkdata="[]" imagealt="logo zanichelli" intlinkdata="[]" ismyz="true" logolink="https://www.zanichelli.it" logopath="./assets/images/png/zanichelli-logo-2.png" userdata='{"islogged":true,"id":123456,"name":"Dario Docente e Professore","usergroup":15,"userlinks":[{"label":"Profilo","link":"http://www.zanichelli.it"},{"label":"Esci","link":"#home"}]}'>
     <mock:shadow-root>
       <header>
-        <div class="false mobile-header" id="mobile-header">
+        <div class="mobile-header" id="mobile-header">
           <div class="logo">
             <z-logo imagealt="logo zanichelli" height="36" width="144" link="https://www.zanichelli.it" targetblank=""></z-logo>
           </div>
           <div class="menu-mobile" id="mobile-menu-wrapper">
-            <div class="false menu-toggle" id="mobile-menu">
+            <div class="menu-toggle" id="mobile-menu">
               <span class="bar"></span>
               <span class="bar"></span>
               <span class="bar"></span>
@@ -93,7 +93,7 @@ describe("Suite test ZHeader", () => {
             </span>
           </div>
         </div>
-        <div class="false mobile-content" id="mobile-content">
+        <div class="mobile-content" id="mobile-content">
           <div class="mobile-login" id="mobile-login">
             <span>
               <a class="menu-item" id="user-data" role="button">
@@ -140,7 +140,7 @@ describe("Suite test ZHeader", () => {
     >
       <mock:shadow-root>
         <header>
-          <div class="false mobile-header" id="mobile-header">
+          <div class="mobile-header" id="mobile-header">
             <div class="logo">
               <z-logo imagealt="logo zanichelli" height="36" width="144" link="https://www.zanichelli.it" targetblank=""></z-logo>
             </div>
@@ -153,7 +153,7 @@ describe("Suite test ZHeader", () => {
               <span>Menu</span>
             </div>
           </div>
-          <div id="mobile-content" class="mobile-content open false">
+          <div id="mobile-content" class="mobile-content open">
             <div id="mobile-login" class="mobile-login">
               <span>
                 <a class="menu-item" id="user-data" role="button">
@@ -255,13 +255,13 @@ describe("Suite test ZHeader", () => {
 
       <z-header activeintlinkid="" extlinkdata='[]' imagealt="logo zanichelli" intlinkdata='[]' ismyz="true" logolink="https://www.zanichelli.it" logopath="./assets/images/png/zanichelli-logo-2.png">
       <mock:shadow-root>
-        <header class="false">
+        <header>
           <div class="top-header">
             <div class="editors">
               <slot name="editors"></slot>
             </div>
           </div>
-          <div class="main-header false" id="main-header">
+          <div class="main-header" id="main-header">
             <div class="logo">
               <z-logo imagealt="logo zanichelli" height="36" width="144" link="https://www.zanichelli.it" targetblank></z-logo>
             </div>
@@ -293,13 +293,13 @@ describe("Suite test ZHeader", () => {
       activeintlinkid="home"
     >
       <mock:shadow-root>
-        <header class="false">
+        <header>
           <div class="top-header">
             <div class="editors">
               <slot name="editors" />
             </div>
           </div>
-          <div id="main-header" class="main-header false">
+          <div id="main-header" class="main-header">
             <div class="logo">
               <z-logo
                 height="36"
@@ -366,13 +366,13 @@ describe("Suite test ZHeader", () => {
       activeintlinkid=""
     >
       <mock:shadow-root>
-        <header class="false">
+        <header>
           <div class="top-header">
             <div class="editors">
               <slot name="editors" />
             </div>
           </div>
-          <div id="main-header" class="main-header false">
+          <div id="main-header" class="main-header">
             <div class="logo">
               <z-logo
                 height="36"
@@ -424,7 +424,7 @@ describe("Suite test ZHeader", () => {
               />
             </div>
             <div id="link-ext" class="link-ext">
-              <span class="link-ext-span false">
+              <span class="link-ext-span">
                 <z-link id="supporto" href="https://www.zanichelli.it/contatti-e-recapiti" icon="question-mark.png" target="_blank" htmlid="supporto" htmltabindex="10">Supporto</z-link>
               </span>
             </div>
@@ -464,13 +464,13 @@ describe("Suite test ZHeader", () => {
       activeintlinkid=""
     >
       <mock:shadow-root>
-        <header class="false">
+        <header>
           <div class="top-header">
             <div class="editors">
               <slot name="editors" />
             </div>
           </div>
-          <div id="main-header" class="main-header false">
+          <div id="main-header" class="main-header">
             <div class="logo">
               <z-logo
                 height="36"

--- a/src/components/navigation/z-header/index.tsx
+++ b/src/components/navigation/z-header/index.tsx
@@ -352,7 +352,7 @@ export class ZHeader {
 
   renderMainHeader(): HTMLDivElement {
     return (
-      <div id="main-header" class={`main-header ${!this.ismyz && "myz-out"}`}>
+      <div id="main-header" class={`main-header${this.ismyz ? "" : " myz-out"}`}>
         {this.renderLogoDiv()}
         {this.renderIntMenu(this.intMenuData)}
         {this.renderExtMenu(this.extMenuData)}
@@ -374,7 +374,7 @@ export class ZHeader {
     return (
       <div
         id="mobile-header"
-        class={`mobile-header ${!this.ismyz && "myz-out"}`}
+        class={`mobile-header${this.ismyz ? "" : " myz-out"}`}
       >
         {this.renderLogoDiv()}
         {this.renderMobileMenuToggle()}
@@ -392,7 +392,7 @@ export class ZHeader {
         onClick={() => (this.isMenuMobileOpen = !this.isMenuMobileOpen)}
       >
         <div
-          class={`menu-toggle ${this.isMenuMobileOpen && "is-active"}`}
+          class={`menu-toggle${this.isMenuMobileOpen ? " is-active" : ""}`}
           id="mobile-menu"
         >
           <span class="bar" />
@@ -410,8 +410,7 @@ export class ZHeader {
     return (
       <div
         id="mobile-content"
-        class={`mobile-content ${this.isMenuMobileOpen && "open"} ${!this
-          .ismyz && "myz-out"}`}
+        class={`mobile-content${this.isMenuMobileOpen ? " open" : ""}${this.ismyz ? "" : " myz-out"}`}
       >
         {this.renderMobileLoginDiv(this.userData)}
         {this.ismyz && <hr />}

--- a/src/components/navigation/z-header/index.tsx
+++ b/src/components/navigation/z-header/index.tsx
@@ -164,11 +164,7 @@ export class ZHeader {
         <svg
           height="8"
           width="16"
-          class={
-            this.activeMenuItem
-              ? id !== this.activeMenuItem.id && "hidden"
-              : "hidden"
-          }
+          class={(!this.activeMenuItem || this.activeMenuItem.id !== id) ? "hidden" : ""}
         >
           <polygon points="8,0 16,8 0,8" class="arrow" />
         </svg>
@@ -252,13 +248,13 @@ export class ZHeader {
           (menuItem: MenuItem): HTMLSpanElement => {
             const { id, label, link, icon } = menuItem;
             return (
-              <span class={`link-ext-span ${this.ismyz && "myz"}`}>
+              <span class={`link-ext-span${this.ismyz ? " myz" : ""}`}>
                 <z-link
                   id={id}
                   htmlid={id}
                   href={link}
                   icon={icon}
-                  iswhite={this.ismyz ? true : false}
+                  iswhite={!!this.ismyz}
                   target="_blank"
                   htmltabindex={10}
                 >
@@ -342,7 +338,7 @@ export class ZHeader {
 
   renderDesktopHeader(): HTMLHeadingElement {
     return (
-      <header class={`${!this.ismyz && "myz-out"}`}>
+      <header class={!this.ismyz ? "myz-out" : ""}>
         {this.renderTopHeader()}
         {this.renderMainHeader()}
         {this.renderSubMenu(this.activeMenuItem)}


### PR DESCRIPTION
This PR enhances classlist generation with template literals. With the previous implementation, checks like `${!this.ismyz && "myz-out"}` often resulted in having `false` between the classes of the elements. This happens when the first operand is evaluated to `false`, because of the `&&` operator [**Short-circuit evaluation**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND).