### PR TITLE
Feature - z-combobox - changed default state to closed

### DIFF
--- a/src/components/inputs/z-combobox/index.spec.ts
+++ b/src/components/inputs/z-combobox/index.spec.ts
@@ -8,12 +8,10 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox items='[]'></z-combobox>`
     });
-    page.rootInstance.isopen = false;
-    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox items='[]'>
         <mock:shadow-root>
-          <div class="false" data-action="combo-undefined">
+          <div data-action="combo-undefined">
             <div class="header" role="button" tabindex="0">
               <h2><span></span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -29,12 +27,10 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox items='[]' inputid="combobox" label="label" isfixed></z-combobox>`
     });
-    page.rootInstance.isopen = false;
-    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox items='[]' inputid="combobox" label="label" isfixed>
         <mock:shadow-root>
-          <div class="false fixed" id="combobox" data-action="combo-combobox">
+          <div class="fixed" id="combobox" data-action="combo-combobox">
             <div class="header" role="button" tabindex="0">
               <h2>
                 label
@@ -53,12 +49,10 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]' inputid="combobox" label="label"></z-combobox>`
     });
-    page.rootInstance.isopen = false;
-    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]' inputid="combobox" label="label">
         <mock:shadow-root>
-          <div class="false" data-action="combo-combobox" id="combobox">
+          <div data-action="combo-combobox" id="combobox">
             <div class="header" role="button" tabindex="0">
               <h2>
                 label
@@ -77,10 +71,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox items='[]' noresultslabel='non ci sono risultati'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox items='[]' noresultslabel='non ci sono risultati'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-undefined">
+          <div class="open" data-action="combo-undefined">
             <div class="header" role="button" tabindex="0">
               <h2><span></span></h2>
               <z-icon name="caret-down" width="18" height="18"></z-icon>
@@ -101,10 +97,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -132,10 +130,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -164,12 +164,13 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" closesearchtext="CHIUDI" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
     page.rootInstance.searchValue = "primo";
     await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" closesearchtext="CHIUDI" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -198,12 +199,13 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
     page.rootInstance.searchValue = "primo";
     await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -232,12 +234,13 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" closesearchtext="CHIUDI" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]' noresultslabel='non ci sono risultati'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
     page.rootInstance.searchValue = "prova";
     await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" closesearchtext="CHIUDI" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]' noresultslabel='non ci sono risultati'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -264,10 +267,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -298,10 +303,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(2)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -332,10 +339,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" maxcheckableitems="1" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" maxcheckableitems="1" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -363,10 +372,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" maxcheckableitems="3" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":false}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" maxcheckableitems="3" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":false}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />
@@ -397,10 +408,12 @@ describe("Suite test ZCombobox", () => {
       components: [ZCombobox],
       html: `<z-combobox inputid="combo" label="combo" maxcheckableitems="1" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":false}]'></z-combobox>`
     });
+    page.rootInstance.isopen = true;
+    await page.waitForChanges();
     expect(page.root).toEqualHtml(`
       <z-combobox inputid="combo" label="combo" maxcheckableitems="1" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":false}]'>
         <mock:shadow-root>
-          <div class="open false" data-action="combo-combo" id="combo">
+          <div class="open" data-action="combo-combo" id="combo">
             <div class="header" role="button" tabindex="0">
               <h2>combo<span>(1)</span></h2>
               <z-icon name="caret-down" width="18" height="18" />

--- a/src/components/inputs/z-combobox/index.tsx
+++ b/src/components/inputs/z-combobox/index.tsx
@@ -100,7 +100,7 @@ export class ZCombobox {
   }
 
   constructor() {
-    this.closeComboBox = this.closeComboBox.bind(this);
+    this.toggleComboBox = this.toggleComboBox.bind(this);
     this.closeFilterItems = this.closeFilterItems.bind(this);
   }
 
@@ -156,7 +156,7 @@ export class ZCombobox {
     this.resetRenderItemsList();
   }
 
-  closeComboBox(): void {
+  toggleComboBox(): void {
     this.isopen = !this.isopen;
   }
 
@@ -164,12 +164,12 @@ export class ZCombobox {
     return (
       <div
         class="header"
-        onClick={() => this.closeComboBox()}
+        onClick={() => this.toggleComboBox()}
         onKeyDown={(ev: KeyboardEvent) => {
           if (ev.keyCode === keybordKeyCodeEnum.SPACE) ev.preventDefault();
         }}
         onKeyUp={(ev: KeyboardEvent) =>
-          handleKeyboardSubmit(ev, this.closeComboBox)
+          handleKeyboardSubmit(ev, this.toggleComboBox)
         }
         role="button"
         tabindex={0}
@@ -220,7 +220,7 @@ export class ZCombobox {
               id={item.id}
               listitemid={item.id}
               action={`combo-li-${this.inputid}`}
-              underlined={i === items.length - 1 ? false : true}
+              underlined={i !== items.length - 1}
             >
               <z-input
                 type={InputTypeEnum.checkbox}
@@ -314,7 +314,7 @@ export class ZCombobox {
     return (
       <div
         data-action={`combo-${this.inputid}`}
-        class={`${this.isopen && "open"} ${this.isfixed && "fixed"}`}
+        class={`${this.isopen ? "open" : ""} ${this.isfixed ? "fixed": ""}`}
         id={this.inputid}
       >
         {this.renderHeader()}

--- a/src/components/inputs/z-combobox/index.tsx
+++ b/src/components/inputs/z-combobox/index.tsx
@@ -40,7 +40,7 @@ export class ZCombobox {
   /** no result text message */
   @Prop() noresultslabel?: string = "Nessun risultato";
   /** toggle combo list opening flag */
-  @Prop({ mutable: true }) isopen: boolean = true;
+  @Prop({ mutable: true }) isopen: boolean = false;
   /** fixed style flag */
   @Prop() isfixed: boolean = false;
   /** close combobox list text */

--- a/src/components/inputs/z-combobox/readme.md
+++ b/src/components/inputs/z-combobox/readme.md
@@ -11,6 +11,7 @@
   searchplaceholder="Cerca Autore"
   label="Combo Corta"
   closesearchtext="CHIUDI"
+  isopen="true"
 ></z-combobox>
 <z-combobox
   inputid="combo_2"
@@ -19,7 +20,6 @@
   searchlabel="Autore"
   searchplaceholder="Cerca Autore"
   label="Combo Corta"
-  isopen="false"
   label="Combo Lunga"
   closesearchtext="CHIUDI"
 ></z-combobox>

--- a/src/components/inputs/z-combobox/readme.md
+++ b/src/components/inputs/z-combobox/readme.md
@@ -38,7 +38,7 @@
 | `hassearch`         | `hassearch`         | show search input flag (optional)             | `boolean`                   | `false`               |
 | `inputid`           | `inputid`           | input unique id                               | `string`                    | `undefined`           |
 | `isfixed`           | `isfixed`           | fixed style flag                              | `boolean`                   | `false`               |
-| `isopen`            | `isopen`            | toggle combo list opening flag                | `boolean`                   | `true`                |
+| `isopen`            | `isopen`            | toggle combo list opening flag                | `boolean`                   | `false`               |
 | `items`             | `items`             | list items array                              | `ComboItemBean[] \| string` | `undefined`           |
 | `label`             | `label`             | label text                                    | `string`                    | `undefined`           |
 | `maxcheckableitems` | `maxcheckableitems` | max number of checkable items (0 = unlimited) | `number`                    | `0`                   |


### PR DESCRIPTION
# Feature - z-combobox - changed default state to closed
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->
<!--- [short description] description of the action -->
----

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->
Default state of z-combobox must be "closed".
This change would not be breaking for MyZ/Classi Virtuali.

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [x] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract
<!--- Refers to Design System Abstract sheets or collections -->
<!--- Add Screenshots if appropriate -->

### Screenshots

### Note
<!-- Adds description, notes, any blocks -->
<!-- Free field, not mandatory -->
----

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
