### PR TITLE
Fix - ZTable - Empty box border and height

### DIFF
--- a/src/snowflakes/registro-table/z-registro-table-empty-box/index.spec.ts
+++ b/src/snowflakes/registro-table/z-registro-table-empty-box/index.spec.ts
@@ -1,0 +1,52 @@
+import { newSpecPage } from "@stencil/core/testing";
+
+import { ZRegistroTableEmptyBox } from "./index";
+
+describe("ZRegistroTableEmptyBox", () => {
+  it("renders default `ZRegistroTableEmptyBox`", async () => {
+    const page = await newSpecPage({
+      components: [ZRegistroTableEmptyBox],
+      html: `<z-registro-table-empty-box></z-registro-table-empty-box>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <z-registro-table-empty-box>
+        <z-body level="3" variant="semibold">Siamo spiacenti, al momento non sono presenti dati da visualizzare.</z-body><br />
+      </z-registro-table-empty-box>
+    `);
+  });
+
+  it("renders default `ZRegistroTableEmptyBox` with custom `message` and `subtitle`", async () => {
+    const page = await newSpecPage({
+      components: [ZRegistroTableEmptyBox],
+      html: `<z-registro-table-empty-box message="Custom message" subtitle="Custom subtitle"></z-registro-table-empty-box>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <z-registro-table-empty-box message="Custom message" subtitle="Custom subtitle">
+        <z-body level="3" variant="semibold">Custom message</z-body><br />
+        <z-body level="4" variant="regular">Custom subtitle</z-body>
+      </z-registro-table-empty-box>
+    `);
+  });
+
+  it("renders default `ZRegistroTableEmptyBox` with custom `cta1` and `cta2` slots", async () => {
+    const page = await newSpecPage({
+      components: [ZRegistroTableEmptyBox],
+      html: `<z-registro-table-empty-box>
+              <z-button slot="cta1">CTA 1</z-button>
+              <z-button slot="cta2">CTA 2</z-button>
+            </z-registro-table-empty-box>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <z-registro-table-empty-box>
+        <z-body level="3" variant="semibold">Siamo spiacenti, al momento non sono presenti dati da visualizzare.</z-body><br />
+        <div class="cta">
+          <z-button slot="cta1">CTA 1</z-button>
+          <z-button slot="cta2">CTA 2</z-button>
+        </div>
+      </z-registro-table-empty-box>
+    `);
+  });
+});

--- a/src/snowflakes/registro-table/z-registro-table-empty-box/index.tsx
+++ b/src/snowflakes/registro-table/z-registro-table-empty-box/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, Prop } from "@stencil/core";
+import { Component, Element, h, Host, Prop } from "@stencil/core";
 
 @Component({
   tag: "z-registro-table-empty-box",
@@ -7,6 +7,8 @@ import { Component, h, Host, Prop } from "@stencil/core";
   scoped: true,
 })
 export class ZRegistroTableEmptyBox {
+  @Element() hostElement: HTMLElement;
+
   /** Sets main title message*/
   @Prop() message?: string =
     "Siamo spiacenti, al momento non sono presenti dati da visualizzare.";
@@ -14,20 +16,35 @@ export class ZRegistroTableEmptyBox {
   /** Sets message */
   @Prop() subtitle?: string = "";
 
+  /** Checks if cta1 or cta2 slots exist */
+  hasCta1Slot: boolean;
+  hasCta2Slot: boolean;
+
+  componentWillLoad() {
+    this.hasCta1Slot = !!this.hostElement.querySelector('[slot="cta1"]');
+    this.hasCta2Slot = !!this.hostElement.querySelector('[slot="cta2"]');
+  }
+
   render() {
     return (
       <Host>
-        <z-body level={3} variant={"semibold"}>
-          {this.message}
-        </z-body>
+        {!!this.message && (
+          <z-body level={3} variant={"semibold"}>
+            {this.message}
+          </z-body>
+        )}
         <br />
-        <z-body level={4} variant={"regular"}>
-          {this.subtitle}
-        </z-body>
-        <div class="cta">
-          <slot name="cta1"></slot>
-          <slot name="cta2"></slot>
-        </div>
+        {!!this.subtitle && (
+          <z-body level={4} variant={"regular"}>
+            {this.subtitle}
+          </z-body>
+        )}
+        {(!!this.hasCta1Slot || this.hasCta2Slot) && (
+          <div class="cta">
+            <slot name="cta1"></slot>
+            <slot name="cta2"></slot>
+          </div>
+        )}
       </Host>
     );
   }

--- a/src/snowflakes/registro-table/z-registro-table-empty-box/index.tsx
+++ b/src/snowflakes/registro-table/z-registro-table-empty-box/index.tsx
@@ -28,18 +28,16 @@ export class ZRegistroTableEmptyBox {
   render() {
     return (
       <Host>
-        {!!this.message && (
-          <z-body level={3} variant={"semibold"}>
-            {this.message}
-          </z-body>
-        )}
+        <z-body level={3} variant={"semibold"}>
+          {this.message}
+        </z-body>
         <br />
         {!!this.subtitle && (
           <z-body level={4} variant={"regular"}>
             {this.subtitle}
           </z-body>
         )}
-        {(!!this.hasCta1Slot || this.hasCta2Slot) && (
+        {(!!this.hasCta1Slot || !!this.hasCta2Slot) && (
           <div class="cta">
             <slot name="cta1"></slot>
             <slot name="cta2"></slot>

--- a/src/snowflakes/registro-table/z-registro-table/index.spec.ts
+++ b/src/snowflakes/registro-table/z-registro-table/index.spec.ts
@@ -118,9 +118,9 @@ describe("Suite test ZRegistroTable", () => {
     </z-registro-table-head></z-registro-table>`,
     });
     expect(page.root)
-      .toEqualHtml(`<z-registro-table empty=\"true\" role=\"table\" slot=\"table-header\">                                                                   
-    <z-registro-table-head hidden=\"\">                                                                                                               
-      <z-registro-table-header-row>                                                                                                                   
+      .toEqualHtml(`<z-registro-table empty=\"true\" role=\"table\" slot=\"table-header\">
+    <z-registro-table-head hidden=\"\">
+      <z-registro-table-header-row>
         <z-registro-table-header>
           <span>
             Titolo 1
@@ -172,7 +172,7 @@ describe("Suite test ZRegistroTable", () => {
     expect(page.root)
       .toEqualHtml(`<z-registro-table call-to-action-label=\"Call To Action\" call-to-action-two-label=\"Call To Action 2\" empty=\"true\" role=\"table\">
     <div class=\"table table-empty\"></div>
-    <z-registro-table-empty-box message=\"Siamo spiacenti, al momento non sono presenti dati da visualizzare\" subtitle=\"\">                          
+    <z-registro-table-empty-box message=\"Siamo spiacenti, al momento non sono presenti dati da visualizzare\" subtitle=\"\">
       <z-button size=\"big\" slot=\"cta1\" variant=\"tertiary\">
         Call To Action
       </z-button>
@@ -209,6 +209,71 @@ describe("Suite test ZRegistroTable", () => {
         </z-registro-table-header-row>
       </z-registro-table-head>
     </z-registro-table>`,
+    });
+
+    expect(page.root)
+      .toEqualHtml(`<z-registro-table call-to-action-label=\"Call to action\" empty=\"true\" message=\"Siamo spiacenti, al momento non sono presenti dati da visualizzare!\" role=\"table\" subtitle=\"Eventuale testo\">
+    <div class=\"table table-empty\">
+      <z-registro-table-head slot=\"table-header\">
+        <z-registro-table-header-row>
+          <z-registro-table-header>
+            <span>
+              Titolo 1
+            </span>
+          </z-registro-table-header>
+          <z-registro-table-header>
+            <span>
+              Titolo 2
+            </span>
+          </z-registro-table-header>
+          <z-registro-table-header>
+            <span>
+              Titolo 3
+            </span>
+          </z-registro-table-header>
+          <z-registro-table-header>
+            <span>
+              Titolo 4
+            </span>
+          </z-registro-table-header>
+        </z-registro-table-header-row>
+      </z-registro-table-head>
+    </div>
+    <z-registro-table-empty-box message=\"Siamo spiacenti, al momento non sono presenti dati da visualizzare!\" subtitle=\"Eventuale testo\">
+      <z-button size=\"big\" slot=\"cta1\" variant=\"tertiary\">
+        Call to action
+      </z-button>
+    </z-registro-table-empty-box>
+  </z-registro-table>`);
+  });
+
+  it("Test render ZRegistroTable with empty <z-registro-table-body> component", async () => {
+    const page = await newSpecPage({
+      components: [ZRegistroTable],
+      html: `<z-registro-table
+        empty="true"
+        message="Siamo spiacenti, al momento non sono presenti dati da visualizzare!"
+        subtitle="Eventuale testo"
+        call-to-action-label="Call to action"
+      >
+        <z-registro-table-head slot="table-header">
+          <z-registro-table-header-row>
+            <z-registro-table-header>
+              <span>Titolo 1</span>
+            </z-registro-table-header>
+            <z-registro-table-header>
+              <span>Titolo 2</span>
+            </z-registro-table-header>
+            <z-registro-table-header>
+              <span>Titolo 3</span>
+            </z-registro-table-header>
+            <z-registro-table-header>
+              <span>Titolo 4</span>
+            </z-registro-table-header>
+          </z-registro-table-header-row>
+        </z-registro-table-head>
+        <z-registro-table-body slot="table-body"></z-registro-table-body>
+      </z-registro-table>`,
     });
 
     expect(page.root)
@@ -299,7 +364,7 @@ describe("Suite test ZRegistroTable", () => {
     expect(page.root).toEqualHtml(
       `<z-registro-table bordered="true" role="table">
         <div class="table table-bordered">
-            
+
         </div>
       </z-registro-table>`
     );
@@ -314,7 +379,7 @@ describe("Suite test ZRegistroTable", () => {
     expect(page.root).toEqualHtml(
       `<z-registro-table column-sticky="true" role="table">
         <div class="table table-column-sticky">
-            
+
         </div>
       </z-registro-table>`
     );
@@ -329,7 +394,7 @@ describe("Suite test ZRegistroTable", () => {
     expect(page.root).toEqualHtml(
       `<z-registro-table header-sticky="true" role="table">
         <div class="table table-header-sticky">
-            
+
         </div>
       </z-registro-table>`
     );

--- a/src/snowflakes/registro-table/z-registro-table/index.tsx
+++ b/src/snowflakes/registro-table/z-registro-table/index.tsx
@@ -100,7 +100,13 @@ export class ZRegistroTable {
 
   componentWillLoad() {
     this.isMobile = window.innerWidth <= mobileBreakpoint;
-    this.hasTableBody = !!this.host.querySelector('[slot="table-body"]');
+
+    const tableBody = this.host.querySelector('[slot="table-body"]');
+    this.hasTableBody = !!tableBody?.children?.length;
+
+    if (!!tableBody && !this.hasTableBody) {
+      tableBody.remove();
+    }
   }
 
   componentWillRender() {


### PR DESCRIPTION
# Fix - ZTable - Empty box border and height

### Motivation and Context
Related to [CLAV-166](https://zanichelli.atlassian.net/browse/CLAV-166) and [CLAV-174](https://zanichelli.atlassian.net/browse/CLAV-174): with this PR we improve how the empty table is rendered.

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Screenshots
**Before**:
![localhost_3000_classroom_321_registro_activities](https://user-images.githubusercontent.com/2866531/148935424-6e3e4b4b-7695-496f-bc3e-2d57b30ef985.png)

**After**: 
![localhost_3333_](https://user-images.githubusercontent.com/2866531/148935488-154b60cc-4945-4f26-8c03-b47829afb409.png)

