### PR TITLE
Z-Chip with slots, keeping retrocompatibility

### DIFF
--- a/src/components/buttons/z-chip/index.spec.ts
+++ b/src/components/buttons/z-chip/index.spec.ts
@@ -22,7 +22,7 @@ describe("Suite test ZChip", () => {
   });
 
 
-  it("Test render ZChip with values", async () => {
+  it("Test render ZChip with attributes", async () => {
     const page = await newSpecPage({
       components: [ZChip],
       html: `<z-chip boldtext="20" regulartext="libri trovati"></z-chip>`
@@ -32,7 +32,7 @@ describe("Suite test ZChip", () => {
         <z-chip boldtext="20" regulartext="libri trovati">
           <mock:shadow-root>
             <div>
-              <span><span class="boldtext">20</span>&nbsp;libri trovati</span>
+              <span class="boldtext">20</span>&nbsp;libri trovati
             </div>
           </mock:shadow-root>
         </z-chip>
@@ -57,7 +57,7 @@ describe("Suite test ZChip", () => {
     `);
   });
 
-  it("Test render ZChip with children", async () => {
+  it("Test render ZChip with attributes and children", async () => {
     const page = await newSpecPage({
       components: [ZChip],
       html: `<z-chip boldtext="20" regulartext="libri trovati">
@@ -69,7 +69,7 @@ describe("Suite test ZChip", () => {
         <z-chip boldtext="20" regulartext="libri trovati">
           <mock:shadow-root>
             <div>
-              <span><span class="boldtext">20</span>&nbsp;libri trovati</span>
+              <span class="boldtext">20</span>&nbsp;libri trovati
             </div>
           </mock:shadow-root>
           <z-body>ciao 1</z-body>

--- a/src/components/buttons/z-chip/index.spec.ts
+++ b/src/components/buttons/z-chip/index.spec.ts
@@ -14,14 +14,14 @@ describe("Suite test ZChip", () => {
         <z-chip>
           <mock:shadow-root>
           <div>
-          <span class="boldtext"></span>&nbsp;
+          <slot></slot>&nbsp;
           </div>
         </mock:shadow-root>
       </z-chip>
     `);
   });
-  
-  
+
+
   it("Test render ZChip with values", async () => {
     const page = await newSpecPage({
       components: [ZChip],
@@ -31,11 +31,49 @@ describe("Suite test ZChip", () => {
     expect(page.root).toEqualHtml(`
         <z-chip boldtext="20" regulartext="libri trovati">
           <mock:shadow-root>
-         <div>
-          <span class="boldtext">20</span>&nbsp;libri trovati
-      </div>
-        </mock:shadow-root>
-      </z-chip>
+            <div>
+              <span><span class="boldtext">20</span>&nbsp;libri trovati</span>
+            </div>
+          </mock:shadow-root>
+        </z-chip>
+    `);
+  });
+
+  it("Test render ZChip with children", async () => {
+    const page = await newSpecPage({
+      components: [ZChip],
+      html: `<z-chip><z-body>ciao 1</z-body></z-chip>`
+    });
+
+    expect(page.root).toEqualHtml(`
+        <z-chip>
+          <mock:shadow-root>
+            <div>
+              <slot />
+            </div>
+          </mock:shadow-root>
+          <z-body>ciao 1</z-body>
+        </z-chip>
+    `);
+  });
+
+  it("Test render ZChip with children", async () => {
+    const page = await newSpecPage({
+      components: [ZChip],
+      html: `<z-chip boldtext="20" regulartext="libri trovati">
+               <z-body>ciao 1</z-body>
+             </z-chip>`
+    });
+
+    expect(page.root).toEqualHtml(`
+        <z-chip boldtext="20" regulartext="libri trovati">
+          <mock:shadow-root>
+            <div>
+              <span><span class="boldtext">20</span>&nbsp;libri trovati</span>
+            </div>
+          </mock:shadow-root>
+          <z-body>ciao 1</z-body>
+        </z-chip>
     `);
   });
 });

--- a/src/components/buttons/z-chip/index.stories.mdx
+++ b/src/components/buttons/z-chip/index.stories.mdx
@@ -6,15 +6,26 @@ import { text } from '@storybook/addon-knobs';
 
 <Meta title="Buttons/ZChip" component="z-chip" />
 
-  # ZChip
+  # ZChip with attributes
 
 <Preview>
-  <Story name="z-chip">
+  <Story name="z-chip with attributes">
     {html`
       <z-chip
         boldtext="${text('boldtext', '1234')}"
         regulartext="${text('regulartext', 'libri trovati')}"
       ></z-chip>`}
+  </Story>
+</Preview>
+
+# ZChip with children
+
+<Preview>
+  <Story name="z-chip with children">
+    {html`
+      <z-chip>
+        <z-body level="4">My custom element</z-body>
+      </z-chip>`}
   </Story>
 </Preview>
 

--- a/src/components/buttons/z-chip/index.tsx
+++ b/src/components/buttons/z-chip/index.tsx
@@ -9,12 +9,16 @@ import { Component, Prop, h } from '@stencil/core';
 export class ZChip {
   @Prop() regulartext?: string;
   @Prop() boldtext?: number;
-  
+
 
   render() {
     return (
       <div>
-          <span class="boldtext">{this.boldtext}</span> {this.regulartext}
+        {
+          this.boldtext || this.regulartext ?
+          <span><span class="boldtext">{this.boldtext}</span> {this.regulartext}</span> :
+          <slot />
+        }
       </div>
     );
   }

--- a/src/components/buttons/z-chip/index.tsx
+++ b/src/components/buttons/z-chip/index.tsx
@@ -10,16 +10,15 @@ export class ZChip {
   @Prop() regulartext?: string;
   @Prop() boldtext?: number;
 
+  private renderLegacyChip() {
+    return <div>
+      <span class="boldtext">{this.boldtext}</span> {this.regulartext}
+    </div>;
+  }
 
   render() {
-    return (
-      <div>
-        {
-          this.boldtext || this.regulartext ?
-          <span><span class="boldtext">{this.boldtext}</span> {this.regulartext}</span> :
-          <slot />
-        }
-      </div>
-    );
+    return this.boldtext || this.regulartext ?
+      this.renderLegacyChip() :
+      <div><slot /></div>;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -482,6 +482,15 @@
       <z-button-filter filtername="filter 3" isfixed hasicon="false"></z-button-filter>
       <z-button-filter filtername="filter 4" hasicon="false"></z-button-filter>
       <z-chip boldtext="1234" regulartext="libri trovati"></z-chip>
+      <z-chip>
+        <z-body level="4">ciao 1</z-body>
+      </z-chip>
+      <z-chip>
+        <z-body level="1" variant="semibold"><span style="color: red">ciao 2</span></z-body>
+      </z-chip>
+      <z-chip boldtext="1234" regulartext="libri trovati">
+        <z-body level="4">ciao 3</z-body>
+      </z-chip>
       <br/>
       <br/>
 


### PR DESCRIPTION
# z-chip - add slot keeping retrocompatibility

### Motivation and Context
Adds support to custom slots and maintains backwards compatibility with the previous implementation.
The request arises from the need to add typography elements customized with different colors.

### Priority
- [ ] 1 - Highest
- [ ] 2 - High
- [X] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved dy Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract
https://app.abstract.com/projects/fd370780-e659-11e8-99dc-0d08537c5fde/branches/master/commits/e23f154e523fbe380233e3edab892dfe962349da/files/2B453759-9259-472B-8098-2846C9D506B5/layers/BFC98A10-F410-4D40-BFE8-B4486B0F2CA9?collectionLayerId=4adbe381-83ab-44a5-8716-97a9c67e69fb&mode=design

### Screenshots
![Screenshot from 2021-05-07 15-30-07](https://user-images.githubusercontent.com/39956539/117457184-44ff7d80-af49-11eb-9aeb-cd62f8072a46.png)

----

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
