### PR TITLE
Fix - ZAppHeader - Removed offset setting

### DIFF
--- a/src/components/navigation/z-app-header/index.spec.ts
+++ b/src/components/navigation/z-app-header/index.spec.ts
@@ -6,11 +6,11 @@ describe("Suite test ZAppHeader", () => {
   it("Test render empty ZAppHeader", async () => {
     const page = await newSpecPage({
       components: [ZAppHeader],
-      html: `<z-app-header></z-app-header>`
+      html: `<z-app-header></z-app-header>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-app-header menu-length="0" flow="auto" style="--app-header-top-offset: 0px;">
+      <z-app-header menu-length="0" flow="auto">
         <mock:shadow-root>
           <div class="heading-panel">
             <div class="hero-container">
@@ -40,7 +40,7 @@ describe("Suite test ZAppHeader", () => {
           </div>
         </mock:shadow-root>
       </z-app-header>
-    `)
+    `);
   });
 
   it("Test render ZAppHeader with title", async () => {
@@ -48,11 +48,11 @@ describe("Suite test ZAppHeader", () => {
       components: [ZAppHeader],
       html: `<z-app-header>
         <h1 slot="title">Titolo di test</h1>
-      </z-app-header>`
+      </z-app-header>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-app-header menu-length="0" flow="auto" style="--app-header-top-offset: 0px;">
+      <z-app-header menu-length="0" flow="auto">
         <mock:shadow-root>
           <div class="heading-panel">
             <div class="hero-container">
@@ -92,11 +92,11 @@ describe("Suite test ZAppHeader", () => {
       html: `<z-app-header>
         <h1 slot="title">Titolo di test</h1>
         <h2 slot="subtitle">Sottotitolo di test</h2>
-      </z-app-header>`
+      </z-app-header>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-app-header menu-length="0" flow="auto" style="--app-header-top-offset: 0px;">
+      <z-app-header menu-length="0" flow="auto">
         <mock:shadow-root>
           <div class="heading-panel">
             <div class="hero-container">
@@ -137,11 +137,11 @@ describe("Suite test ZAppHeader", () => {
       components: [ZAppHeader],
       html: `<z-app-header drawer>
         <h1 slot="title">Titolo di test</h1>
-      </z-app-header>`
+      </z-app-header>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-app-header menu-length="0" flow="auto" drawer style="--app-header-top-offset: 0px;">
+      <z-app-header menu-length="0" flow="auto" drawer>
         <mock:shadow-root>
           <div class="heading-panel">
             <div class="hero-container">
@@ -179,11 +179,11 @@ describe("Suite test ZAppHeader", () => {
       components: [ZAppHeader],
       html: `<z-app-header stuck>
         <h1 slot="title">Titolo di test</h1>
-      </z-app-header>`
+      </z-app-header>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-app-header menu-length="0" flow="auto" stuck style="--app-header-top-offset: 0px;">
+      <z-app-header menu-length="0" flow="auto" stuck>
         <mock:shadow-root>
           <div class="heading-panel">
             <div class="hero-container">
@@ -216,4 +216,3 @@ describe("Suite test ZAppHeader", () => {
     `);
   });
 });
-

--- a/src/components/navigation/z-app-header/index.tsx
+++ b/src/components/navigation/z-app-header/index.tsx
@@ -82,13 +82,11 @@ export class ZAppHeader {
   constructor() {
     this.openDrawer = this.openDrawer.bind(this);
     this.closeDrawer = this.closeDrawer.bind(this);
-    this.setStuckPosition = this.setStuckPosition.bind(this);
   }
 
   componentDidLoad() {
     this.collectMenuElements();
     this.onStuckMode();
-    this.setStuckPosition();
   }
 
   private get title() {
@@ -112,15 +110,6 @@ export class ZAppHeader {
     const menuElements = this.menuElements = this.hostElement.querySelectorAll('[slot="menu"]');
     this.menuLength = menuElements.length;
     this.setMenuFloatingMode();
-  }
-
-  /**
-   * Set `z-app-topbar`'s height as stucked header top offset.
-   */
-  private setStuckPosition() {
-    const topbar = this.hostElement.ownerDocument.querySelector('z-app-topbar');
-    const top = topbar ? topbar.clientHeight : 0;
-    this.hostElement.style.setProperty('--app-header-top-offset', `${top}px`);
   }
 
   @Watch('stuck')
@@ -152,12 +141,6 @@ export class ZAppHeader {
       return;
     }
     this.emitStickingEvent();
-    if (this.stucked) {
-      this.setStuckPosition();
-      scrollParent.addEventListener('scroll', this.setStuckPosition);
-    } else {
-      scrollParent.removeEventListener('scroll', this.setStuckPosition);
-    }
   }
 
   @Watch('drawerOpen')

--- a/src/components/navigation/z-app-header/styles.css
+++ b/src/components/navigation/z-app-header/styles.css
@@ -43,7 +43,7 @@
   /**
    * Variable to set stucked header and drawer's top offset. Useful when something is absolutely positioned above the header.
    */
-  --app-header-top-offset: var(var(--app-header-top-offset), 0);
+  --app-header-top-offset: 48px;
 
   --app-header-drawer-trigger-size: calc(var(--space-unit) * 4);
 


### PR DESCRIPTION
# Fix - ZAppHeader - Removed offset setting
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->
<!--- [short description] description of the action -->
----

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->
The `ZAppHeader` component used to dinamically set the stuck mode offset based on the `ZAppTopbar` component height.
The `ZAppTopbar` component is not longer user in the `IdpLogin` component, so the offset is always set to 0 and breaks the stuck mode.

### Priority
<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->
- [ ] 1 - Highest
- [X] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes
<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract
<!--- Refers to Design System Abstract sheets or collections -->
<!--- Add Screenshots if appropriate -->

### Screenshots

### Note
<!-- Adds description, notes, any blocks -->
<!-- Free field, not mandatory -->
----

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
