### PR TITLE
Fix - z-offcanvas - avoid double rendering upon opening

### DIFF
--- a/src/components/z-offcanvas/index.spec.ts
+++ b/src/components/z-offcanvas/index.spec.ts
@@ -12,7 +12,7 @@ describe("Suite test ZOffcanvas", () => {
     });
 
     expect(page.root).toEqualHtml(`
-			<z-offcanvas open="" transitiondirection="left" variant="pushcontent" style="display: flex;">
+			<z-offcanvas open="" transitiondirection="left" variant="pushcontent" style="opacity: 0; display: flex;">
 
 				<div class="canvas-container">
 					<div class="canvas-content">

--- a/src/components/z-offcanvas/index.tsx
+++ b/src/components/z-offcanvas/index.tsx
@@ -44,6 +44,7 @@ export class ZOffcanvas {
 
   private handleOpenStatus(): void {
     if (this.open) {
+      this.hostElement.style.opacity = "0";
       this.hostElement.style.display = "flex";
     } else if (this.variant === OffCanvasVariant.PUSHCONTENT) {
       this.hostElement.style.display = "none";
@@ -60,12 +61,19 @@ export class ZOffcanvas {
     }
   }
 
+  private handleAnimationStart(): void {
+    if (this.hostElement.hasAttribute("open")) {
+      this.hostElement.style.opacity = "1";
+    }
+  }
+
   render(): HTMLZOffcanvasElement {
     return (
       <Host>
         <div
           class="canvas-container"
           onAnimationEnd={() => this.handleAnimationEnd()}
+          onAnimationStart={() => this.handleAnimationStart()}
         >
           <div class="canvas-content">
             <slot name="canvasContent"></slot>


### PR DESCRIPTION
### Motivation and Context
BTH-5920 - while trying to integrate the appswitcher into idp-login-component, we encountered an issue with the component briefly flashing on the screen before sliding in as it should. 

### Priority
- [ ] 1 - Highest
- [x] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Note

This PR is meant as a workaround. A more structural refactoring might be advisable.

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
