### PR TITLE
fix: avoid render loop

### DIFF
--- a/src/components/inputs/z-combobox/index.tsx
+++ b/src/components/inputs/z-combobox/index.tsx
@@ -91,11 +91,12 @@ export class ZCombobox {
   watchItems(): void {
     this.itemsList = typeof this.items === "string" ? JSON.parse(this.items) : this.items;
     this.selectedCounter = this.itemsList.filter((item) => item.checked).length;
-    if (this.searchValue) {
-      this.filterItems(this.searchValue);
-    } else {
-      this.resetRenderItemsList();
-    }
+    this.updateRenderItemsList();
+  }
+
+  @Watch("searchValue")
+  watchSearchValue(): void {
+    this.filterItems(this.searchValue);
   }
 
   @Listen("inputCheck")
@@ -113,7 +114,7 @@ export class ZCombobox {
 
       return item;
     });
-    this.resetRenderItemsList();
+    this.updateRenderItemsList();
     this.emitComboboxChange();
   }
 
@@ -136,8 +137,13 @@ export class ZCombobox {
 
   componentWillRender(): void {
     this.selectedCounter = this.itemsList.filter((item) => item.checked).length;
+  }
+
+  private updateRenderItemsList(): void {
     if (this.searchValue) {
       this.filterItems(this.searchValue);
+    } else {
+      this.resetRenderItemsList();
     }
   }
 
@@ -153,7 +159,6 @@ export class ZCombobox {
     if (!value) {
       return this.closeFilterItems();
     }
-    this.searchValue = value;
 
     this.resetRenderItemsList();
     this.renderItemsList = this.renderItemsList.filter((item) => {
@@ -364,7 +369,7 @@ export class ZCombobox {
           if (e.detail.keycode === 27) {
             return this.closeFilterItems();
           }
-          this.filterItems(e.detail.value);
+          this.searchValue = e.detail.value;
         }}
       />
     );


### PR DESCRIPTION
# Title
Fix - Z-Combobox - fix render loop on props change when search is populated

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## <!--- [short description] description of the action -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [X] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract

<!--- Refers to Design System Abstract sheets or collections -->
<!--- Add Screenshots if appropriate -->

### Screenshots

### Note

<!-- Adds description, notes, any blocks -->

## <!-- Free field, not mandatory -->

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
