### PR TITLE
Fix Z-Icon style

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -834,6 +834,12 @@ export namespace Components {
          */
         "pressed": boolean;
     }
+    interface ZStoriaButton {
+        /**
+          * graphic variant
+         */
+        "variant"?: ButtonVariantBean;
+    }
     interface ZToggleButton {
         /**
           * avoidclick status flag
@@ -1153,6 +1159,12 @@ declare global {
         prototype: HTMLZStepperItemElement;
         new (): HTMLZStepperItemElement;
     };
+    interface HTMLZStoriaButtonElement extends Components.ZStoriaButton, HTMLStencilElement {
+    }
+    var HTMLZStoriaButtonElement: {
+        prototype: HTMLZStoriaButtonElement;
+        new (): HTMLZStoriaButtonElement;
+    };
     interface HTMLZToggleButtonElement extends Components.ZToggleButton, HTMLStencilElement {
     }
     var HTMLZToggleButtonElement: {
@@ -1220,6 +1232,7 @@ declare global {
         "z-select": HTMLZSelectElement;
         "z-stepper": HTMLZStepperElement;
         "z-stepper-item": HTMLZStepperItemElement;
+        "z-storia-button": HTMLZStoriaButtonElement;
         "z-toggle-button": HTMLZToggleButtonElement;
         "z-tooltip": HTMLZTooltipElement;
         "z-typography": HTMLZTypographyElement;
@@ -2106,6 +2119,12 @@ declare namespace LocalJSX {
          */
         "pressed"?: boolean;
     }
+    interface ZStoriaButton {
+        /**
+          * graphic variant
+         */
+        "variant"?: ButtonVariantBean;
+    }
     interface ZToggleButton {
         /**
           * avoidclick status flag
@@ -2188,6 +2207,7 @@ declare namespace LocalJSX {
         "z-select": ZSelect;
         "z-stepper": ZStepper;
         "z-stepper-item": ZStepperItem;
+        "z-storia-button": ZStoriaButton;
         "z-toggle-button": ZToggleButton;
         "z-tooltip": ZTooltip;
         "z-typography": ZTypography;
@@ -2245,6 +2265,7 @@ declare module "@stencil/core" {
             "z-select": LocalJSX.ZSelect & JSXBase.HTMLAttributes<HTMLZSelectElement>;
             "z-stepper": LocalJSX.ZStepper & JSXBase.HTMLAttributes<HTMLZStepperElement>;
             "z-stepper-item": LocalJSX.ZStepperItem & JSXBase.HTMLAttributes<HTMLZStepperItemElement>;
+            "z-storia-button": LocalJSX.ZStoriaButton & JSXBase.HTMLAttributes<HTMLZStoriaButtonElement>;
             "z-toggle-button": LocalJSX.ZToggleButton & JSXBase.HTMLAttributes<HTMLZToggleButtonElement>;
             "z-tooltip": LocalJSX.ZTooltip & JSXBase.HTMLAttributes<HTMLZTooltipElement>;
             "z-typography": LocalJSX.ZTypography & JSXBase.HTMLAttributes<HTMLZTypographyElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -834,12 +834,6 @@ export namespace Components {
          */
         "pressed": boolean;
     }
-    interface ZStoriaButton {
-        /**
-          * graphic variant
-         */
-        "variant"?: ButtonVariantBean;
-    }
     interface ZToggleButton {
         /**
           * avoidclick status flag
@@ -1159,12 +1153,6 @@ declare global {
         prototype: HTMLZStepperItemElement;
         new (): HTMLZStepperItemElement;
     };
-    interface HTMLZStoriaButtonElement extends Components.ZStoriaButton, HTMLStencilElement {
-    }
-    var HTMLZStoriaButtonElement: {
-        prototype: HTMLZStoriaButtonElement;
-        new (): HTMLZStoriaButtonElement;
-    };
     interface HTMLZToggleButtonElement extends Components.ZToggleButton, HTMLStencilElement {
     }
     var HTMLZToggleButtonElement: {
@@ -1232,7 +1220,6 @@ declare global {
         "z-select": HTMLZSelectElement;
         "z-stepper": HTMLZStepperElement;
         "z-stepper-item": HTMLZStepperItemElement;
-        "z-storia-button": HTMLZStoriaButtonElement;
         "z-toggle-button": HTMLZToggleButtonElement;
         "z-tooltip": HTMLZTooltipElement;
         "z-typography": HTMLZTypographyElement;
@@ -2119,12 +2106,6 @@ declare namespace LocalJSX {
          */
         "pressed"?: boolean;
     }
-    interface ZStoriaButton {
-        /**
-          * graphic variant
-         */
-        "variant"?: ButtonVariantBean;
-    }
     interface ZToggleButton {
         /**
           * avoidclick status flag
@@ -2207,7 +2188,6 @@ declare namespace LocalJSX {
         "z-select": ZSelect;
         "z-stepper": ZStepper;
         "z-stepper-item": ZStepperItem;
-        "z-storia-button": ZStoriaButton;
         "z-toggle-button": ZToggleButton;
         "z-tooltip": ZTooltip;
         "z-typography": ZTypography;
@@ -2265,7 +2245,6 @@ declare module "@stencil/core" {
             "z-select": LocalJSX.ZSelect & JSXBase.HTMLAttributes<HTMLZSelectElement>;
             "z-stepper": LocalJSX.ZStepper & JSXBase.HTMLAttributes<HTMLZStepperElement>;
             "z-stepper-item": LocalJSX.ZStepperItem & JSXBase.HTMLAttributes<HTMLZStepperItemElement>;
-            "z-storia-button": LocalJSX.ZStoriaButton & JSXBase.HTMLAttributes<HTMLZStoriaButtonElement>;
             "z-toggle-button": LocalJSX.ZToggleButton & JSXBase.HTMLAttributes<HTMLZToggleButtonElement>;
             "z-tooltip": LocalJSX.ZTooltip & JSXBase.HTMLAttributes<HTMLZTooltipElement>;
             "z-typography": LocalJSX.ZTypography & JSXBase.HTMLAttributes<HTMLZTypographyElement>;

--- a/src/components/icons/z-icon/styles.css
+++ b/src/components/icons/z-icon/styles.css
@@ -7,7 +7,10 @@
   margin-left: var(--z-icon-left-margin, 0);
 }
 
-svg {
-  width: inherit;
-  height: inherit;
+:host(:not([width])) svg {
+  width: var(--z-icon-width, 18px);
+}
+
+:host(:not([height])) svg {
+  height: var(--z-icon-height, 18px);
 }


### PR DESCRIPTION
# Fix Z-Icon style
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->


### Motivation and Context

With latest modify to z-button (for slot), z-icon width/height properties are violated by "inherit" CSS rules previously added.
The result is that z-icon width/height properties  are not used correctly.
This small PR fixes this side-effect refining the CSS rules. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [x] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved dy Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract
<!--- Refers to Design System Abstract sheets or collections -->
<!--- Add Screenshots if appropriate -->

### Screenshots

### Note
<!-- Adds description, notes, any blocks -->
<!-- Free field, not mandatory -->
----

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
