### PR TITLE
Fix/z carousel ghostloading

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -215,7 +215,7 @@ export namespace Components {
         /**
           * sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show.
          */
-        "ghostLoadingHeight": string;
+        "ghostLoadingHeight": number;
         /**
           * sets whether the z-carousel is on loading state
          */
@@ -2624,7 +2624,7 @@ declare namespace LocalJSX {
         /**
           * sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show.
          */
-        "ghostLoadingHeight"?: string;
+        "ghostLoadingHeight"?: number;
         /**
           * sets whether the z-carousel is on loading state
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -215,11 +215,11 @@ export namespace Components {
         /**
           * sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show.
          */
-        "ghostloadingheight": string;
+        "ghostLoadingHeight": string;
         /**
           * sets whether the z-carousel is on loading state
          */
-        "isloading": boolean;
+        "isLoading": boolean;
     }
     interface ZChip {
         "boldtext"?: number;
@@ -2624,11 +2624,11 @@ declare namespace LocalJSX {
         /**
           * sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show.
          */
-        "ghostloadingheight"?: string;
+        "ghostLoadingHeight"?: string;
         /**
           * sets whether the z-carousel is on loading state
          */
-        "isloading"?: boolean;
+        "isLoading"?: boolean;
     }
     interface ZChip {
         "boldtext"?: number;

--- a/src/components/z-carousel/index.spec.ts
+++ b/src/components/z-carousel/index.spec.ts
@@ -31,13 +31,13 @@ describe("Suite test ZCarousel", () => {
     `);
   });
 
-  it("renders ZCarousel ghostloading with custom height when isloading equals true ", async () => {
+  it("renders ZCarousel ghostloading with custom height when isLoading equals true ", async () => {
     const page = await newSpecPage({
       components: [ZCarousel],
-      html: `<z-carousel isloading='true' ghostloadingheight='200'></z-carousel>`,
+      html: `<z-carousel is-loading='true' ghost-loading-height='200'></z-carousel>`,
     });
     expect(page.root)
-      .toEqualHtml(`<z-carousel isloading="true"  ghostloadingheight="200">
+      .toEqualHtml(`<z-carousel is-loading="true" ghost-loading-height="200">
       <div style="height: 200px;">
         <z-ghost-loading></z-ghost-loading>
         <div style="display: none;"></div>

--- a/src/components/z-carousel/index.spec.ts
+++ b/src/components/z-carousel/index.spec.ts
@@ -34,10 +34,10 @@ describe("Suite test ZCarousel", () => {
   it("renders ZCarousel ghostloading with custom height when isLoading equals true ", async () => {
     const page = await newSpecPage({
       components: [ZCarousel],
-      html: `<z-carousel is-loading='true' ghost-loading-height='200'></z-carousel>`,
+      html: `<z-carousel is-loading='true' ghost-loading-height=200></z-carousel>`,
     });
     expect(page.root)
-      .toEqualHtml(`<z-carousel is-loading="true" ghost-loading-height="200">
+      .toEqualHtml(`<z-carousel is-loading="true" ghost-loading-height=200>
       <div style="height: 200px;">
         <z-ghost-loading></z-ghost-loading>
         <div style="display: none;"></div>

--- a/src/components/z-carousel/index.stories.mdx
+++ b/src/components/z-carousel/index.stories.mdx
@@ -1,19 +1,32 @@
 import { html } from "lit-html";
-import { Meta, Story, Preview, Props } from "@storybook/addon-docs";
-import { number, text, boolean } from "@storybook/addon-knobs";
+import { Meta, Canvas, Story, ArgsTable } from "@storybook/addon-docs";
+
 import "./index.stories.css";
 import "./index";
 
-<Meta title="ZCarousel" component="z-carousel" />
+<Meta
+  title="ZCarousel"
+  component="z-carousel"
+  argTypes={{
+    isLoading: { control: { type: "boolean" } },
+    ghostLoadinghHeight: {
+      control: "text",
+    },
+    zCarouselGutter: { control: "number", min: 0 },
+  }}
+/>
 
 # ZCarousel
 
-<Preview>
-  <Story name="ZCarousel-with-div">
-    {html`<z-carousel
-      style="--z-carousel-gutter: ${number("--z-carousel-gutter", 8, {
-        min: 0,
-      })}px"
+<Canvas>
+  <Story
+    name="ZCarousel-with-div"
+    args={{
+      zCarouselGutter: 8,
+    }}
+  >
+    {(args) => html`<z-carousel
+      style="--z-carousel-gutter: ${args.zCarouselGutter}px"
     >
       <li>
         <div class="carousel-box"></div>
@@ -44,14 +57,17 @@ import "./index";
       </li>
     </z-carousel>`}
   </Story>
-</Preview>
+</Canvas>
 
-<Preview>
-  <Story name="ZCarousel-with-component">
-    {html`<z-carousel
-      style="--z-carousel-gutter: ${number("--z-carousel-gutter", 8, {
-        min: 0,
-      })}px"
+<Canvas>
+  <Story
+    name="ZCarousel-with-component"
+    args={{
+      zCarouselGutter: 8,
+    }}
+  >
+    {(args) => html`<z-carousel
+      style="--z-carousel-gutter: ${args.zCarouselGutter}px"
     >
       <li>
         <z-button variant="primary" size="big" disabled="false" icon="download">
@@ -155,14 +171,17 @@ import "./index";
       </li>
     </z-carousel>`}
   </Story>
-</Preview>
+</Canvas>
 
-<Preview>
-  <Story name="ZCarousel-with-elements-loading">
-    {html`<z-carousel
-      style="--z-carousel-gutter: ${number("--z-carousel-gutter", 8, {
-        min: 0,
-      })}px"
+<Canvas>
+  <Story
+    name="ZCarousel-with-elements-loading"
+    args={{
+      zCarouselGutter: 8,
+    }}
+  >
+    {(args) => html`<z-carousel
+      style="--z-carousel-gutter: ${args.zCarouselGutter}px"
     >
       <li>
         <div class="carousel-box-loading">
@@ -201,19 +220,25 @@ import "./index";
       </li>
     </z-carousel>`}
   </Story>
-</Preview>
+</Canvas>
 
-<Preview>
-  <Story name="ZCarousel-ghost-loading">
-    {html`<z-carousel
-      is-loading="${boolean("is-loading", true)}"
-      ghost-loading-height="${text("ghost-loading-height", "200")}"
+<Canvas>
+  <Story
+    name="ZCarousel-ghost-loading"
+    args={{
+      isLoading: true,
+      ghostLoadinghHeight: "200",
+    }}
+  >
+    {(args) => html`<z-carousel
+      is-loading=${args.isLoading}
+      ghost-loading-height=${args.ghostLoadinghHeight}
     >
     </z-carousel>`}
   </Story>
-</Preview>
+</Canvas>
 
-<Props of="z-carousel" />
+<ArgsTable of="z-carousel" />
 
 ## Description
 

--- a/src/components/z-carousel/index.stories.mdx
+++ b/src/components/z-carousel/index.stories.mdx
@@ -206,8 +206,8 @@ import "./index";
 <Preview>
   <Story name="ZCarousel-ghost-loading">
     {html`<z-carousel
-      isLoading="${boolean("isloading", true)}"
-      ghostLoadingHeight="${text("ghostloadingheight", "200")}"
+      is-loading="${boolean("is-loading", true)}"
+      ghost-loading-height="${text("ghost-loading-height", "200")}"
     >
     </z-carousel>`}
   </Story>
@@ -246,8 +246,8 @@ z-carousel {
 
 You can handle ghost loading for the whole z-carousel passing two properties:
 
-- `isloading` (boolean) : if `true`, it shows z-ghost-loading element.
-- `ghostloadingheight` (string): sets the height of the z-carousel ghost loading component.
+- `isLoading` (boolean) : if `true`, it shows z-ghost-loading element.
+- `ghostLoadinghHeight` (string): sets the height of the z-carousel ghost loading component.
 
 You can also handle ghost-loading of each single z-carousel element.
 You can see an example of use in the preview above (with story's name as ZCarousel-with-elements-loading).

--- a/src/components/z-carousel/index.stories.mdx
+++ b/src/components/z-carousel/index.stories.mdx
@@ -10,7 +10,7 @@ import "./index";
   argTypes={{
     isLoading: { control: { type: "boolean" } },
     ghostLoadinghHeight: {
-      control: "text",
+      control: "number",
     },
     zCarouselGutter: { control: "number", min: 0 },
   }}
@@ -227,7 +227,7 @@ import "./index";
     name="ZCarousel-ghost-loading"
     args={{
       isLoading: true,
-      ghostLoadinghHeight: "200",
+      ghostLoadinghHeight: 200,
     }}
   >
     {(args) => html`<z-carousel
@@ -272,7 +272,7 @@ z-carousel {
 You can handle ghost loading for the whole z-carousel passing two properties:
 
 - `isLoading` (boolean) : if `true`, it shows z-ghost-loading element.
-- `ghostLoadinghHeight` (string): sets the height of the z-carousel ghost loading component.
+- `ghostLoadinghHeight` (number): sets the height of the z-carousel ghost loading component.
 
 You can also handle ghost-loading of each single z-carousel element.
 You can see an example of use in the preview above (with story's name as ZCarousel-with-elements-loading).

--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -15,7 +15,7 @@ export class ZCarousel {
   /** sets whether the z-carousel is on loading state */
   @Prop() isLoading: boolean;
   /** sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show. */
-  @Prop() ghostLoadingHeight: string = "100";
+  @Prop() ghostLoadingHeight: number = 100;
   render() {
     if (this.isLoading) {
       return (

--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -13,13 +13,13 @@ import { Component, h, Prop } from "@stencil/core";
 })
 export class ZCarousel {
   /** sets whether the z-carousel is on loading state */
-  @Prop() isloading: boolean;
+  @Prop() isLoading: boolean;
   /** sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show. */
-  @Prop() ghostloadingheight: string = "100";
+  @Prop() ghostLoadingHeight: string = "100";
   render() {
-    if (this.isloading) {
+    if (this.isLoading) {
       return (
-        <div style={{ height: `${this.ghostloadingheight}px` }}>
+        <div style={{ height: `${this.ghostLoadingHeight}px` }}>
           <z-ghost-loading></z-ghost-loading>
           <div style={{ display: "none" }}>
             <slot />

--- a/src/components/z-carousel/readme.md
+++ b/src/components/z-carousel/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property             | Attribute            | Description                                                                                                                               | Type      | Default     |
-| -------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `ghostloadingheight` | `ghostloadingheight` | sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show. | `string`  | `"100"`     |
-| `isloading`          | `isloading`          | sets whether the z-carousel is on loading state                                                                                           | `boolean` | `undefined` |
+| Property             | Attribute              | Description                                                                                                                               | Type      | Default     |
+| -------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `ghostLoadingHeight` | `ghost-loading-height` | sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show. | `string`  | `"100"`     |
+| `isLoading`          | `is-loading`           | sets whether the z-carousel is on loading state                                                                                           | `boolean` | `undefined` |
 
 
 ## Slots

--- a/src/components/z-carousel/readme.md
+++ b/src/components/z-carousel/readme.md
@@ -9,7 +9,7 @@
 
 | Property             | Attribute              | Description                                                                                                                               | Type      | Default     |
 | -------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `ghostLoadingHeight` | `ghost-loading-height` | sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show. | `string`  | `"100"`     |
+| `ghostLoadingHeight` | `ghost-loading-height` | sets the height of z-carousel ghost loading, this prop is mandatory when isloading is set to true, as otherwise the component won't show. | `number`  | `100`       |
 | `isLoading`          | `is-loading`           | sets whether the z-carousel is on loading state                                                                                           | `boolean` | `undefined` |
 
 


### PR DESCRIPTION
# Fix - z carousel ghostloading



### Motivation and Context

 this PR:
- set CamelCase props
- use controls instead of knobs on storybook

### Priority
- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)



## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
