### PR TITLE
Refactor/z menu theme colors

### DIFF
--- a/src/components/navigation/z-menu-section/styles.css
+++ b/src/components/navigation/z-menu-section/styles.css
@@ -4,9 +4,7 @@
   align-items: flex-start;
   justify-content: center;
   padding: 0;
-  font-family: var(--dashboard-font);
-
-  --focus-shadow: 0 0 2px 2px var(--blue100);
+  font-family: var(--font-family-sans);
 }
 
 :host,
@@ -16,20 +14,20 @@
 }
 
 ::slotted(a) {
-  color: var(--text-grey-800);
+  color: var(--color-text01);
   text-decoration: none;
 }
 
 ::slotted(*) {
-  font-family: var(--dashboard-font);
+  font-family: var(--font-family-sans);
   font-weight: var(--font-rg);
-  color: var(--text-grey-800);
+  color: var(--color-text01);
 }
 
 :host([active]) .label,
 :host([open]) .label,
 .label:hover {
-  border-color: var(--blue500);
+  border-color: var(--color-secondary01);
 }
 
 .label {
@@ -42,25 +40,25 @@
   background: transparent;
   border-radius: 0;
   border: 0;
-  border-bottom: var(--border-size-small) solid var(--bg-grey-800);
+  border-bottom: var(--border-size-small) solid var(--color-surface05);
   cursor: pointer;
 }
 
 .label ::slotted(*) {
   width: 100%;
   margin: 0;
-  font-size: 16px;
-  line-height: 20px;
+  font-size: var(--font-size-3);
+  line-height: 1.25;
 }
 
 .label:focus:focus-visible {
   outline: none;
-  box-shadow: var(--focus-shadow);
+  box-shadow: var(--shadow-focus-primary);
 }
 
 .label z-icon {
   margin-left: calc(var(--space-unit) * 4);
-  fill: var(--bg-grey-800);
+  fill: currentColor;
 }
 
 .items {
@@ -74,15 +72,15 @@
   display: inline-flex;
   margin: 0;
   padding: calc(var(--space-unit) / 2) calc(var(--space-unit) / 2);
-  font-size: 14px;
-  line-height: 20px;
+  font-size: var(--font-size-2);
+  line-height: 1.4;
   outline: none;
 }
 
 .items > ::slotted([slot='item']:focus:focus-visible) {
-  box-shadow: var(--focus-shadow);
+  box-shadow: var(--shadow-focus-primary);
 }
 
 .items > ::slotted([slot='item']:hover) {
-  color: var(--blue500);
+  color: var(--color-secondary01);
 }

--- a/src/components/navigation/z-menu-section/styles.css
+++ b/src/components/navigation/z-menu-section/styles.css
@@ -14,7 +14,6 @@
 }
 
 ::slotted(a) {
-  color: var(--color-text01);
   text-decoration: none;
 }
 

--- a/src/components/navigation/z-menu/index.tsx
+++ b/src/components/navigation/z-menu/index.tsx
@@ -37,7 +37,7 @@ export class ZMenu {
    * The opening state of the menu.
    * @default false
    */
-  @Prop({ mutable: true }) open: boolean = false;
+  @Prop({ mutable: true, reflect: true }) open: boolean = false;
   @State() hasHeader: boolean;
   @State() hasContent: boolean;
   @Element() hostElement: HTMLElement;
@@ -114,7 +114,7 @@ export class ZMenu {
   }
 
   render() {
-    return <Host role="menu" open={this.open}>
+    return <Host role="menu">
       <button class="label" aria-pressed={this.open ? 'true' : 'false'} onClick={this.toggle.bind(this)}>
         <div class="label-content">
           <slot></slot>

--- a/src/components/navigation/z-menu/styles.css
+++ b/src/components/navigation/z-menu/styles.css
@@ -8,25 +8,22 @@
   display: inline-flex;
   flex-direction: column;
   position: relative;
-
-  --border-size-large: 4px;
-  --focus-shadow: 0 0 2px 2px var(--blue100);
 }
 
 ::slotted(a) {
-  color: var(--text-grey-800);
+  color: var(--color-text01);
   text-decoration: none;
 }
 
 ::slotted(*) {
-  font-family: var(--dashboard-font);
+  font-family: var(--font-family-sans);
   font-weight: var(--font-rg);
 }
 
 :host([active]) .label-content,
 :host([open]) .label-content,
 .label:hover .label-content {
-  border-color: var(--blue500);
+  border-color: var(--color-secondary01);
 }
 
 .label {
@@ -45,11 +42,11 @@
   display: flex;
   align-items: center;
   padding: var(--space-unit) calc(var(--space-unit) / 2) var(--space-unit);
-  border-bottom: var(--border-size-large) solid currentColor;
+  border-bottom: var(--border-size-large) solid var(--color-surface05);
 }
 
 .label:focus:focus-visible {
-  box-shadow: var(--focus-shadow);
+  box-shadow: var(--shadow-focus-primary);
   z-index: 1;
 }
 
@@ -57,8 +54,8 @@
   width: 100%;
   margin: 0;
   appearance: none;
-  font-size: 20px;
-  line-height: 24px;
+  font-size: var(--font-size-5);
+  line-height: 1.2;
 }
 
 .label z-icon {
@@ -68,7 +65,7 @@
 
 .content {
   padding: var(--space-unit) 0;
-  background: var(--color-white);
+  background: var(--color-surface02);
 }
 
 .content[hidden] {
@@ -109,36 +106,36 @@
   margin: auto 0;
   margin-left: calc(var(--space-unit) / 2 * 3);
   font-weight: var(--font-sb);
-  font-size: 16px;
-  line-height: 24px;
+  font-size: var(--font-size-3);
+  line-height: 1.5;
 }
 
 .items {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  background: var(--color-white);
+  background: inherit;
 }
 
 .items > ::slotted([slot='item']) {
   display: inline-flex;
   width: 100%;
   margin: 0;
-  font-size: 16px;
-  line-height: 20px;
+  font-size: var(--font-size-3);
+  line-height: 1.25;
   outline: none;
 }
 
 .items > ::slotted([slot='item']:focus:focus-visible) {
-  box-shadow: var(--focus-shadow);
+  box-shadow: var(--shadow-focus-primary);
 }
 
 .items > ::slotted([slot='item']:not(z-menu-section)) {
   padding: calc(var(--space-unit) * 2) calc(var(--space-unit) / 2);
-  border-bottom: var(--border-size-small) solid currentColor;
+  border-bottom: var(--border-size-small) solid var(--color-surface05);
 }
 
 .items > ::slotted([slot='item']:hover),
 .items > ::slotted([slot='item']:active) {
-  border-color: var(--blue500);
+  border-color: var(--color-secondary01);
 }


### PR DESCRIPTION
# Refactor - ZMenu - use theming color tokens
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->
<!--- [short description] description of the action -->
----

### Motivation and Context
Add the use of color tokens to handle color themes.
This is an example of themed menu from _Storia in digitale_
<img width="535" alt="Schermata 2021-07-02 alle 15 54 59" src="https://user-images.githubusercontent.com/15926182/124285078-e112c300-db4d-11eb-8318-682b04ed74a4.png">

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Notes
Depends on [this PR on tokens repo](https://github.com/ZanichelliEditore/design-tokens/pull/9) for tokens fixes.