### PR TITLE
fix: z-header second row height

### DIFF
--- a/src/components/navigation/z-header/styles.css
+++ b/src/components/navigation/z-header/styles.css
@@ -471,7 +471,7 @@ hr {
 @media only screen and (min-width: 768px) {
   header {
     grid-template-columns: 1fr 0.8fr 1.5fr 1.1fr 0.7fr;
-    grid-template-rows: 0.2fr 0.2fr;
+    grid-template-rows: 0.2fr auto;
     grid-template-areas: "main-header main-header main-header main-header main-header" "dropdown-menu dropdown-menu dropdown-menu dropdown-menu dropdown-menu";
     margin-bottom: 0;
   }


### PR DESCRIPTION
This PR fixes z-header second row height (now it's hidden when it's empty)