### PR TITLE
feat: MYZ-7754 added hideinfobtn prop to ZCardDictionary

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -183,6 +183,10 @@ export namespace Components {
          */
         "flipped": boolean;
         /**
+          * hide info button
+         */
+        "hideinfobtn": boolean;
+        /**
           * card title
          */
         "name": string;
@@ -1532,6 +1536,10 @@ declare namespace LocalJSX {
           * card is flipped
          */
         "flipped"?: boolean;
+        /**
+          * hide info button
+         */
+        "hideinfobtn"?: boolean;
         /**
           * card title
          */

--- a/src/components/card/z-card-dictionary/index.spec.ts
+++ b/src/components/card/z-card-dictionary/index.spec.ts
@@ -92,4 +92,34 @@ describe("Suite test ZCardDictionary", () => {
       </z-card-dictionary>
     `);
   });
+
+  it("Test render ZCardDictionary - with props info button hidden", async () => {
+    const page = await newSpecPage({
+      components: [ZCardDictionary],
+      html: `<z-card-dictionary hideinfobtn="true" name="title" cover="img-url" disabled="true"></z-card-dictionary>`
+    });
+    expect(page.root).toEqualHtml(`
+      <z-card-dictionary name="title" cover="img-url" disabled="true" hideinfobtn="true" >
+        <mock:shadow-root>
+          <div>
+            <z-card>
+              <z-card-header titolo="title"></z-card-header>
+              <div class="content">
+                <div class="front">
+                  <z-card-body>
+                    <z-card-cover titolo="title" img="img-url" slot="cover" faded=""></z-card-cover>
+                  </z-card-body>
+                  <z-button class="hideInfo" variant="secondary" icon="informationsource" issmall="">INFO</z-button>
+                </div>
+                <div class="back">
+                  <slot name="info"></slot>
+                </div>
+              </div>
+              <slot></slot>
+            </z-card>
+          </div>
+        </mock:shadow-root>
+      </z-card-dictionary>
+    `);
+  });
 });

--- a/src/components/card/z-card-dictionary/index.stories.mdx
+++ b/src/components/card/z-card-dictionary/index.stories.mdx
@@ -13,6 +13,7 @@ import { text, boolean } from '@storybook/addon-knobs';
         name="${text('name', 'Lo Zingarelli')}"
         cover="${text('cover', 'https://staticmy.zanichelli.it/catalogo/assets/m40004.9788808194121.jpg')}"
         disabled="${boolean('disabled', false)}"
+        hideinfobtn="${boolean("hideinfobtn", false)}"
         flipped="${boolean('flipped', false)}"
         flipbuttonlabel="${text('flipbuttonlabel', 'info')}"
       >
@@ -35,7 +36,31 @@ import { text, boolean } from '@storybook/addon-knobs';
         name="${text('name', 'Lo Zingarelli')}"
         cover="${text('cover', 'https://staticmy.zanichelli.it/catalogo/assets/m40004.9788808194121.jpg')}"
         disabled="${boolean('disabled', false)}"
+        hideinfobtn="${boolean("hideinfobtn", false)}"
         flipped="${boolean('flipped', true)}"
+        flipbuttonlabel="${text('flipbuttonlabel', 'info')}"
+      >
+        <z-card-footer-sections>
+          <div slot="top">Vocabolario della lingua italiana</div>
+          <div slot="bottom"><z-button variant="primary" style="width:100%;">VAI AL PRODOTTO</z-button></div>
+        </z-card-footer-sections>
+        <z-card-info
+          slot="info"
+          data='{"author":"Nicola Zingarelli","year":"2021","title":"Vocabolario della lingua italiana","description":"A cura di Mario Cannella, Beata Lazzarini","onlineLicense":{"expiration":"31/12/2021","installations":"1"},"offlineLicense":{"expiration":"30/06/2021","installations":"2"}}'
+        >
+          <z-button variant="tertiary" icon="gear">Gestisci Licenze</z-button>
+        </z-card-info>
+      </z-card-dictionary>
+    `}
+  </Story>
+  <Story name="card-no-info-button">
+    {html`
+      <z-card-dictionary
+        name="${text('name', 'Lo Zingarelli')}"
+        cover="${text('cover', 'https://staticmy.zanichelli.it/catalogo/assets/m40004.9788808194121.jpg')}"
+        disabled="${boolean('disabled', false)}"
+        hideinfobtn="${boolean("hideinfobtn", true)}"
+        flipped="${boolean('flipped', false)}"
         flipbuttonlabel="${text('flipbuttonlabel', 'info')}"
       >
         <z-card-footer-sections>

--- a/src/components/card/z-card-dictionary/index.tsx
+++ b/src/components/card/z-card-dictionary/index.tsx
@@ -21,6 +21,8 @@ export class ZCardDictionary {
   @Prop({ mutable: true }) flipped: boolean = false;
   /** flip button label */
   @Prop() flipbuttonlabel: string = "INFO";
+  /** hide info button */
+  @Prop() hideinfobtn: boolean = false;
 
   @Listen("flipCard")
   handleFlipCard(e: CustomEvent) {
@@ -50,6 +52,7 @@ export class ZCardDictionary {
                 />
               </z-card-body>
               <z-button
+                class={this.hideinfobtn ? "hideInfo" : ""}
                 variant={ButtonVariantEnum.secondary}
                 icon="informationsource"
                 issmall={true}

--- a/src/components/card/z-card-dictionary/readme.md
+++ b/src/components/card/z-card-dictionary/readme.md
@@ -13,6 +13,7 @@
 | `disabled`        | `disabled`        | card is disabled  | `boolean` | `false`     |
 | `flipbuttonlabel` | `flipbuttonlabel` | flip button label | `string`  | `"INFO"`    |
 | `flipped`         | `flipped`         | card is flipped   | `boolean` | `false`     |
+| `hideinfobtn`     | `hideinfobtn`     | hide info button  | `boolean` | `false`     |
 | `name`            | `name`            | card title        | `string`  | `undefined` |
 
 

--- a/src/components/card/z-card-dictionary/styles.css
+++ b/src/components/card/z-card-dictionary/styles.css
@@ -68,6 +68,10 @@
   justify-content: center;
 }
 
+.hideInfo {
+  display: none;
+}
+
 /* Tablet breakpoint */
 @media only screen and (min-width: 768px) {
 }

--- a/src/index.html
+++ b/src/index.html
@@ -534,6 +534,19 @@
         <z-button variant="tertiary" icon="gear">Gestisci Licenze</z-button>
       </z-card-info>
     </z-card-dictionary>
+
+    <z-card-dictionary hideinfobtn="true" name="Lo Zingarelli" cover="https://staticmy.zanichelli.it/catalogo/assets/m40004.9788808194121.jpg">
+      <z-card-footer-sections>
+        <div slot="top">Vocabolario della lingua italiana</div>
+        <div slot="bottom"><z-button variant="primary" style="width:100%;">VAI AL PRODOTTO</z-button></div>
+      </z-card-footer-sections>
+      <z-card-info
+        slot="info"
+        data='{"author":"Nicola Zingarelli","year":"2021","title":"Vocabolario della lingua italiana","description":"A cura di Mario Cannella, Beata Lazzarini","onlineLicense":{"expiration":"31/12/2021"},"offlineLicense":{"expiration":"30/06/2021","installations":"2"}}'
+      >
+        <z-button variant="tertiary" icon="gear">Gestisci Licenze</z-button>
+      </z-card-info>
+    </z-card-dictionary>
   </div>
 
   <br /><br />


### PR DESCRIPTION
Feature: MYZ-7754 
added "hideinfobtn" prop to ZCardDictionary
----

### Motivation and Context
To be able to use it on "AddOrTryDictionary" modal.

### Priority
- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved dy Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract

### Screenshots

### Note
ref: https://zanichelli.atlassian.net/browse/MYZ-7754
## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
