### PR TITLE
Fix - ZPopover/ZContextualMenu - Fix popover content positioning inside the viewport

### DIFF
--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -40,10 +40,6 @@ export class ZPopover {
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
-  componentDidLoad() {
-    this.checkSpaceAvailable();
-  }
-
   @Listen("closePopover")
   closePopover() {
     this.isVisible = false;
@@ -82,7 +78,6 @@ export class ZPopover {
   }
 
   checkSpaceAvailable() {
-
     const width = document.body.clientWidth;
     const height = window.innerHeight;
     const rect = this.popoverElem.getBoundingClientRect();

--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -40,42 +40,6 @@ export class ZPopover {
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
-  @Listen("closePopover")
-  closePopover() {
-    this.popoverPosition = this.position;
-    this.isVisible = false;
-  }
-
-  @Listen("keyup", { target: "window" })
-  closePopoverWithKeyboard(e: any) {
-    if (e.key === KeyboardKeys.ESC) {
-      this.closePopover();
-    }
-  }
-
-  handleClick(event) {
-    this.isVisible ? this.closePopover() : this.openPopover();
-    event.stopPropagation();
-  }
-
-  handleKeyDown(event) {
-    if (event.code === KeyboardKeys.ENTER) {
-      this.isVisible ? this.closePopover() : this.openPopover();
-    }
-  }
-
-  @Listen("click", { target: "body", capture: true })
-  handleOutsideClick(e: any) {
-    const tree = getElementTree(e.target);
-    const parent = tree.find(
-      (elem: Element) => elem.nodeName.toLowerCase() === "z-popover"
-    );
-
-    if (!parent) {
-      this.closePopover();
-    }
-  }
-
   openPopover() {
     const width = document.body.clientWidth;
     const height = window.innerHeight;
@@ -133,6 +97,42 @@ export class ZPopover {
 
     this.popoverPosition = PopoverPosition[`${firstSide}-${secondSide}`];
     this.isVisible = true;
+  }
+
+  @Listen("closePopover")
+  closePopover() {
+    this.popoverPosition = this.position;
+    this.isVisible = false;
+  }
+
+  @Listen("keyup", { target: "window" })
+  closePopoverWithKeyboard(e: any) {
+    if (e.key === KeyboardKeys.ESC) {
+      this.closePopover();
+    }
+  }
+
+  handleClick(event) {
+    this.isVisible ? this.closePopover() : this.openPopover();
+    event.stopPropagation();
+  }
+
+  handleKeyDown(event) {
+    if (event.code === KeyboardKeys.ENTER) {
+      this.isVisible ? this.closePopover() : this.openPopover();
+    }
+  }
+
+  @Listen("click", { target: "body", capture: true })
+  handleOutsideClick(e: any) {
+    const tree = getElementTree(e.target);
+    const parent = tree.find(
+      (elem: Element) => elem.nodeName.toLowerCase() === "z-popover"
+    );
+
+    if (!parent) {
+      this.closePopover();
+    }
   }
 
   render() {

--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -16,8 +16,7 @@ import { getElementTree } from "../../utils/utils";
 })
 export class ZPopover {
   /** [optional] Popover position */
-  @Prop({ mutable: true }) position?: PopoverPosition =
-    PopoverPosition["after-up"];
+  @Prop() position?: PopoverPosition = PopoverPosition["after-up"];
   /** [optional] Background color token for popover */
   @Prop() backgroundColor?: string = "color-white";
   /** [optional] Border radius token for popover */
@@ -30,6 +29,7 @@ export class ZPopover {
   @Prop() padding?: string = "8px";
 
   @State() isVisible: boolean = false;
+  @State() popoverPosition: PopoverPosition = this.position;
 
   private popoverElem: HTMLElement;
 
@@ -137,7 +137,7 @@ export class ZPopover {
       }
     }
 
-    this.position = PopoverPosition[`${firstSide}-${secondSide}`];
+    this.popoverPosition = PopoverPosition[`${firstSide}-${secondSide}`];
   }
 
   render() {
@@ -158,7 +158,7 @@ export class ZPopover {
           ref={(e) => (this.popoverElem = e)}
           class={classNames(
             "popover-content-container",
-            this.position,
+            this.popoverPosition,
             `border-radius-${this.borderRadius}`,
             this.boxShadow,
             { "show-arrow": this.showArrow },

--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -42,6 +42,7 @@ export class ZPopover {
 
   @Listen("closePopover")
   closePopover() {
+    this.popoverPosition = this.position;
     this.isVisible = false;
   }
 
@@ -53,15 +54,13 @@ export class ZPopover {
   }
 
   handleClick(event) {
-    this.isVisible = !this.isVisible;
-    this.checkSpaceAvailable();
+    this.isVisible ? this.closePopover() : this.openPopover();
     event.stopPropagation();
   }
 
   handleKeyDown(event) {
     if (event.code === KeyboardKeys.ENTER) {
-      this.isVisible = !this.isVisible;
-      this.checkSpaceAvailable();
+      this.isVisible ? this.closePopover() : this.openPopover();
     }
   }
 
@@ -69,15 +68,15 @@ export class ZPopover {
   handleOutsideClick(e: any) {
     const tree = getElementTree(e.target);
     const parent = tree.find(
-      (elem: any) => elem.nodeName.toLowerCase() === "z-popover"
+      (elem: Element) => elem.nodeName.toLowerCase() === "z-popover"
     );
 
     if (!parent) {
-      this.isVisible = false;
+      this.closePopover();
     }
   }
 
-  checkSpaceAvailable() {
+  openPopover() {
     const width = document.body.clientWidth;
     const height = window.innerHeight;
     const rect = this.popoverElem.getBoundingClientRect();
@@ -133,6 +132,7 @@ export class ZPopover {
     }
 
     this.popoverPosition = PopoverPosition[`${firstSide}-${secondSide}`];
+    this.isVisible = true;
   }
 
   render() {


### PR DESCRIPTION
# Fix - ZPopover/ZContextualMenu - Fix popover content positioning inside the viewport

### Motivation and Context
With the following PR, we solve a weird behaviour of ZPopover and related components. On trigger click the popover content according to the [popover position](https://github.com/ZanichelliEditore/design-system/blob/master/src/beans/index.tsx#L214) set by the developer. 

In case the open popover-content size exceeds the viewport, this is positioned programmatically according to the original configuration. 

In some cases, the position wasn't calculated correctly, e.g. the trigger is positioned below the fold and the user scroll the page.

Related to [CLAV-304](https://zanichelli.atlassian.net/browse/CLAV-304)

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)


## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
