### PR TITLE
Remove host selector from root variable for edge compatibility

### DIFF
--- a/src/globals/global-border-and-radius.css
+++ b/src/globals/global-border-and-radius.css
@@ -1,5 +1,4 @@
-:root,
-:host {
+:root {
   --border-base: 2px;
   --border-size-small: 1px;
 

--- a/src/globals/global-colors.css
+++ b/src/globals/global-colors.css
@@ -1,5 +1,4 @@
-:root,
-:host {
+:root {
   --myz-blue: #0056c1;
   --myz-blue-dark: #003476;
   --myz-blue-light: #1973e1;

--- a/src/globals/global-fonts.css
+++ b/src/globals/global-fonts.css
@@ -1,7 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,600&display=swap');
 
-:root,
-:host {
+:root {
   --dashboard-font: IBM Plex Sans;
   --font-lt: 300;
   --font-rg: 400;

--- a/src/globals/global-grid.css
+++ b/src/globals/global-grid.css
@@ -1,5 +1,4 @@
-:root,
-:host {
+:root {
   --grid-mobile-viewport: 768px;
   --grid-mobile-column: 4;
   --grid-mobile-margin: 16px;

--- a/src/globals/global-spacing.css
+++ b/src/globals/global-spacing.css
@@ -1,5 +1,4 @@
-:root,
-:host {
+:root {
   --basex1: 8px;
   --basex2: 16px;
   --basex3: 24px;


### PR DESCRIPTION
This PR fixes a compatibility issue with Edge which does not support `:host` selector. Since those variables are used in the main context only, we do not really need that selector at all.