### PR TITLE
Refactor - ZRegistroTableExpandedRow - remove spacing and border rules

### DIFF
--- a/src/snowflakes/registro-table/z-registro-table-expanded-row/index.stories.mdx
+++ b/src/snowflakes/registro-table/z-registro-table-expanded-row/index.stories.mdx
@@ -10,7 +10,14 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
 <Preview>
   <Story name="ZRegistroTableExpandedRow-all-expanded">
-    {html`<z-registro-table bordered="true">
+    {html`<style>
+      .expanded-row-content {
+        margin: 0 calc(var(--space-unit) * 2) 0 calc(var(--space-unit) * 2);
+        padding: calc(var(--space-unit) * 2) 0 calc(var(--space-unit) * 2) 0;
+        border-top: 1px solid var(--gray200);
+      }
+    </style>
+    <z-registro-table bordered="true">
       <z-registro-table-head>
         <z-registro-table-header-row expandable="true">
           <z-registro-table-header>
@@ -43,7 +50,7 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
           </z-registro-table-cell>
         </z-registro-table-row>
         <z-registro-table-expanded-row col-span="5">
-          <div>Contenuto aggiuntivo 1</div>
+          <div class="expanded-row-content">Contenuto aggiuntivo 1</div>
         </z-registro-table-expanded-row>
         <z-registro-table-row expanded-type="expandable">
           <z-registro-table-cell>
@@ -60,7 +67,7 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
           </z-registro-table-cell>
         </z-registro-table-row>
         <z-registro-table-expanded-row col-span="5">
-          <div>Contenuto aggiuntivo 2</div>
+          <div class="expanded-row-content">Contenuto aggiuntivo 2</div>
         </z-registro-table-expanded-row>
         <z-registro-table-row expanded-type="expandable">
           <z-registro-table-cell>
@@ -77,7 +84,7 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
           </z-registro-table-cell>
         </z-registro-table-row>
         <z-registro-table-expanded-row col-span="5">
-          <div>Contenuto aggiuntivo 3</div>
+          <div class="expanded-row-content">Contenuto aggiuntivo 3</div>
         </z-registro-table-expanded-row>
       </z-registro-table-body>
       <z-registro-table-sticky-footer slot="sticky-footer">
@@ -86,7 +93,14 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
     </z-registro-table>`}
   </Story>
   <Story name="ZRegistroTableExpandedRow-mix">
-    {html`<z-registro-table bordered="true">
+    {html`<style>
+      .expanded-row-content {
+        margin: 0 calc(var(--space-unit) * 2) 0 calc(var(--space-unit) * 2);
+        padding: calc(var(--space-unit) * 2) 0 calc(var(--space-unit) * 2) 0;
+        border-top: 1px solid var(--gray200);
+      }
+    </style>
+    <z-registro-table bordered="true">
       <z-registro-table-head>
         <z-registro-table-header-row expandable="true">
           <z-registro-table-header>
@@ -136,7 +150,7 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
           </z-registro-table-cell>
         </z-registro-table-row>
         <z-registro-table-expanded-row col-span="5">
-          <div>Contenuto aggiuntivo 2</div>
+          <div class="expanded-row-content">Contenuto aggiuntivo 2</div>
         </z-registro-table-expanded-row>
         <z-registro-table-row expanded-type="padding">
           <z-registro-table-cell>
@@ -179,3 +193,7 @@ to respect the correct alignment.
 
 When you insert a clickable element in the row (for example z-button or z-icon) remember to add **stopPropagation()**
 to the onClick function to prevent unwanted row expansion.
+
+### Spacing and borders
+
+In order to improve modularity and component flexibility, spacing related rules must be handled inside the content component.

--- a/src/snowflakes/registro-table/z-registro-table-expanded-row/index.tsx
+++ b/src/snowflakes/registro-table/z-registro-table-expanded-row/index.tsx
@@ -13,9 +13,7 @@ export class ZRegistroTableExpandedRow {
     return (
       <td colSpan={this.colSpan}>
         <div class="content-container">
-          <div class="inner-content">
-            <slot />
-          </div>
+          <slot />
         </div>
       </td>
     );

--- a/src/snowflakes/registro-table/z-registro-table-expanded-row/styles.css
+++ b/src/snowflakes/registro-table/z-registro-table-expanded-row/styles.css
@@ -1,16 +1,9 @@
 :host {
-  font-family: var(--dashboard-font);
   background-color: var(--gray50);
   display: none;
 }
 
 :host > td > div.content-container {
-  padding: 0 calc(var(--space-unit) * 2) 0 calc(var(--space-unit) * 6);
   box-shadow: var(--shadow-2);
   margin-bottom: calc(var(--space-unit) / 2);
-}
-
-:host > td > div.content-container > div.inner-content {
-  padding: calc(var(--space-unit) * 2) 0 calc(var(--space-unit) * 2) 0;
-  border-top: 1px solid var(--gray200);
 }


### PR DESCRIPTION
### Motivation and Context
Related to [CLAV-239](https://zanichelli.atlassian.net/browse/CLAV-239), we must handle different spacing and border width mobile users. With this PR we remove ALL rules related to spacing (margin and padding) and border. These properties will be handle by the content inside the component.

### Priority
- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [x] Breaking (fix or feature that would cause existing functionality to not work as expected)


## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
