### PR TITLE
feat: added hasheader param in z-modal

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -561,6 +561,10 @@ export namespace Components {
     }
     interface ZModal {
         /**
+          * has header (optional)
+         */
+        "hasheader"?: boolean;
+        /**
           * unique id
          */
         "modalid": string;
@@ -1538,6 +1542,10 @@ declare namespace LocalJSX {
         "nomeutente"?: string;
     }
     interface ZModal {
+        /**
+          * has header (optional)
+         */
+        "hasheader"?: boolean;
         /**
           * unique id
          */

--- a/src/components/modal/z-modal/index.spec.ts
+++ b/src/components/modal/z-modal/index.spec.ts
@@ -12,16 +12,18 @@ describe("Suite test ZModal", () => {
       <z-modal>
         <mock:shadow-root>
           <div data-action="modalBackground">
-            <div id="">
-              <header>
-                <div>
-                </div>
-                <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" />
-              </header>
-              <main>
-                <slot name="modalContent" />
-              </main>
-              <div class="bottomBackground" data-action="modalBackground"></div>
+            <div class="scrollWrapper" data-action="modalBackground">
+              <div id="">
+                <header>
+                  <div>
+                  </div>
+                  <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" />
+                </header>
+                <main>
+                  <slot name="modalContent" />
+                </main>
+                <div class="bottomBackground" data-action="modalBackground"></div>
+              </div>
             </div>
           </div>
         </mock:shadow-root>
@@ -38,18 +40,20 @@ describe("Suite test ZModal", () => {
       <z-modal modalid="modal" modaltitle="title" modalsubtitle="subtitle">
         <mock:shadow-root>
           <div data-action="modalBackground" data-modal="modal">
-            <div id="modal">
-              <header>
-                <div>
-                  <h1>title</h1>
-                  <h2>subtitle</h2>
-                </div>
-                <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" data-modal="modal" />
-              </header>
-              <main>
-                <slot name="modalContent" />
-              </main>
-              <div class="bottomBackground" data-action="modalBackground" data-modal="modal"></div>
+            <div class="scrollWrapper" data-action="modalBackground" data-modal="modal">
+              <div id="modal">
+                <header>
+                  <div>
+                    <h1>title</h1>
+                    <h2>subtitle</h2>
+                  </div>
+                  <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" data-modal="modal" />
+                </header>
+                <main>
+                  <slot name="modalContent" />
+                </main>
+                <div class="bottomBackground" data-action="modalBackground" data-modal="modal"></div>
+              </div>
             </div>
           </div>
         </mock:shadow-root>
@@ -70,20 +74,48 @@ describe("Suite test ZModal", () => {
       <z-modal>
         <mock:shadow-root>
           <div data-action="modalBackground">
-            <div id="">
-              <header>
-                <div>
-                </div>
-                <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" />
-              </header>
-              <main>
-                <slot name="modalContent" />
-              </main>
-              <div class="bottomBackground" data-action="modalBackground"></div>
+            <div class="scrollWrapper" data-action="modalBackground">
+              <div id="">
+                <header>
+                  <div>
+                  </div>
+                  <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" />
+                </header>
+                <main>
+                  <slot name="modalContent" />
+                </main>
+                <div class="bottomBackground" data-action="modalBackground"></div>
+              </div>
             </div>
           </div>
         </mock:shadow-root>
         <div slot="modalContent">Contenuto dello <b>slot</b></div>
+      </z-modal>
+    `);
+  });
+
+  it("Test render ZModal without header", async () => {
+    const page = await newSpecPage({
+      components: [ZModal],
+      html: `<z-modal modalid="modal" modaltitle="title" modalsubtitle="subtitle" hasheader="false"></z-modal>`
+    });
+    expect(page.root).toEqualHtml(`
+      <z-modal modalid="modal" modaltitle="title" modalsubtitle="subtitle" hasheader="false">
+        <mock:shadow-root>
+          <div data-action="modalBackground" data-modal="modal">
+            <div class="scrollWrapper" data-action="modalBackground" data-modal="modal">
+              <div id="modal">
+                <div class="iconWrapper">
+                  <z-icon name="circle-cross-fill" tabindex="0" width="24" height="24" data-action="modalClose" data-modal="modal" />
+                </div>
+                <main class="noHeader">
+                  <slot name="modalContent" />
+                </main>
+                <div class="bottomBackground" data-action="modalBackground" data-modal="modal"></div>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
       </z-modal>
     `);
   });

--- a/src/components/modal/z-modal/index.stories.mdx
+++ b/src/components/modal/z-modal/index.stories.mdx
@@ -1,6 +1,6 @@
 import { html } from "lit-html";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
-import { text } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 
 ## Stories
 
@@ -13,8 +13,12 @@ import { text } from '@storybook/addon-knobs';
     {html`
       <z-modal
         modaltitle="${text('modaltitle', 'Modal title')}"
-        modalsubtitle="${text('modalsubtitle', 'Modal subtitle')}">
-        <div slot="modalContent">Modal Content</div>
+        modalsubtitle="${text('modalsubtitle', 'Modal subtitle')}"
+        hasheader="${boolean('hasheader', 'true')}"
+      >
+        <div slot="modalContent" style="width:300px;height:200px;display:flex;justify-content:center;align-items:center">
+          Modal Content
+        </div>
       </z-modal>`}
   </Story>
 </Preview>

--- a/src/components/modal/z-modal/index.tsx
+++ b/src/components/modal/z-modal/index.tsx
@@ -17,6 +17,8 @@ export class ZModal {
   @Prop() modaltitle?: string;
   /** subtitle (optional) */
   @Prop() modalsubtitle?: string;
+  /** has header (optional) */
+  @Prop() hasheader?: boolean = true;
 
   constructor() {
     this.emitModalClose = this.emitModalClose.bind(this);
@@ -35,36 +37,58 @@ export class ZModal {
     this.modalHeaderActive.emit({ modalid: this.modalid });
   }
 
+  renderHeader() {
+    if (!this.hasheader) {
+      return <div class="iconWrapper">{this.renderCloseIcon()}</div>;
+    }
+
+    return (
+      <header onClick={this.emitModalHeaderActive}>
+        <div>
+          {this.modaltitle && <h1>{this.modaltitle}</h1>}
+          {this.modalsubtitle && <h2>{this.modalsubtitle}</h2>}
+        </div>
+        {this.renderCloseIcon()}
+      </header>
+    );
+  }
+
+  renderCloseIcon() {
+    return (
+      <z-icon
+        name="circle-cross-fill"
+        width={24}
+        height={24}
+        onClick={() => this.emitModalClose()}
+        data-action="modalClose"
+        data-modal={this.modalid}
+        onKeyPress={(ev: KeyboardEvent) =>
+          handleKeyboardSubmit(ev, this.emitModalClose)
+        }
+        tabindex="0"
+      />
+    );
+  }
+
   render() {
     return (
       <div data-action="modalBackground" data-modal={this.modalid}>
-        <div id={this.modalid}>
-          <header onClick={this.emitModalHeaderActive}>
-            <div>
-              {this.modaltitle && <h1>{this.modaltitle}</h1>}
-              {this.modalsubtitle && <h2>{this.modalsubtitle}</h2>}
-            </div>
-            <z-icon
-              name="circle-cross-fill"
-              width={24}
-              height={24}
-              onClick={() => this.emitModalClose()}
-              data-action="modalClose"
+        <div
+          class="scrollWrapper"
+          data-action="modalBackground"
+          data-modal={this.modalid}
+        >
+          <div id={this.modalid}>
+            {this.renderHeader()}
+            <main class={!this.hasheader && "noHeader"}>
+              <slot name="modalContent" />
+            </main>
+            <div
+              class="bottomBackground"
+              data-action="modalBackground"
               data-modal={this.modalid}
-              onKeyPress={(ev: KeyboardEvent) =>
-                handleKeyboardSubmit(ev, this.emitModalClose)
-              }
-              tabindex="0"
             />
-          </header>
-          <main>
-            <slot name="modalContent" />
-          </main>
-          <div
-            class="bottomBackground"
-            data-action="modalBackground"
-            data-modal={this.modalid}
-          />
+          </div>
         </div>
       </div>
     );

--- a/src/components/modal/z-modal/readme.md
+++ b/src/components/modal/z-modal/readme.md
@@ -10,11 +10,12 @@
 
 ## Properties
 
-| Property        | Attribute       | Description           | Type     | Default     |
-| --------------- | --------------- | --------------------- | -------- | ----------- |
-| `modalid`       | `modalid`       | unique id             | `string` | `undefined` |
-| `modalsubtitle` | `modalsubtitle` | subtitle (optional)   | `string` | `undefined` |
-| `modaltitle`    | `modaltitle`    | title text (optional) | `string` | `undefined` |
+| Property        | Attribute       | Description           | Type      | Default     |
+| --------------- | --------------- | --------------------- | --------- | ----------- |
+| `hasheader`     | `hasheader`     | has header (optional) | `boolean` | `true`      |
+| `modalid`       | `modalid`       | unique id             | `string`  | `undefined` |
+| `modalsubtitle` | `modalsubtitle` | subtitle (optional)   | `string`  | `undefined` |
+| `modaltitle`    | `modaltitle`    | title text (optional) | `string`  | `undefined` |
 
 
 ## Events

--- a/src/components/modal/z-modal/styles.css
+++ b/src/components/modal/z-modal/styles.css
@@ -3,7 +3,7 @@
   font-weight: var(--font-rg);
 }
 
-:host>div {
+:host > div {
   position: fixed;
   top: 0;
   left: 0;
@@ -12,28 +12,35 @@
   background: rgba(0, 0, 0, 0.7);
   width: 100%;
   height: 100%;
-  z-index: 1000;
-  overflow: auto;
-  overflow: -moz-scrollbars-none;
-  -ms-overflow-style: none;
+  z-index: 99999;
+  overflow: hidden;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
 }
 
-:host>div::-webkit-scrollbar {
-  width: 0 !important
+:host > div > div {
+  overflow: auto;
+  max-height: 100%;
+  scrollbar-width: none;
+  width: 100%;
+  height: 100vh;
 }
 
-:host>div>div {
+:host > div > div::-webkit-scrollbar {
+  width: 0 !important;
+}
+
+:host > div > div > div {
   z-index: 1010;
   width: 100%;
   margin: 0;
   background: var(--bg-white);
+  height: 100%;
 }
 
-:host>div>div>header {
+:host > div > div > div > header {
   display: flex;
   flex-wrap: nowrap;
   flex-direction: row;
@@ -43,19 +50,19 @@
   background: var(--bg-grey-050);
 }
 
-:host>div>div>header>z-icon {
+:host > div > div > div > header > z-icon {
   cursor: pointer;
   fill: var(--myz-blue);
   margin: var(--basex2) var(--basex2);
   transform: scale(0.9);
 }
 
-:host>div>div>header>div {
+:host > div > div > div > header > div {
   margin: var(--basex2) var(--basex2);
 }
 
-:host>div>div>header>div>h1,
-:host>div>div>header>div>h2 {
+:host > div > div > div > header > div > h1,
+:host > div > div > div > header > div > h2 {
   font-family: var(--dashboard-font);
   font-weight: var(--font-rg);
   color: var(--text-grey-800);
@@ -63,52 +70,80 @@
   padding: 0;
 }
 
-:host>div>div>header>div>h1 {
+:host > div > div > div > header > div > h1 {
   font-size: 20px;
   line-height: 28px;
 }
 
-:host>div>div>header>div>h2 {
+:host > div > div > div > header > div > h2 {
   font-size: 16px;
   line-height: 24px;
   margin-top: var(--basex1);
 }
 
-:host>div>div>main {
+:host > div > div > div > div.iconWrapper {
+  position: relative;
+  width: 100%;
+}
+
+:host > div > div > div > div.iconWrapper > z-icon {
+  cursor: pointer;
+  fill: var(--myz-blue);
+  transform: scale(0.8);
+  position: absolute;
+  top: var(--basex3);
+  right: var(--basex3);
+  z-index: 1020;
+}
+
+:host > div > div > div > main {
   background: white;
   overflow: hidden;
 }
 
+:host > div > div > div > main.noHeader {
+  min-height: 72px;
+}
 
 /* Tablet / Desktop style */
 
 @media only screen and (min-width: 768px) {
-  :host>div>div {
+  :host > div > div {
     width: auto;
+    height: auto;
+  }
+
+  :host > div > div > div {
+    width: auto;
+    height: auto;
     min-width: 300px;
     min-height: 300px;
     margin-top: var(--basex6);
     background: none;
   }
 
-  :host>div>div>header {
+  :host > div > div > div > header {
     border-radius: var(--radius-base) var(--radius-base) 0 0;
   }
 
-  :host>div>div>header>z-icon {
+  :host > div > div > div > header > z-icon {
     margin: var(--half-x3) var(--basex3) var(--half-x3) 0px;
     transform: scale(1);
   }
 
-  :host>div>div>header>div {
+  :host > div > div > div > header > div {
     margin: var(--half-x3) var(--basex3);
   }
 
-  :host>div>div>main {
+  :host > div > div > div > main {
     border-radius: 0 0 var(--radius-base) var(--radius-base);
   }
 
-  :host>div>div>div.bottomBackground {
+  :host > div > div > div > main.noHeader {
+    border-radius: var(--radius-base);
+  }
+
+  :host > div > div > div > div.bottomBackground {
     background: transparent;
     height: var(--basex4);
   }

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,16 @@
 
 <body style="background-color: #f9f9f9">
 
+  <!-- <z-modal hasheader="false">
+    <div slot="modalContent" style="width:300px;height:200px;display:flex;justify-content:center;align-items:center">
+      Content of modal without header
+    </div>
+  </z-modal> -->
+
   <!-- <z-modal modaltitle="titolotitolo" modalsubtitle="sottotitolo">
-    <div slot="modalContent">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</div>
+    <div slot="modalContent" style="width:300px;height:200px;display:flex;justify-content:center;align-items:center">
+      Content of modal with header
+    </div>
   </z-modal> -->
 
   <!-- non zanichelli logged -->


### PR DESCRIPTION
The hasheader property allow to create z-modal without header. 

It will be like this: 
<img width="364" alt="Schermata 2020-08-11 alle 12 36 10" src="https://user-images.githubusercontent.com/52574539/89887845-4a54b500-dbcf-11ea-918e-432d501e50b9.png">
