### PR TITLE
Chore - Fix path to bundle served via unpkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/web-components-library.js",
+  "unpkg": "dist/web-components-library/web-components-library.esm.js",
   "files": [
     "dist/",
     "loader/",


### PR DESCRIPTION
# Chore - Fix path to bundle served via unpkg

### Motivation and Context

The `unpkg` field in the current `package.json` points to a nonexistent bundle. As per [unpkg docs](https://unpkg.com/):

> If you omit the file path (i.e. use a “bare” URL), unpkg will serve the file specified by the `unpkg` field in `package.json`, or fall back to `main`.

With the current release (1.7.0, at the time of this writing), the request is being redirected to `dist/web-components-library.js`, but the file is not included in the dist files. The correct path would be `dist/web-components-library/web-components-library.esm.js`, as it is correctly documented in this project's README.

This happens, for instance, when including the script as a "bare" URL (<https://unpkg.com/@zanichelli/albe-web-components>), and the browser gets redirected to the aforementioned missing path, which then causes a **404 Not Found**:

<details><summary>Example cURL request</summary>

```console
$ curl -IL https://unpkg.com/@zanichelli/albe-web-components@1.7.0

HTTP/2 302
date: Tue, 20 Apr 2021 08:00:16 GMT
content-type: text/plain; charset=utf-8
access-control-allow-origin: *
cache-control: public, max-age=31536000
location: /@zanichelli/albe-web-components@1.7.0/dist/web-components-library.js
vary: Accept
via: 1.1 fly.io
fly-request-id: 01F3Q4N9QW1DBWG0P0H365TXG8
cf-cache-status: HIT
age: 43
cf-request-id: 098fe46a190000e903ee0bf000000001
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-content-type-options: nosniff
server: cloudflare
cf-ray: 642cd689ceede903-MXP

HTTP/2 404
date: Tue, 20 Apr 2021 08:00:18 GMT
content-type: text/plain; charset=utf-8
access-control-allow-origin: *
cache-control: public, max-age=31536000
etag: W/"56-ouT8vI2BHuiH/amxj2f4PydIt34"
via: 1.1 fly.io
fly-request-id: 01F3Q4PMK83F0YG7GZSDYTEKG4
cf-cache-status: MISS
cf-request-id: 098fe46a3b0000e903b8be0000000001
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-content-type-options: nosniff
server: cloudflare
cf-ray: 642cd689ff87e903-MXP
```

</details>

### Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved dy Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract

N/A

### Screenshots

N/A

### Notes

The URL from unpkg.com as documented in this project's README does work at present, but since it does not include a version number, it may be prone to stop working at any time in case the bundle path inside the package published on NPM changes again.

To make it more future proof, I'd advise to either include a version number in the URL (probably undesirable, as it would pin the library to a specific version) or to use the "bare" URL <https://unpkg.com/@zanichelli/albe-web-components> instead, which causes a redirect to the correct bundle inside the dist files — as long as the `unpkg` field in the `package.json` is correct, of course — and doesn't need to be updated if the path changes once again.

Furtherly, since what is being exported is an ESM rather than an ES5 bundle, it should probably be documented that the `<script>` tag is required to specify `type="module"`.