### PR TITLE
chore: limit width, go on next line for very long strings

### DIFF
--- a/src/components/inputs/z-input/styles-select.css
+++ b/src/components/inputs/z-input/styles-select.css
@@ -16,6 +16,7 @@
   position: absolute;
   z-index: 10;
   max-height: 300px;
+  max-width: 100%;
 }
 
 :host > div.selectWrapper > div > ul.closed {
@@ -25,7 +26,6 @@
 :host > div.selectWrapper > div > ul > li {
   padding: 0 var(--half-x3);
   text-align: left;
-  white-space: nowrap;
   cursor: pointer;
 }
 
@@ -39,7 +39,6 @@
 :host > div.selectWrapper > div > ul > li.selected > span {
   width: calc(100% - 40px);
   overflow: hidden;
-  white-space: nowrap;
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
Fixes #52 

* Limit `ul` width
* Wrap `li` and inner `span` content and go on next line if the string is very long and overflows.