### PR TITLE
Refactor/remove nav tabs shadow dom

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1087,7 +1087,7 @@ export namespace Components {
          */
         "htmlTitle": string;
         /**
-          * Name of the icon to use. Use the slot `icon` for extra customization. The `filled` version will be automatically used (if found) when the tab is `selected`.
+          * Name of the icon to use. The `filled` version will be automatically used (if found) when the tab is `selected`.
          */
         "icon": string;
         /**
@@ -1121,7 +1121,7 @@ export namespace Components {
          */
         "htmlTitle": string;
         /**
-          * Name of the icon to use. Use the slot `icon` for extra customization. The `filled` version will be automatically used (if found) when the tab is `selected`.
+          * Name of the icon to use. The `filled` version will be automatically used (if found) when the tab is `selected`.
          */
         "icon": string;
         /**
@@ -3663,7 +3663,7 @@ declare namespace LocalJSX {
          */
         "htmlTitle"?: string;
         /**
-          * Name of the icon to use. Use the slot `icon` for extra customization. The `filled` version will be automatically used (if found) when the tab is `selected`.
+          * Name of the icon to use. The `filled` version will be automatically used (if found) when the tab is `selected`.
          */
         "icon"?: string;
         /**
@@ -3698,7 +3698,7 @@ declare namespace LocalJSX {
          */
         "htmlTitle"?: string;
         /**
-          * Name of the icon to use. Use the slot `icon` for extra customization. The `filled` version will be automatically used (if found) when the tab is `selected`.
+          * Name of the icon to use. The `filled` version will be automatically used (if found) when the tab is `selected`.
          */
         "icon"?: string;
         /**

--- a/src/components/navigation/tabs/navigation-tab.css
+++ b/src/components/navigation/tabs/navigation-tab.css
@@ -1,5 +1,5 @@
-:host > button,
-:host > a {
+z-navigation-tab > button,
+z-navigation-tab-link > a {
   position: relative;
   z-index: 0;
   display: inline-flex;
@@ -23,38 +23,53 @@
   cursor: pointer;
 }
 
-:host > a {
+z-navigation-tab-link > a {
   text-decoration: none;
 }
 
-:host *::before,
-:host *::after {
+z-navigation-tab *,
+z-navigation-tab-link *,
+z-navigation-tab *::before,
+z-navigation-tab *::after,
+z-navigation-tab-link *::before,
+z-navigation-tab-link *::after {
   box-sizing: border-box;
 }
 
-:host(:not([disabled]):hover) > *,
-:host([selected]) > * {
+z-navigation-tab > *:focus:focus-visible,
+z-navigation-tab-link > *:focus:focus-visible {
+  box-shadow: inset var(--shadow-focus-primary);
+}
+
+z-navigation-tab:not([disabled]):hover > *,
+z-navigation-tab[selected] > *,
+z-navigation-tab-link:not([disabled]):hover > *,
+z-navigation-tab-link[selected] > * {
   color: var(--color-hover-secondary);
   fill: currentColor;
 }
 
-:host(:not([disabled]):hover) > *::after,
-:host([selected]) > *::after {
-  content: '';
+z-navigation-tab:not([disabled]):hover > *::after,
+z-navigation-tab[selected] > *::after,
+z-navigation-tab-link:not([disabled]):hover > *::after,
+z-navigation-tab-link[selected] > *::after {
+  content: "";
   position: absolute;
   background-color: var(--color-hover-secondary);
 }
 
-:host([orientation='horizontal']:not([disabled]):hover) > *::after,
-:host([orientation='horizontal'][selected]) > *::after {
+z-navigation-tab[orientation="horizontal"]:not([disabled]):hover > *::after,
+z-navigation-tab[orientation="horizontal"][selected] > *::after,
+z-navigation-tab-link[orientation="horizontal"]:not([disabled]):hover > *::after,
+z-navigation-tab-link[orientation="horizontal"][selected] > *::after {
   bottom: 0;
   left: 0;
   width: 100%;
   height: var(--border-size-large);
 }
 
-slot[name="icon"] z-icon,
-::slotted([slot="icon"]) {
+z-navigation-tab z-icon,
+z-navigation-tab-link z-icon {
   --z-icon-width: calc(var(--space-unit) * 2);
   --z-icon-height: calc(var(--space-unit) * 2);
 
@@ -62,20 +77,16 @@ slot[name="icon"] z-icon,
   margin: 0;
 }
 
-:host([orientation='horizontal']) slot[name="icon"] z-icon,
-:host([orientation='horizontal']) ::slotted([slot="icon"]) {
+z-navigation-tab[orientation="horizontal"] z-icon,
+z-navigation-tab-link[orientation="horizontal"] z-icon {
   margin-right: var(--space-unit);
 }
 
-:host(:not([disabled]):hover) > * {
+z-navigation-tab:not([disabled]):hover > * {
   background-color: var(--color-background);
 }
 
-:host > *:focus:focus-visible {
-  box-shadow: var(--shadow-focus-primary);
-}
-
-:host([disabled]) > * {
+z-navigation-tab[disabled] > * {
   pointer-events: all;
   cursor: not-allowed;
   color: var(--gray500);
@@ -83,34 +94,41 @@ slot[name="icon"] z-icon,
 }
 
 /* Size small (only available for horizontal) */
-:host([size='small']) > * {
+z-navigation-tab[size="small"] > *,
+z-navigation-tab-link[size="small"] > * {
   font-size: var(--font-size-2);
   line-height: 1.4;
   letter-spacing: 0.16px;
 }
 
-:host([size='small'][orientation='horizontal']) > * {
+z-navigation-tab[size="small"][orientation="horizontal"] > *,
+z-navigation-tab-link[size="small"][orientation="horizontal"] > * {
   padding: var(--space-unit) calc(var(--space-unit) * 2);
 }
 
-:host([size='small'][orientation='horizontal']:not([disabled]):hover) > *::after,
-:host([size='small'][orientation='horizontal'][selected]) > *::after {
+z-navigation-tab[size="small"][orientation="horizontal"]:not([disabled]):hover > *::after,
+z-navigation-tab[size="small"][orientation="horizontal"][selected] > *::after,
+z-navigation-tab-link[size="small"][orientation="horizontal"]:hover > *::after,
+z-navigation-tab-link[size="small"][orientation="horizontal"][selected] > *::after {
   height: var(--border-size-medium);
 }
 
-:host([size='small']:not([orientation='vertical'])) slot[name="icon"] z-icon,
-:host([size='small']:not([orientation='vertical'])) ::slotted([slot="icon"]) {
+z-navigation-tab[size="small"]:not([orientation="vertical"]) z-icon,
+z-navigation-tab-link[size="small"]:not([orientation="vertical"]) z-icon {
   --z-icon-width: 14px;
   --z-icon-height: 14px;
 }
 
 /* Orientation Vertical */
-:host([orientation='vertical']) > * {
+z-navigation-tab[orientation="vertical"] > *,
+z-navigation-tab-link[orientation="vertical"] > * {
   padding: calc(var(--space-unit) * 3) calc(var(--space-unit) * 2);
 }
 
-:host([orientation='vertical']:hover:not([disabled])) > *::after,
-:host([orientation='vertical'][selected]) > *::after {
+z-navigation-tab[orientation="vertical"]:hover:not([disabled]) > *::after,
+z-navigation-tab[orientation="vertical"][selected] > *::after,
+z-navigation-tab-link[orientation="vertical"]:hover > *::after,
+z-navigation-tab-link[orientation="vertical"][selected] > *::after {
   width: var(--border-size-large);
   height: 100%;
   top: 0;

--- a/src/components/navigation/tabs/z-navigation-tab-link/index.stories.mdx
+++ b/src/components/navigation/tabs/z-navigation-tab-link/index.stories.mdx
@@ -71,42 +71,4 @@ import "./index";
   </Story>
 </Canvas>
 
-## Slotted icon
-You can use the slot named `icon` if you need extra customization (such as a product specific icon).
-
-<Canvas>
-  <Story name="z-navigation-tab-link with slotted icon"
-    args={{
-      selected: false,
-      disabled: false,
-      size: NavigationTabsSizes.big,
-      orientation: NavigationTabsOrientations.horizontal,
-      href: 'https://www.google.com',
-      target: "_blank",
-      htmlTitle: "Go to Google",
-      label: "Google",
-    }}
-    parameters={{
-      controls: {
-        exclude: ["icon"],
-      }
-    }}
-  >
-    {(args) => html`
-      <z-navigation-tab-link
-        .selected=${args.selected}
-        .disabled=${args.disabled}
-        .size=${args.size}
-        .orientation=${args.orientation}
-        .href=${args.href}
-        .htmlTitle=${args.htmlTitle}
-        .target=${args.target}
-        .label=${args.label}
-      >
-        <span slot="icon">🧩</span>
-      </z-navigation-tab-link>
-    `}
-  </Story>
-</Canvas>
-
 <ArgsTable of="z-navigation-tab-link" />

--- a/src/components/navigation/tabs/z-navigation-tab-link/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tab-link/index.tsx
@@ -2,7 +2,6 @@ import {
   Component,
   Prop,
   h,
-  Element,
   Listen,
   Event,
   EventEmitter,
@@ -24,8 +23,6 @@ import { icons } from "../../../icons/icons";
   styleUrl: "../navigation-tab.css",
 })
 export class ZNavigationTabLink {
-  @Element() host: HTMLElement;
-
   /**
    * Whether the tab is selected.
    */
@@ -74,14 +71,19 @@ export class ZNavigationTabLink {
   @Prop() label: string;
 
   @Event({ eventName: "selected" })
-  private emitSelected: EventEmitter;
+  private selectedEvent: EventEmitter;
 
-  @Listen("focus")
-  onFocus() {
-    this.host.scrollIntoView({
+  /**
+   * Scroll into view to center the tab.
+   */
+  scrollToTab({ target: button }) {
+    const scrollOptions = this.orientation === NavigationTabsOrientations.horizontal ?
+      { block: "nearest", inline: "center" } as ScrollIntoViewOptions :
+      { block: "center", inline: "nearest" } as ScrollIntoViewOptions;
+
+    button.scrollIntoView({
       behavior: "smooth",
-      block: "nearest",
-      inline: "nearest",
+      ...scrollOptions,
     });
   }
 
@@ -93,7 +95,7 @@ export class ZNavigationTabLink {
   @Watch("selected")
   onSelected() {
     if (this.selected) {
-      this.emitSelected.emit();
+      this.selectedEvent.emit();
     }
   }
 
@@ -120,6 +122,7 @@ export class ZNavigationTabLink {
         href={!this.disabled && this.href}
         title={this.htmlTitle}
         target={this.target}
+        onFocus={this.scrollToTab.bind(this)}
       >
         {this.icon && this.renderIcon()}
         {this.orientation === "horizontal" && this.label}

--- a/src/components/navigation/tabs/z-navigation-tab-link/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tab-link/index.tsx
@@ -18,12 +18,10 @@ import { icons } from "../../../icons/icons";
 
 /**
  * Single tab component to use inside `z-navigation-tabs`. It renders an anchor element.
- * @slot icon - Tab icon. If no extra customization is needed, use the `icon` prop passing the icon's name.
  */
 @Component({
   tag: "z-navigation-tab-link",
   styleUrl: "../navigation-tab.css",
-  shadow: true,
 })
 export class ZNavigationTabLink {
   @Element() host: HTMLElement;
@@ -65,7 +63,7 @@ export class ZNavigationTabLink {
   @Prop() href: string;
 
   /**
-   * Name of the icon to use. Use the slot `icon` for extra customization.
+   * Name of the icon to use.
    * The `filled` version will be automatically used (if found) when the tab is `selected`.
    */
   @Prop() icon: string;
@@ -123,7 +121,7 @@ export class ZNavigationTabLink {
         title={this.htmlTitle}
         target={this.target}
       >
-        <slot name="icon">{this.icon && this.renderIcon()}</slot>
+        {this.icon && this.renderIcon()}
         {this.orientation === "horizontal" && this.label}
       </a>
     );

--- a/src/components/navigation/tabs/z-navigation-tab-link/readme.md
+++ b/src/components/navigation/tabs/z-navigation-tab-link/readme.md
@@ -13,17 +13,17 @@
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                                  | Type                         | Default                                 |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | --------------------------------------- |
-| `disabled`    | `disabled`    | Whether the tab is disabled.                                                                                                                                 | `boolean`                    | `false`                                 |
-| `href`        | `href`        | Url to set to the anchor element.                                                                                                                            | `string`                     | `undefined`                             |
-| `htmlTitle`   | `html-title`  | Html title attribute for the anchor element.                                                                                                                 | `string`                     | `undefined`                             |
-| `icon`        | `icon`        | Name of the icon to use. Use the slot `icon` for extra customization. The `filled` version will be automatically used (if found) when the tab is `selected`. | `string`                     | `undefined`                             |
-| `label`       | `label`       | Label to show in the tab.                                                                                                                                    | `string`                     | `undefined`                             |
-| `orientation` | `orientation` | Tab orientation. Do not set this manually: `z-navigation-tabs` will handle this.                                                                             | `"horizontal" \| "vertical"` | `NavigationTabsOrientations.horizontal` |
-| `selected`    | `selected`    | Whether the tab is selected.                                                                                                                                 | `boolean`                    | `false`                                 |
-| `size`        | `size`        | Tab size. Do not set this manually: `z-navigation-tabs` will handle this.                                                                                    | `"big" \| "small"`           | `NavigationTabsSizes.big`               |
-| `target`      | `target`      | Html `target` attribute for the anchor element.                                                                                                              | `string`                     | `undefined`                             |
+| Property      | Attribute     | Description                                                                                                     | Type                         | Default                                 |
+| ------------- | ------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------- |
+| `disabled`    | `disabled`    | Whether the tab is disabled.                                                                                    | `boolean`                    | `false`                                 |
+| `href`        | `href`        | Url to set to the anchor element.                                                                               | `string`                     | `undefined`                             |
+| `htmlTitle`   | `html-title`  | Html title attribute for the anchor element.                                                                    | `string`                     | `undefined`                             |
+| `icon`        | `icon`        | Name of the icon to use. The `filled` version will be automatically used (if found) when the tab is `selected`. | `string`                     | `undefined`                             |
+| `label`       | `label`       | Label to show in the tab.                                                                                       | `string`                     | `undefined`                             |
+| `orientation` | `orientation` | Tab orientation. Do not set this manually: `z-navigation-tabs` will handle this.                                | `"horizontal" \| "vertical"` | `NavigationTabsOrientations.horizontal` |
+| `selected`    | `selected`    | Whether the tab is selected.                                                                                    | `boolean`                    | `false`                                 |
+| `size`        | `size`        | Tab size. Do not set this manually: `z-navigation-tabs` will handle this.                                       | `"big" \| "small"`           | `NavigationTabsSizes.big`               |
+| `target`      | `target`      | Html `target` attribute for the anchor element.                                                                 | `string`                     | `undefined`                             |
 
 
 ## Events
@@ -31,13 +31,6 @@
 | Event      | Description | Type               |
 | ---------- | ----------- | ------------------ |
 | `selected` |             | `CustomEvent<any>` |
-
-
-## Slots
-
-| Slot     | Description                                                                                 |
-| -------- | ------------------------------------------------------------------------------------------- |
-| `"icon"` | Tab icon. If no extra customization is needed, use the `icon` prop passing the icon's name. |
 
 
 ## Dependencies

--- a/src/components/navigation/tabs/z-navigation-tab/index.stories.mdx
+++ b/src/components/navigation/tabs/z-navigation-tab/index.stories.mdx
@@ -67,38 +67,4 @@ import "./index";
   </Story>
 </Canvas>
 
-## Slotted icon
-You can use the slot named `icon` if you need extra customization (such as a product specific icon).
-<Canvas>
-  <Story
-    name="z-navigation-tab with slotted icon"
-    args={{
-      selected: false,
-      disabled: false,
-      size: NavigationTabsSizes.big,
-      orientation: NavigationTabsOrientations.horizontal,
-      htmlTitle: "Download stuff",
-      label: "Download",
-    }}
-    parameters={{
-      controls: {
-        exclude: ["icon"],
-      }
-    }}
-  >
-    {(args) => html`
-      <z-navigation-tab
-        .selected=${args.selected}
-        .disabled=${args.disabled}
-        .size=${args.size}
-        .orientation=${args.orientation}
-        .htmlTitle=${args.htmlTitle}
-        .label=${args.label}
-      >
-        <span slot="icon">🧩</span>
-      </z-navigation-tab>
-    `}
-  </Story>
-</Canvas>
-
 <ArgsTable of="z-navigation-tab" />

--- a/src/components/navigation/tabs/z-navigation-tab/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tab/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Element, Listen, Event, EventEmitter, Watch } from "@stencil/core";
+import { Component, Prop, h, Listen, Event, EventEmitter, Watch } from "@stencil/core";
 import {
   NavigationTabsOrientations,
   NavigationTabsOrientation,
@@ -15,8 +15,6 @@ import { icons } from "../../../icons/icons";
   styleUrl: "../navigation-tab.css"
 })
 export class ZNavigationTab {
-  @Element() host: HTMLElement;
-
   /**
    * Whether the tab is selected.
    */
@@ -54,14 +52,19 @@ export class ZNavigationTab {
   @Prop() htmlTitle: string;
 
   @Event({ eventName: "selected" })
-  private emitSelected: EventEmitter;
+  private selectedEvent: EventEmitter;
 
-  @Listen("focus")
-  onFocus() {
-    this.host.scrollIntoView({
+  /**
+   * Scroll into view to center the tab.
+   */
+  scrollToTab({ target: button }) {
+    const scrollOptions = this.orientation === NavigationTabsOrientations.horizontal ?
+      { block: "nearest", inline: "center" } as ScrollIntoViewOptions :
+      { block: "center", inline: "nearest" } as ScrollIntoViewOptions;
+
+    button.scrollIntoView({
       behavior: "smooth",
-      block: "nearest",
-      inline: "nearest",
+      ...scrollOptions,
     });
   }
 
@@ -75,7 +78,7 @@ export class ZNavigationTab {
   @Watch("selected")
   onSelected() {
     if (this.selected) {
-      this.emitSelected.emit();
+      this.selectedEvent.emit();
     }
   }
 
@@ -97,7 +100,11 @@ export class ZNavigationTab {
 
   render() {
     return (
-      <button role="tab" disabled={this.disabled} title={this.htmlTitle}>
+      <button role="tab"
+        disabled={this.disabled}
+        title={this.htmlTitle}
+        onFocus={this.scrollToTab.bind(this)}
+      >
         {this.icon && this.renderIcon()}
         {this.orientation === "horizontal" && this.label}
       </button>

--- a/src/components/navigation/tabs/z-navigation-tab/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tab/index.tsx
@@ -9,12 +9,10 @@ import { icons } from "../../../icons/icons";
 
 /**
  * Single tab component to use inside `z-navigation-tabs`. It renders a button.
- * @slot icon - Tab icon. If no extra customization is needed, use the `icon` prop passing the icon's name.
  */
 @Component({
   tag: "z-navigation-tab",
-  styleUrl: "../navigation-tab.css",
-  shadow: true
+  styleUrl: "../navigation-tab.css"
 })
 export class ZNavigationTab {
   @Element() host: HTMLElement;
@@ -40,7 +38,7 @@ export class ZNavigationTab {
   @Prop({ reflect: true }) size: NavigationTabsSize = NavigationTabsSizes.big;
 
   /**
-   * Name of the icon to use. Use the slot `icon` for extra customization.
+   * Name of the icon to use.
    * The `filled` version will be automatically used (if found) when the tab is `selected`.
    */
   @Prop() icon: string;
@@ -100,7 +98,7 @@ export class ZNavigationTab {
   render() {
     return (
       <button role="tab" disabled={this.disabled} title={this.htmlTitle}>
-        <slot name="icon">{this.icon && this.renderIcon()}</slot>
+        {this.icon && this.renderIcon()}
         {this.orientation === "horizontal" && this.label}
       </button>
     );

--- a/src/components/navigation/tabs/z-navigation-tab/readme.md
+++ b/src/components/navigation/tabs/z-navigation-tab/readme.md
@@ -13,15 +13,15 @@
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                                                                                                  | Type                         | Default                                 |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | --------------------------------------- |
-| `disabled`    | `disabled`    | Whether the tab is disabled.                                                                                                                                 | `boolean`                    | `false`                                 |
-| `htmlTitle`   | `html-title`  | Html `title` attribute for the button.                                                                                                                       | `string`                     | `undefined`                             |
-| `icon`        | `icon`        | Name of the icon to use. Use the slot `icon` for extra customization. The `filled` version will be automatically used (if found) when the tab is `selected`. | `string`                     | `undefined`                             |
-| `label`       | `label`       | Label to show in the tab.                                                                                                                                    | `string`                     | `undefined`                             |
-| `orientation` | `orientation` | Tab orientation. Do not set this manually: `z-navigation-tabs` will handle this.                                                                             | `"horizontal" \| "vertical"` | `NavigationTabsOrientations.horizontal` |
-| `selected`    | `selected`    | Whether the tab is selected.                                                                                                                                 | `boolean`                    | `false`                                 |
-| `size`        | `size`        | Tab size. Do not set this manually: `z-navigation-tabs` will handle this.                                                                                    | `"big" \| "small"`           | `NavigationTabsSizes.big`               |
+| Property      | Attribute     | Description                                                                                                     | Type                         | Default                                 |
+| ------------- | ------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------- | --------------------------------------- |
+| `disabled`    | `disabled`    | Whether the tab is disabled.                                                                                    | `boolean`                    | `false`                                 |
+| `htmlTitle`   | `html-title`  | Html `title` attribute for the button.                                                                          | `string`                     | `undefined`                             |
+| `icon`        | `icon`        | Name of the icon to use. The `filled` version will be automatically used (if found) when the tab is `selected`. | `string`                     | `undefined`                             |
+| `label`       | `label`       | Label to show in the tab.                                                                                       | `string`                     | `undefined`                             |
+| `orientation` | `orientation` | Tab orientation. Do not set this manually: `z-navigation-tabs` will handle this.                                | `"horizontal" \| "vertical"` | `NavigationTabsOrientations.horizontal` |
+| `selected`    | `selected`    | Whether the tab is selected.                                                                                    | `boolean`                    | `false`                                 |
+| `size`        | `size`        | Tab size. Do not set this manually: `z-navigation-tabs` will handle this.                                       | `"big" \| "small"`           | `NavigationTabsSizes.big`               |
 
 
 ## Events
@@ -29,13 +29,6 @@
 | Event      | Description | Type               |
 | ---------- | ----------- | ------------------ |
 | `selected` |             | `CustomEvent<any>` |
-
-
-## Slots
-
-| Slot     | Description                                                                                 |
-| -------- | ------------------------------------------------------------------------------------------- |
-| `"icon"` | Tab icon. If no extra customization is needed, use the `icon` prop passing the icon's name. |
 
 
 ## Dependencies

--- a/src/components/navigation/tabs/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tabs/index.tsx
@@ -126,11 +126,8 @@ export class ZNavigationTabs {
    * Scroll the navigation bar half of its size backward.
    */
   navigateBackwards() {
-    const safeScrollAreaSize = parseFloat(getComputedStyle(this.host).getPropertyValue('--safe-scroll-area'));
     this.tabsNav.scrollBy({
-      [this.direction.toLowerCase()]: 0 -
-        (this.tabsNav[`client${this.dimension}`] / 2) -
-        safeScrollAreaSize,
+      [this.direction.toLowerCase()]: 0 - (this.tabsNav[`client${this.dimension}`] / 2),
       behavior: 'smooth',
     });
   }
@@ -139,11 +136,9 @@ export class ZNavigationTabs {
    * Scroll the navigation bar half of its size forward.
    */
   navigateForward() {
-    const safeScrollAreaSize = parseFloat(getComputedStyle(this.host).getPropertyValue('--safe-scroll-area'));
     this.tabsNav.scrollBy({
       [this.direction.toLowerCase()]: this.tabsNav[`scroll${this.direction}`] +
-        (this.tabsNav[`client${this.dimension}`] / 2) +
-        safeScrollAreaSize,
+        (this.tabsNav[`client${this.dimension}`] / 2),
       behavior: 'smooth',
     });
   }

--- a/src/components/navigation/tabs/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tabs/index.tsx
@@ -109,6 +109,8 @@ export class ZNavigationTabs {
 
   /**
    * Listen for child tab selection.
+   * Deselect all other previously selected tabs,
+   * then scroll to the new selected tab and center it.
    * @param {CustomEvent} event `selected` event triggered by a child tab
    */
   @Listen('selected')
@@ -119,6 +121,15 @@ export class ZNavigationTabs {
       if (child !== tab) {
         child.removeAttribute('selected');
       }
+    });
+
+    const scrollOptions = this.orientation === NavigationTabsOrientations.horizontal ?
+      { block: "nearest", inline: "center" } as ScrollIntoViewOptions :
+      { block: "center", inline: "nearest" } as ScrollIntoViewOptions;
+
+    (tab as Element).scrollIntoView({
+      behavior: "smooth",
+      ...scrollOptions,
     });
   }
 
@@ -156,39 +167,39 @@ export class ZNavigationTabs {
         'interactive-1': this.size !== NavigationTabsSizes.small
       }}
       scrollable={this.canNavigate}
+    >
+      {this.canNavigate && <button
+        class="navigation-button"
+        onClick={this.navigateBackwards.bind(this)}
+        tabindex="-1"
+        disabled={!this.canNavigatePrev}
       >
-        {this.canNavigate && <button
-          class="navigation-button"
-          onClick={this.navigateBackwards.bind(this)}
-          tabindex="-1"
-          disabled={!this.canNavigatePrev}
-        >
-          <z-icon
-            name={this.orientation == NavigationTabsOrientations.horizontal ? 'chevron-left' : 'chevron-up'}
-            width={16}
-            height={16}
-          />
-        </button>}
+        <z-icon
+          name={this.orientation == NavigationTabsOrientations.horizontal ? 'chevron-left' : 'chevron-up'}
+          width={16}
+          height={16}
+        />
+      </button>}
 
-        <nav
-          role="tablist"
-          ref={(el) => this.tabsNav = el ?? this.tabsNav }
-          onScroll={this.checkScrollEnabled.bind(this)}
-        >
-          <slot></slot>
-        </nav>
+      <nav
+        role="tablist"
+        ref={(el) => this.tabsNav = el ?? this.tabsNav }
+        onScroll={this.checkScrollEnabled.bind(this)}
+      >
+        <slot></slot>
+      </nav>
 
-        {this.canNavigate && <button
-          class="navigation-button"
-          onClick={this.navigateForward.bind(this)}
-          tabindex="-1"
-          disabled={!this.canNavigateNext}
-        >
-          <z-icon name={this.orientation == NavigationTabsOrientations.horizontal ? 'chevron-right' : 'chevron-down'}
-            width={16}
-            height={16}
-          />
-        </button>}
+      {this.canNavigate && <button
+        class="navigation-button"
+        onClick={this.navigateForward.bind(this)}
+        tabindex="-1"
+        disabled={!this.canNavigateNext}
+      >
+        <z-icon name={this.orientation == NavigationTabsOrientations.horizontal ? 'chevron-right' : 'chevron-down'}
+          width={16}
+          height={16}
+        />
+      </button>}
     </Host>;
   }
 }

--- a/src/components/navigation/tabs/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tabs/index.tsx
@@ -122,15 +122,6 @@ export class ZNavigationTabs {
         child.removeAttribute('selected');
       }
     });
-
-    const scrollOptions = this.orientation === NavigationTabsOrientations.horizontal ?
-      { block: "nearest", inline: "center" } as ScrollIntoViewOptions :
-      { block: "center", inline: "nearest" } as ScrollIntoViewOptions;
-
-    (tab as Element).scrollIntoView({
-      behavior: "smooth",
-      ...scrollOptions,
-    });
   }
 
   /**

--- a/src/components/navigation/tabs/z-navigation-tabs/styles.css
+++ b/src/components/navigation/tabs/z-navigation-tabs/styles.css
@@ -35,7 +35,7 @@
   box-shadow: 0px 0px 4px 1px rgb(66, 69, 72, 0.40);
 }
 
-.navigation-button:focus {
+.navigation-button:focus:focus-visible {
   fill: var(--color-primary01);
   box-shadow: inset var(--shadow-focus-primary);
 }

--- a/src/components/navigation/tabs/z-navigation-tabs/styles.css
+++ b/src/components/navigation/tabs/z-navigation-tabs/styles.css
@@ -1,13 +1,8 @@
 :host {
-  --safe-scroll-area: 4px;
-  --negative-safe-scroll-area: calc(-1 * var(--safe-scroll-area));
-
   position: relative;
   display: flex;
   flex-direction: row;
   z-index: 0;
-  margin: var(--negative-safe-scroll-area);
-  padding: var(--safe-scroll-area);
   font-family: var(--font-family-sans);
   font-weight: var(--font-rg);
   overflow: hidden;
@@ -37,11 +32,12 @@
   border-radius: var(--border-no-radius);
   cursor: pointer;
   z-index: 1;
+  box-shadow: 0px 0px 4px 1px rgb(66, 69, 72, 0.40);
 }
 
 .navigation-button:focus {
   fill: var(--color-primary01);
-  box-shadow: var(--shadow-focus-primary);
+  box-shadow: inset var(--shadow-focus-primary);
 }
 
 .navigation-button:disabled {
@@ -53,9 +49,6 @@ nav {
   align-items: center;
   justify-content: flex-start;
   overflow: auto;
-  margin: var(--negative-safe-scroll-area);
-  padding: var(--safe-scroll-area);
-  scroll-padding: var(--safe-scroll-area);
 
   /* hide scrollbar in Firefox */
   scrollbar-width: none;
@@ -68,19 +61,15 @@ nav {
 :host([orientation='horizontal']) .navigation-button {
   top: 0;
   height: 100%;
-  width: calc((var(--space-unit) * 4) + var(--safe-scroll-area));
+  width: calc(var(--space-unit) * 4);
 }
 
 :host([orientation='horizontal']) .navigation-button:first-child {
   left: 0;
-  padding-left: var(--safe-scroll-area);
-  box-shadow: 5px 0px var(--safe-scroll-area) var(--negative-safe-scroll-area) rgba(66, 69, 72, 0.40);
 }
 
 :host([orientation='horizontal']) .navigation-button:last-child {
   right: 0;
-  padding-right: 4px;
-  box-shadow: -5px 0px var(--safe-scroll-area) var(--negative-safe-scroll-area) rgba(66, 69, 72, 0.40);
 }
 
 /* Orientation vertical */
@@ -98,19 +87,15 @@ nav {
 :host([orientation='vertical']) .navigation-button {
   left: 0;
   width: 100%;
-  height: calc((var(--space-unit) * 4) + var(--safe-scroll-area));
+  height: calc(var(--space-unit) * 4);
 }
 
 :host([orientation='vertical']) .navigation-button:first-child {
   top: 0;
-  padding-top: var(--safe-scroll-area);
-  box-shadow: 0px 5px var(--safe-scroll-area) var(--negative-safe-scroll-area) rgba(66, 69, 72, 0.40);
 }
 
 :host([orientation='vertical']) .navigation-button:last-child {
   bottom: 0;
-  padding-bottom: var(--safe-scroll-area);
-  box-shadow: 0px -5px var(--safe-scroll-area) var(--negative-safe-scroll-area) rgba(66, 69, 72, 0.40);
 }
 
 :host([size='small'][orientation='vertical']) .navigation-button {

--- a/src/components/navigation/tabs/z-navigation-tabs/styles.css
+++ b/src/components/navigation/tabs/z-navigation-tabs/styles.css
@@ -49,6 +49,7 @@ nav {
   align-items: center;
   justify-content: flex-start;
   overflow: auto;
+  scroll-behavior: smooth;
 
   /* hide scrollbar in Firefox */
   scrollbar-width: none;


### PR DESCRIPTION
# Refactor - z-navigation-tab/z-navigation-tab-link
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->
<!--- [short description] description of the action -->

### Motivation and Context
Shadow DOM "hides" the buttons/anchors of the navigation tab components and this could create accessibility and navigation problems: the clicks on the anchors are not seen by the internal router of the applications and this would cause a total refresh of the page instead of an optimized one.

Also added a scroll to center the selected tab in the scrollable navbar and some style fixes.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)