### PR TITLE
Feat/z-app-header max width

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2459,7 +2459,7 @@ declare namespace LocalJSX {
          */
         "hero"?: string;
         /**
-          * Emitted when the `stucked` state of the header changes
+          * Emitted when the `stuck` state of the header changes
          */
         "onSticking"?: (event: ZAppHeaderCustomEvent<any>) => void;
         /**

--- a/src/components/inputs/z-combobox/index.stories.mdx
+++ b/src/components/inputs/z-combobox/index.stories.mdx
@@ -11,73 +11,75 @@ import "./index";
   argTypes={{
     items: {
       control: {type: "object"},
-      defaultValue: [
-        {id: "item_1", name: "First item", checked: false, category: "Gruppo 1"},
-        {id: "item_2", name: "Second item", checked: false, category: "Gruppo 1"},
-        {id: "item_3", name: "Other item", checked: false, category: "Gruppo 2"},
-        {id: "item_4", name: "Last item", checked: false, category: "Gruppo 3"},
-      ],
     },
     checkalltext: {
       control: {type: "text"},
-      defaultValue: "Select all",
     },
     closesearchtext: {
       control: {type: "text"},
-      defaultValue: "Close",
     },
     hascheckall: {
       control: {type: "boolean"},
-      defaultValue: true,
     },
     hassearch: {
       control: {type: "boolean"},
-      defaultValue: true,
     },
     inputid: {
       control: {type: "text"},
-      defaultValue: "combo_1",
     },
     isfixed: {
       control: {type: "boolean"},
-      defaultValue: true,
     },
     isopen: {
       control: {type: "boolean"},
-      defaultValue: true,
     },
     label: {
       control: {type: "text"},
-      defaultValue: "Combobox Label",
     },
     maxcheckableitems: {
       control: {type: "number"},
-      defaultValue: 4,
     },
     hasgroupitems: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     noresultslabel: {
       control: {type: "text"},
-      defaultValue: "No items",
     },
     searchlabel: {
       control: {type: "text"},
-      defaultValue: "Search Label",
     },
     searchplaceholder: {
       control: {type: "text"},
-      defaultValue: "Search Placeholder",
     },
     searchtitle: {
       control: {type: "text"},
-      defaultValue: "Search Title",
     },
     uncheckalltext: {
       control: {type: "text"},
-      defaultValue: "Uncheck All",
     },
+  }}
+  args={{
+    items: [
+      {id: "item_1", name: "First item", checked: false, category: "Gruppo 1"},
+      {id: "item_2", name: "Second item", checked: false, category: "Gruppo 1"},
+      {id: "item_3", name: "Other item", checked: false, category: "Gruppo 2"},
+      {id: "item_4", name: "Last item", checked: false, category: "Gruppo 3"},
+    ],
+    checkalltext: "Select all",
+    closesearchtext: "Close",
+    hascheckall: true,
+    hassearch: true,
+    inputid: "combo_1",
+    isfixed: true,
+    isopen: true,
+    label: "Combobox Label",
+    maxcheckableitems: 4,
+    hasgroupitems: false,
+    noresultslabel: "No items",
+    searchlabel: "Search Label",
+    searchplaceholder: "Search Placeholder",
+    searchtitle: "Search Title",
+    uncheckalltext: "Uncheck All",
   }}
 />
 

--- a/src/components/inputs/z-input/index.stories.mdx
+++ b/src/components/inputs/z-input/index.stories.mdx
@@ -12,94 +12,96 @@ import "./index";
     type: {
       control: {type: "inline-radio"},
       options: Object.values(InputType),
-      defaultValue: "text",
     },
     label: {
       control: {type: "text"},
-      defaultValue: "this is the input label",
     },
     ariaLabel: {
       control: {type: "text"},
-      defaultValue: "",
     },
     labelPosition: {
       control: {type: "inline-radio"},
       options: Object.values(LabelPosition),
-      defaultValue: LabelPosition.RIGHT,
     },
     placeholder: {
       control: {type: "text"},
-      defaultValue: "input placeholder text",
     },
     value: {
       control: {type: "text"},
-      defaultValue: "",
     },
     name: {
       control: {type: "text"},
-      defaultValue: "",
     },
     status: {
       control: {type: "inline-radio"},
       options: ["default", ...Object.values(InputStatus)],
-      defaultValue: "default",
     },
     message: {
       control: {type: "text"},
-      defaultValue: "helper text",
     },
     icon: {
       control: {type: "text"},
-      defaultValue: "",
     },
     disabled: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     readonly: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     required: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     checked: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     hasclearicon: {
       control: {type: "boolean"},
-      defaultValue: true,
     },
     htmlid: {
       control: {type: "text"},
-      defaultValue: "input-id",
     },
     htmltitle: {
       control: {type: "text"},
-      defaultValue: "",
     },
     autocomplete: {
       control: {type: "text"},
-      defaultValue: "",
     },
     min: {
       control: {type: "number"},
-      defaultValue: 1,
     },
     max: {
       control: {type: "number"},
-      defaultValue: 10,
     },
     step: {
       control: {type: "number"},
-      defaultValue: 1,
     },
     pattern: {
       control: {type: "text"},
-      defaultValue: "",
     },
+  }}
+  args={{
+    type: "text",
+    label: "this is the input label",
+    ariaLabel: "",
+    labelPosition: LabelPosition.RIGHT,
+    placeholder: "input placeholder text",
+    value: "",
+    name: "",
+    status: "default",
+    message: "helper text",
+    icon: "",
+    disabled: false,
+    readonly: false,
+    required: false,
+    checked: false,
+    hasclearicon: true,
+    htmlid: "input-id",
+    htmltitle: "",
+    autocomplete: "",
+    min: 1,
+    max: 10,
+    step: 1,
+    pattern: "",
   }}
 />
 
@@ -213,8 +215,10 @@ import "./index";
     argTypes={{
       type: {
         options: ["textarea"],
-        defaultValue: "textarea",
       },
+    }}
+    args={{
+      type: "textarea",
     }}
   >
     {(args) =>
@@ -259,8 +263,10 @@ import "./index";
     argTypes={{
       type: {
         options: ["checkbox"],
-        defaultValue: "checkbox",
       },
+    }}
+    args={{
+      type: "checkbox",
     }}
   >
     {(args) =>
@@ -304,8 +310,10 @@ import "./index";
     argTypes={{
       type: {
         options: ["radio"],
-        defaultValue: "radio",
       },
+    }}
+    args={{
+      type: "radio",
     }}
   >
     {(args) =>
@@ -337,23 +345,12 @@ import "./index";
     argTypes={{
       type: {
         options: ["number"],
-        defaultValue: "number",
       },
-      min: {
-        defaultValue: 1,
-      },
-      max: {
-        defaultValue: 10,
-      },
-      step: {
-        defaultValue: 1,
-      },
-      value: {
-        defaultValue: "1",
-      },
-      hasclearicon: {
-        defaultValue: false,
-      },
+    }}
+    args={{
+      type: "number",
+      value: "1",
+      hasclearicon: false,
     }}
   >
     {(args) =>

--- a/src/components/inputs/z-select/index.stories.mdx
+++ b/src/components/inputs/z-select/index.stories.mdx
@@ -11,83 +11,85 @@ import "./index";
   argTypes={{
     items: {
       control: {type: "object"},
-      defaultValue: [
-        {
-          id: "item_1",
-          name: "first item",
-          selected: false,
-        },
-        {
-          id: "item_2",
-          name: "second item",
-          selected: true,
-        },
-        {
-          id: "item_3",
-          name: "disabled item",
-          selected: false,
-          disabled: true,
-        },
-        {
-          id: "item_4",
-          name: "fourth item",
-          selected: false,
-        },
-      ],
     },
     label: {
       control: {type: "text"},
-      defaultValue: "this is the label",
     },
     ariaLabel: {
       control: {type: "text"},
-      defaultValue: "",
     },
     placeholder: {
       control: {type: "text"},
-      defaultValue: "select placeholder",
     },
     name: {
       control: {type: "text"},
-      defaultValue: "",
     },
     status: {
       control: {type: "select"},
       options: ["-", ...Object.values(InputStatus)],
-      defaultValue: "-",
     },
     message: {
       control: {type: "text"},
-      defaultValue: "helper text",
     },
     disabled: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     readonly: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     htmlid: {
       control: {type: "text"},
-      defaultValue: "",
     },
     htmltitle: {
       control: {type: "text"},
-      defaultValue: "",
     },
     autocomplete: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     noresultslabel: {
       control: {type: "text"},
-      defaultValue: "Nessun risultato",
     },
     hasListGroups: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
+  }}
+  args={{
+    items: [
+      {
+        id: "item_1",
+        name: "first item",
+        selected: false,
+      },
+      {
+        id: "item_2",
+        name: "second item",
+        selected: true,
+      },
+      {
+        id: "item_3",
+        name: "disabled item",
+        selected: false,
+        disabled: true,
+      },
+      {
+        id: "item_4",
+        name: "fourth item",
+        selected: false,
+      },
+    ],
+    label: "this is the label",
+    ariaLabel: "",
+    placeholder: "select placeholder",
+    name: "",
+    status: "-",
+    message: "helper text",
+    disabled: false,
+    readonly: false,
+    htmlid: "",
+    htmltitle: "",
+    autocomplete: false,
+    noresultslabel: "Nessun risultato",
+    hasListGroups: false
   }}
 />
 

--- a/src/components/inputs/z-select/index.stories.mdx
+++ b/src/components/inputs/z-select/index.stories.mdx
@@ -89,7 +89,7 @@ import "./index";
     htmltitle: "",
     autocomplete: false,
     noresultslabel: "Nessun risultato",
-    hasListGroups: false
+    hasListGroups: false,
   }}
 />
 

--- a/src/components/list/z-list-element/index.stories.mdx
+++ b/src/components/list/z-list-element/index.stories.mdx
@@ -18,65 +18,67 @@ import "./index";
     alignButton: {
       control: {type: "select"},
       options: Object.values(ExpandableListButtonAlign),
-      defaultValue: ExpandableListButtonAlign.LEFT,
     },
     clickable: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     dividerColor: {
       control: {type: "text"},
-      defaultValue: "color-surface03",
     },
     dividerType: {
       control: {type: "select"},
       options: Object.values(ListDividerType),
-      defaultValue: ListDividerType.NONE,
     },
     dividerSize: {
       control: {type: "select"},
       options: Object.values(DividerSize),
-      defaultValue: DividerSize.SMALL,
     },
     expandable: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     expandableStyle: {
       control: {type: "select"},
       options: Object.values(ExpandableListStyle),
-      defaultValue: ExpandableListStyle.ACCORDION,
     },
     listElementId: {
       control: {type: "text"},
-      defaultValue: "0",
     },
     size: {
       control: {type: "select"},
       options: Object.values(ListSize),
-      defaultValue: ListSize.MEDIUM,
     },
     color: {
       control: {type: "text"},
-      defaultValue: "none",
     },
     disabled: {
       control: {type: "boolean"},
-      defaultValue: true,
     },
     isContextualMenu: {
       control: {type: "boolean"},
-      defaultValue: false,
     },
     listElementPosition: {
       control: {type: "text"},
-      defaultValue: "0",
     },
     listType: {
       control: {type: "select"},
       options: Object.values(ListType),
-      defaultValue: ListType.NONE,
     },
+  }}
+  args={{
+    alignButton: ExpandableListButtonAlign.LEFT,
+    clickable: false,
+    dividerColor: "color-surface03",
+    dividerType: ListDividerType.NONE,
+    dividerSize: DividerSize.SMALL,
+    expandable: false,
+    expandableStyle: ExpandableListStyle.ACCORDION,
+    listElementId: "0",
+    size: ListSize.MEDIUM,
+    color: "none",
+    disabled: true,
+    isContextualMenu: false,
+    listElementPosition: "0",
+    listType: ListType.NONE,
   }}
 />
 

--- a/src/components/list/z-list-group/index.stories.mdx
+++ b/src/components/list/z-list-group/index.stories.mdx
@@ -10,27 +10,29 @@ import "./index";
     size: {
       control: {type: "select"},
       options: Object.values(ListSize),
-      defaultValue: ListSize.SMALL,
     },
     dividerType: {
       control: {type: "select"},
       options: Object.values(ListDividerType),
-      defaultValue: ListDividerType.HEADER,
     },
     dividerSize: {
       control: {type: "select"},
       options: Object.values(DividerSize),
-      defaultValue: DividerSize.SMALL,
     },
     dividerColor: {
       control: {type: "text"},
-      defaultValue: "gray200",
     },
     listType: {
       control: {type: "select"},
       options: Object.values(ListType),
-      defaultValue: ListType.NONE,
     },
+  }}
+  argTypes={{
+    size: ListSize.SMALL,
+    dividerType: ListDividerType.HEADER,
+    dividerSize: DividerSize.SMALL,
+    dividerColor: "gray200",
+    listType: ListType.NONE,
   }}
 />
 

--- a/src/components/list/z-list/index.stories.mdx
+++ b/src/components/list/z-list/index.stories.mdx
@@ -18,7 +18,7 @@ import "./index";
   }}
   args={{
     size: ListSize.MEDIUM,
-    listType: ListType.NONE
+    listType: ListType.NONE,
   }}
 />
 

--- a/src/components/list/z-list/index.stories.mdx
+++ b/src/components/list/z-list/index.stories.mdx
@@ -10,13 +10,15 @@ import "./index";
     size: {
       control: {type: "select"},
       options: Object.values(ListSize),
-      defaultValue: ListSize.MEDIUM,
     },
     listType: {
       control: {type: "select"},
       options: Object.values(ListType),
-      defaultValue: ListType.NONE,
     },
+  }}
+  args={{
+    size: ListSize.MEDIUM,
+    listType: ListType.NONE
   }}
 />
 

--- a/src/components/navigation/z-app-header/index.stories.css
+++ b/src/components/navigation/z-app-header/index.stories.css
@@ -1,9 +1,0 @@
-#z-app-header-with-topbar-wrapper {
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
-.content {
-  padding: 0 1rem 1rem;
-}

--- a/src/components/navigation/z-app-header/index.stories.mdx
+++ b/src/components/navigation/z-app-header/index.stories.mdx
@@ -1,46 +1,50 @@
 import {html} from "lit-html";
-import {Meta, Story, Preview, Props} from "@storybook/addon-docs";
-import {select, boolean, text} from "@storybook/addon-knobs";
-import "./index.stories.css";
+import {Meta, Canvas, Story, ArgsTable} from "@storybook/addon-docs";
 import "./index";
 
 <Meta
   title="Navigation/ZAppHeader"
   component="z-app-header"
+  argTypes={{
+    "--app-header-content-max-width": {
+      control: {type: "text"},
+    },
+  }}
+  args={{
+    "--app-header-content-max-width": "100%",
+  }}
 />
 
 # ZAppHeader
 
-[Abstract](https://app.abstract.com/projects/fd370780-e659-11e8-99dc-0d08537c5fde/branches/0c0f3a4b-c77f-421b-857a-40df36455ea1/commits/bd0e05fd10cb1dcb25b30a0cce7aa900f90d9329/files/9f586aa0-bd5b-4c12-9541-aed2e98a7a9c/layers/4E523230-5E7F-4CA2-A228-9670D60C3030?collectionId=98002816-a2d9-48f1-880a-2e6854ac2181&collectionLayerId=c9df3f28-2ff5-40fb-9dca-846f3af1090e&mode=design)
-
-<Preview>
+<Canvas>
   <Story name="Title">
-    {html`<z-app-header>
+    {(args) => html`<z-app-header style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}">
       <h1 slot="title">Applicazione</h1>
     </z-app-header>`}
   </Story>
-</Preview>
+</Canvas>
 
-<Props of="z-app-header" />
+<ArgsTable of="z-app-header" />
 
 ---
 
 ### With payoff
 
-<Preview>
+<Canvas>
   <Story name="Subtitle">
-    {html`<z-app-header>
+    {(args) => html`<z-app-header style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}">
       <h1 slot="title">Applicazione</h1>
       <h2 slot="subtitle">Payoff dell'applicazione</h2>
     </z-app-header>`}
   </Story>
-</Preview>
+</Canvas>
 
 ### With menu
 
-<Preview>
+<Canvas>
   <Story name="Menu">
-    {html`<z-app-header>
+    {(args) => html`<z-app-header style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}">
       <h1 slot="title">Applicazione</h1>
       <h2 slot="subtitle">Payoff dell'applicazione</h2>
       <z-menu
@@ -146,7 +150,7 @@ import "./index";
     </z-app-header>`}
   </Story>
   <Story name="Long title">
-    {html`<z-app-header>
+    {(args) => html`<z-app-header style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}">
       <h1 slot="title">Applicazione con nome veramente lungo che fa andare il menu a capo</h1>
       <h2 slot="subtitle">Payoff dell'applicazione</h2>
       <z-menu
@@ -293,7 +297,7 @@ import "./index";
     </z-app-header>`}
   </Story>
   <Story name="(Very) Long menu">
-    {html`<z-app-header>
+    {(args) => html`<z-app-header style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}">
       <h1 slot="title">Applicazione</h1>
       <h2 slot="subtitle">Payoff dell'applicazione</h2>
       <z-menu
@@ -628,7 +632,10 @@ import "./index";
     </z-app-header>`}
   </Story>
   <Story name="Offcanvas menu">
-    {html`<z-app-header flow="offcanvas">
+    {(args) => html`<z-app-header
+      flow="offcanvas"
+      style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}"
+    >
       <h1 slot="title">Applicazione</h1>
       <h2 slot="subtitle">Payoff dell'applicazione</h2>
       <z-menu slot="menu">
@@ -941,16 +948,187 @@ import "./index";
       </z-menu>
     </z-app-header>`}
   </Story>
-</Preview>
+</Canvas>
+
+### Stuck header
+
+<Story
+  name="Stuck"
+  decorators={[
+    (Story) => html`
+      Scroll to see <code>stuck</code> prop in action.
+      <div style="height: 3000px">${Story()}</div>
+    `,
+  ]}
+>
+  {(args) => html`<z-app-header
+    stuck
+    style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}; --app-header-top-offset: 0"
+  >
+    <h1 slot="title">Applicazione</h1>
+    <h2 slot="subtitle">Payoff dell'applicazione</h2>
+    <z-menu slot="menu">
+      <h3>Menu label</h3>
+      <a
+        href=""
+        slot="item"
+        >Item 1</a
+      >
+      <a
+        href=""
+        slot="item"
+        >Item 2</a
+      >
+      <z-menu-section slot="item">
+        <h3>Item 3</h3>
+        <a
+          href=""
+          slot="item"
+          >Item 3.1</a
+        >
+        <a
+          href=""
+          slot="item"
+          >Item 3.2</a
+        >
+      </z-menu-section>
+    </z-menu>
+    <z-menu slot="menu">
+      <h3>Menu label</h3>
+      <a
+        href=""
+        slot="item"
+        >Item 1</a
+      >
+      <a
+        href=""
+        slot="item"
+        >Item 2</a
+      >
+      <z-menu-section slot="item">
+        <h3>Item 3</h3>
+        <a
+          href=""
+          slot="item"
+          >Item 3.1</a
+        >
+        <a
+          href=""
+          slot="item"
+          >Item 3.2</a
+        >
+      </z-menu-section>
+    </z-menu>
+    <z-menu slot="menu">
+      <h3>Menu label</h3>
+      <a
+        href=""
+        slot="item"
+        >Item 1</a
+      >
+      <a
+        href=""
+        slot="item"
+        >Item 2</a
+      >
+      <z-menu-section slot="item">
+        <h3>Item 3</h3>
+        <a
+          href=""
+          slot="item"
+          >Item 3.1</a
+        >
+        <a
+          href=""
+          slot="item"
+          >Item 3.2</a
+        >
+      </z-menu-section>
+    </z-menu>
+  </z-app-header>`}
+</Story>
+
+### Max width
+
+<Story
+  name="Max width"
+  args={{
+    "--app-header-content-max-width": "1366px",
+  }}
+  decorators={[
+    (Story) => html`
+      Scroll to see max width also in stuck header.
+      <div style="height: 3000px">${Story()}</div>
+    `,
+  ]}
+>
+  {(args) => html`<z-app-header
+    stuck
+    style="--app-header-content-max-width: ${args["--app-header-content-max-width"]}; --app-header-top-offset: 0;"
+  >
+    <h1 slot="title">Applicazione</h1>
+    <h2 slot="subtitle">Payoff dell'applicazione</h2>
+    <z-menu slot="menu">
+      <h3>Menu label</h3>
+      <a
+        href=""
+        slot="item"
+        >Item 1</a
+      >
+      <a
+        href=""
+        slot="item"
+        >Item 2</a
+      >
+    </z-menu>
+    <z-menu slot="menu">
+      <h3>Menu label</h3>
+      <a
+        href=""
+        slot="item"
+        >Item 1</a
+      >
+      <a
+        href=""
+        slot="item"
+        >Item 2</a
+      >
+    </z-menu>
+    <z-menu slot="menu">
+      <h3>Menu label</h3>
+      <a
+        href=""
+        slot="item"
+        >Item 1</a
+      >
+      <a
+        href=""
+        slot="item"
+        >Item 2</a
+      >
+    </z-menu>
+  </z-app-header>`}
+</Story>
 
 ### Hero
 
-<Preview>
-  <Story name="Hero">
-    {html`<z-app-header
+<Canvas>
+  <Story
+    name="Hero"
+    argTypes={{
+      flow: {
+        control: {type: "inline-radio"},
+        options: ["auto", "stack", "offcanvas"],
+      },
+    }}
+    args={{
+      flow: "auto",
+    }}
+  >
+    {(args) => html`<z-app-header
       overlay
-      style="--app-header-height: 400px;"
-      flow="${select("Flow", ["auto", "stack", "offcanvas"], "auto")}"
+      style="--app-header-height: 400px; --app-header-content-max-width: ${args["--app-header-content-max-width"]}"
+      flow=${args.flow}
     >
       <h1 slot="title">Applicazione</h1>
       <h2 slot="subtitle">Payoff dell'applicazione</h2>
@@ -1102,4 +1280,4 @@ import "./index";
       </z-menu>
     </z-app-header>`}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/navigation/z-app-header/index.tsx
+++ b/src/components/navigation/z-app-header/index.tsx
@@ -4,9 +4,53 @@ import {ZMenu} from "../z-menu";
 const SUPPORT_INTERSECTION_OBSERVER = typeof IntersectionObserver !== "undefined";
 
 /**
- * @slot title
- * @slot subtitle
- * @slot stucked-title - Title for the stucked header. By default it uses the text from the `title` slot.
+ * @slot title - Slot for the main title
+ * @slot subtitle - Slot for the subtitle. It will not appear in stuck header.
+ * @slot stucked-title - Title for the stuck header. By default it uses the text from the `title` slot.
+ * @cssprop --app-header-content-max-width - Use it to set header's content max width. Useful when the project use a fixed width layout. Defaults to `100%`.
+ * @cssprop --app-header-height - Defaults to `auto`.
+ * @cssprop --app-header-typography-1-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `24px`.
+ * @cssprop --app-header-typography-2-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `28px`.
+ * @cssprop --app-header-typography-3-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `32px`.
+ * @cssprop --app-header-typography-4-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `36px`.
+ * @cssprop --app-header-typography-5-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `42px`.
+ * @cssprop --app-header-typography-6-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `48px`.
+ * @cssprop --app-header-typography-7-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `54px`.
+ * @cssprop --app-header-typography-8-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `60px`.
+ * @cssprop --app-header-typography-9-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `68px`.
+ * @cssprop --app-header-typography-10-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `76px`.
+ * @cssprop --app-header-typography-11-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `84px`.
+ * @cssprop --app-header-typography-12-size - Part of the heading typography's scale. Use it if you have to override the default value. Value: `92px`.
+ * @cssprop --app-header-typography-1-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.33`.
+ * @cssprop --app-header-typography-2-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.29`.
+ * @cssprop --app-header-typography-3-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.25`.
+ * @cssprop --app-header-typography-4-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.24`.
+ * @cssprop --app-header-typography-5-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.24`.
+ * @cssprop --app-header-typography-6-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.25`.
+ * @cssprop --app-header-typography-7-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.2`.
+ * @cssprop --app-header-typography-8-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.26`.
+ * @cssprop --app-header-typography-9-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.24`.
+ * @cssprop --app-header-typography-10-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.26`.
+ * @cssprop --app-header-typography-11-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.2`.
+ * @cssprop --app-header-typography-12-lineheight - Part of the heading typography's scale. Use it if you have to override the default value. Value: `1.2`.
+ * @cssprop --app-header-typography-1-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-0.2 / 1em)`.
+ * @cssprop --app-header-typography-2-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-0.4 / 1em)`.
+ * @cssprop --app-header-typography-3-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-0.6 / 1em)`.
+ * @cssprop --app-header-typography-4-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-0.8 / 1em)`.
+ * @cssprop --app-header-typography-5-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-1 / 1em)`.
+ * @cssprop --app-header-typography-6-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-1.2 / 1em)`.
+ * @cssprop --app-header-typography-7-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-1.4 / 1em)`.
+ * @cssprop --app-header-typography-8-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-1.6 / 1em)`.
+ * @cssprop --app-header-typography-9-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-1.8 / 1em)`.
+ * @cssprop --app-header-typography-10-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-2 / 1em)`.
+ * @cssprop --app-header-typography-11-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-2.2 / 1em)`.
+ * @cssprop --app-header-typography-12-tracking - Part of the heading typography's scale. Use it if you have to override the default value. Value: `calc(-2.4 / 1em)`.
+ * @cssprop --app-header-top-offset - Top offset for the stuck header. Useful when there are other fixed elements above the header. Defaults to `48px` (the height of the main topbar).
+ * @cssprop --app-header-drawer-trigger-size - The size of the drawer icon. Defaults to `--space-unit * 4`.
+ * @cssprop --app-header-bg - Header background color. Defaults to `--color-white`.
+ * @cssprop --app-header-stucked-bg - Stuck header background color. Defaults to `--color-white`.
+ * @cssprop --app-header-text-color - Text color. Defaults to `--gray800`.
+ * @cssprop --app-header-stucked-text-color - Stuck header text color. Defaults to `--gray800`.
  */
 @Component({
   tag: "z-app-header",
@@ -58,10 +102,10 @@ export class ZAppHeader {
   drawerOpen = false;
 
   /**
-   * The stucked state of the bar.
+   * The stuck state of the bar.
    */
   @State()
-  stucked = false;
+  private _stuck = false;
 
   /**
    * Current count of menu items.
@@ -70,13 +114,13 @@ export class ZAppHeader {
   menuLength: number;
 
   /**
-   * Emitted when the `stucked` state of the header changes
+   * Emitted when the `stuck` state of the header changes
    */
   @Event()
   sticking: EventEmitter;
 
   private emitStickingEvent(): void {
-    this.sticking.emit(this.stucked);
+    this.sticking.emit(this._stuck);
   }
 
   private container?: HTMLDivElement;
@@ -87,7 +131,7 @@ export class ZAppHeader {
     SUPPORT_INTERSECTION_OBSERVER &&
     new IntersectionObserver(
       ([entry]) => {
-        this.stucked = !entry.isIntersecting;
+        this._stuck = !entry.isIntersecting;
       },
       {
         threshold: 0.5,
@@ -145,14 +189,14 @@ export class ZAppHeader {
   }
 
   private disableStuckMode(): void {
-    this.stucked = false;
+    this._stuck = false;
     if (this.observer) {
       this.observer.unobserve(this.container);
     }
   }
 
-  @Watch("stucked")
-  onStucked(): void {
+  @Watch("_stuck")
+  onStuck(): void {
     const scrollParent = this.scrollParent;
     if (!scrollParent) {
       return;
@@ -190,6 +234,7 @@ export class ZAppHeader {
               )}
             </slot>
           </div>
+
           <div class="heading-container">
             <div class="heading-title">
               {this.menuLength > 0 && (
@@ -203,10 +248,12 @@ export class ZAppHeader {
               )}
               <slot name="title"></slot>
             </div>
+
             <div class="heading-subtitle">
               <slot name="subtitle"></slot>
             </div>
           </div>
+
           <div class="menu-container">
             {!this.drawerOpen && this.flow !== "offcanvas" && (
               <slot
@@ -221,6 +268,7 @@ export class ZAppHeader {
             class="drawer-overlay"
             onClick={this.closeDrawer}
           ></div>
+
           <div class="drawer-panel">
             <button
               class="drawer-close"
@@ -229,6 +277,7 @@ export class ZAppHeader {
             >
               <z-icon name="close"></z-icon>
             </button>
+
             <div class="drawer-content">
               {this.drawerOpen && (
                 <slot
@@ -239,19 +288,21 @@ export class ZAppHeader {
             </div>
           </div>
         </div>
-        {this.stucked && (
-          <div class="heading-stucked">
-            {this.menuLength > 0 && (
-              <button
-                class="drawer-trigger"
-                aria-label="Apri menu"
-                onClick={this.openDrawer}
-              >
-                <z-icon name="burger-menu"></z-icon>
-              </button>
-            )}
-            <div class="heading-title">
-              <slot name="stucked-title">{this.title}</slot>
+        {this._stuck && (
+          <div class="heading-stuck">
+            <div class="heading-stuck-content">
+              {this.menuLength > 0 && (
+                <button
+                  class="drawer-trigger"
+                  aria-label="Apri menu"
+                  onClick={this.openDrawer}
+                >
+                  <z-icon name="burger-menu"></z-icon>
+                </button>
+              )}
+              <div class="heading-title">
+                <slot name="stucked-title">{this.title}</slot>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/navigation/z-app-header/readme.md
+++ b/src/components/navigation/z-app-header/readme.md
@@ -16,18 +16,18 @@
 
 ## Events
 
-| Event      | Description                                            | Type               |
-| ---------- | ------------------------------------------------------ | ------------------ |
-| `sticking` | Emitted when the `stucked` state of the header changes | `CustomEvent<any>` |
+| Event      | Description                                          | Type               |
+| ---------- | ---------------------------------------------------- | ------------------ |
+| `sticking` | Emitted when the `stuck` state of the header changes | `CustomEvent<any>` |
 
 
 ## Slots
 
-| Slot              | Description                                                                      |
-| ----------------- | -------------------------------------------------------------------------------- |
-| `"stucked-title"` | Title for the stucked header. By default it uses the text from the `title` slot. |
-| `"subtitle"`      |                                                                                  |
-| `"title"`         |                                                                                  |
+| Slot              | Description                                                                    |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `"stucked-title"` | Title for the stuck header. By default it uses the text from the `title` slot. |
+| `"subtitle"`      | Slot for the subtitle. It will not appear in stuck header.                     |
+| `"title"`         | Slot for the main title                                                        |
 
 
 ## Dependencies

--- a/src/components/navigation/z-app-header/styles.css
+++ b/src/components/navigation/z-app-header/styles.css
@@ -1,4 +1,5 @@
 :host {
+  --app-header-content-max-width: 100%;
   --app-header-height: auto;
   --app-header-typography-1-size: 24px;
   --app-header-typography-2-size: 28px;
@@ -38,7 +39,7 @@
   --app-header-typography-12-tracking: calc(-2.4 / 1em);
 
   /**
-   * Variable to set stucked header and drawer's top offset. Useful when something is absolutely positioned above the header.
+   * Variable to set stuck header and drawer's top offset. Useful when something is absolutely positioned above the header.
    */
   --app-header-top-offset: 48px;
   --app-header-drawer-trigger-size: calc(var(--space-unit) * 4);
@@ -46,13 +47,13 @@
   /* Variable to customize header background color. */
   --app-header-bg: var(--color-white);
 
-  /* Variable to customize stucked header background color. */
+  /* Variable to customize stuck header background color. */
   --app-header-stucked-bg: var(--color-white);
 
   /* Variable to customize text and icon color. */
   --app-header-text-color: var(--gray800);
 
-  /* Variable to customize stucked header's text and icon color. */
+  /* Variable to customize stuck header's text and icon color. */
   --app-header-stucked-text-color: var(--gray800);
 
   display: block;
@@ -68,13 +69,15 @@
   position: relative;
   display: flex;
   width: 100%;
+  max-width: var(--app-header-content-max-width);
   height: var(--app-header-height);
   flex-direction: column;
   flex-grow: 0;
   flex-shrink: 0;
   align-items: baseline;
   justify-content: flex-start;
-  padding: calc(var(--space-unit) * 2) var(--grid-mobile-margin);
+  padding: var(--grid-margin);
+  margin: 0 auto;
   background: var(--app-header-bg);
 }
 
@@ -93,25 +96,29 @@
   padding-left: calc(var(--app-header-drawer-trigger-size) + (var(--space-unit) * 1.5));
 }
 
-.heading-stucked {
+.heading-stuck {
   position: fixed;
   z-index: 20;
   top: var(--app-header-top-offset);
   left: 0;
-  display: flex;
   width: 100%;
   max-width: 100%;
-  flex-direction: row;
-  padding: var(--space-unit) var(--grid-mobile-margin);
-  animation: slide-stucked-heading-in 250ms ease-out;
+  animation: slide-stuck-heading-in 250ms ease-out;
   background: var(--app-header-stucked-bg);
   box-shadow: var(--shadow-2);
   color: var(--app-header-stucked-text-color);
 }
 
-.heading-stucked .heading-title,
-.heading-stucked .heading-title > *,
-.heading-stucked .heading-title ::slotted([slot="stucked-title"]) {
+.heading-stuck-content {
+  display: flex;
+  max-width: var(--app-header-content-max-width);
+  padding: var(--space-unit) var(--grid-margin);
+  margin: 0 auto;
+}
+
+.heading-stuck .heading-title,
+.heading-stuck .heading-title > *,
+.heading-stuck .heading-title ::slotted([slot="stucked-title"]) {
   display: block;
   overflow: hidden;
   line-height: 1.2;
@@ -119,7 +126,7 @@
   white-space: nowrap;
 }
 
-.heading-stucked .heading-title > *,
+.heading-stuck .heading-title > *,
 ::slotted([slot="title"]),
 ::slotted([slot="stucked-title"]) {
   margin: 0;
@@ -342,16 +349,7 @@
 }
 
 /* Tablet breakpoint */
-@media only screen and (min-width: 768px) {
-  .heading-panel {
-    padding: calc(var(--space-unit) * 3) var(--grid-tablet-margin);
-  }
-
-  .heading-stucked {
-    padding-right: var(--grid-tablet-margin);
-    padding-left: var(--grid-tablet-margin);
-  }
-
+@media (min-width: 768px) {
   :host(:not([flow="offcanvas"])) .heading-subtitle {
     padding-left: 0;
   }
@@ -379,19 +377,13 @@
 }
 
 /* Desktop breakpoint */
-@media only screen and (min-width: 1152px) {
-  .heading-panel,
-  .heading-stucked {
-    padding-right: var(--grid-desktop-margin);
-    padding-left: var(--grid-desktop-margin);
-  }
-
+@media (min-width: 1152px) {
   :host(:not([flow="stack"])) .heading-panel {
     flex-flow: row wrap;
   }
 
   ::slotted([slot="title"]) {
-    margin-right: var(--grid-desktop-gutter);
+    margin-right: var(--grid-gutter);
     font-size: var(--app-header-typography-7-size);
     letter-spacing: var(--app-header-typography-7-tracking);
   }
@@ -406,15 +398,8 @@
 }
 
 /* Wide breakpoint */
-@media only screen and (min-width: 1366px) {
-  .heading-panel,
-  .heading-stucked {
-    padding-right: var(--grid-wide-margin);
-    padding-left: var(--grid-wide-margin);
-  }
-
+@media (min-width: 1366px) {
   ::slotted([slot="title"]) {
-    margin-right: var(--grid-wide-gutter);
     font-size: var(--app-header-typography-9-size);
     letter-spacing: var(--app-header-typography-9-tracking);
   }
@@ -424,7 +409,7 @@
   }
 }
 
-@keyframes slide-stucked-heading-in {
+@keyframes slide-stuck-heading-in {
   0% {
     transform: translate3d(0, -100%, 0);
   }

--- a/src/components/z-cover-hero/index.stories.mdx
+++ b/src/components/z-cover-hero/index.stories.mdx
@@ -19,13 +19,11 @@ import "./index";
       "variant": {
         control: {type: "inline-radio"},
         options: Object.values(CoverHeroVariant),
-        defaultValue: CoverHeroVariant.OVERLAY,
       },
       "contentPosition": {
         if: {arg: "variant", eq: CoverHeroVariant.STACKED},
         control: {type: "inline-radio"},
         options: Object.values(CoverHeroContentPosition),
-        defaultValue: CoverHeroContentPosition.TOP,
       },
       "--cover-hero-text-color": {
         control: {type: "select"},
@@ -34,12 +32,16 @@ import "./index";
       "--cover-hero-overlay": {
         if: {arg: "variant", eq: CoverHeroVariant.OVERLAY},
         control: {type: "text"},
-        defaultValue: "linear-gradient(270deg, #00000000 0%, #000000e6 100%) 0% 0% no-repeat",
       },
       "--cover-hero-height": {
         control: {type: "text"},
-        defaultValue: "60vh",
       },
+    }}
+    args={{
+      "variant": CoverHeroVariant.OVERLAY,
+      "contentPosition": CoverHeroContentPosition.TOP,
+      "--cover-hero-overlay": "linear-gradient(270deg, #00000000 0%, #000000e6 100%) 0% 0% no-repeat",
+      "--cover-hero-height": "60vh",
     }}
   >
     {(args) => html`
@@ -83,11 +85,9 @@ import "./index";
     argTypes={{
       "--cover-hero-overlay": {
         control: {type: "text"},
-        defaultValue: "linear-gradient(270deg, #00000000 0%, #000000e6 100%) 0% 0% no-repeat",
       },
       "--cover-hero-height": {
         control: {type: "text"},
-        defaultValue: "60vh",
       },
     }}
   >


### PR DESCRIPTION
# Feat - z-app-header- handle max width

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

### Motivation and Context
This PR adds a CSS property to limit the width of the header's content, both in stacked and sticky mode. The content is centered.

Also some component's Storybook stories has been refactored to remove the deprecated `defaultValue` property.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)