### PR TITLE
Fix - Ztable - remove min-height / add border bottom to empty table

### DIFF
--- a/src/snowflakes/registro-table/z-registro-table/styles.css
+++ b/src/snowflakes/registro-table/z-registro-table/styles.css
@@ -4,7 +4,6 @@ z-registro-table {
   width: 100%;
   font-family: var(--dashboard-font);
   font-weight: var(--font-rg);
-  min-height: 288px;
   background-color: var(--color-white);
 }
 
@@ -110,13 +109,8 @@ z-registro-table
   z-index: 5;
 }
 
-z-registro-table-empty-box.bordered {
-  border-left: var(--border-size-small) solid var(--bg-grey-200);
-}
-
 z-registro-table-body {
   width: auto;
-  min-height: 288px;
   background-color: var(--color-white);
 }
 
@@ -124,6 +118,11 @@ z-registro-table-empty-box {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  border-bottom: var(--border-size-small) solid var(--bg-grey-200);
+}
+
+z-registro-table-empty-box.bordered {
+  border-left: var(--border-size-small) solid var(--bg-grey-200);
 }
 
 .error-message {


### PR DESCRIPTION
# Fix - Ztable - remove min-height / add border bottom to empty table
----
### Motivation and Context
Related stories: [CLAV-174](https://zanichelli.atlassian.net/browse/CLAV-174) and [CLAV-166](https://zanichelli.atlassian.net/browse/CLAV-166)

With this bugfix:

- we remove the min-height (288px) set to the empty table, allowing it the expand vertically according to the content inside
- we add a border at the bottom of the table content in case of empty table

### Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

