### PR TITLE
fix: force autocomplete input background color

### DIFF
--- a/src/components/inputs/z-input/styles-text.css
+++ b/src/components/inputs/z-input/styles-text.css
@@ -57,9 +57,12 @@
 }
 
 /* Disable background color webkit */
+/* stylelint-disable property-no-vendor-prefix */
 .text-wrapper > div > input:-webkit-autofill,
 .text-wrapper > div > input:-webkit-autofill:hover,
 .text-wrapper > div > input:-webkit-autofill:focus,
 .text-wrapper > div > input:-webkit-autofill:active {
+  background: var(--color-white) !important;
   background-clip: text !important;
+  -webkit-transition-delay: 99999s !important; /* trick: background color will be applied after 99999s */
 }


### PR DESCRIPTION
# Fix - ZInput - Force background color with autocomplete inputs

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## <!--- [short description] description of the action -->

### Motivation and Context
Force background color to white to prevent Chrome light blue background on inputs with autocomplete prop (login form).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [X] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract

<!--- Refers to Design System Abstract sheets or collections -->
<!--- Add Screenshots if appropriate -->

### Screenshots

### Note

<!-- Adds description, notes, any blocks -->

## <!-- Free field, not mandatory -->

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
