### PR TITLE
fix: z-offcanvas - block page scroll for overlay variant

### DIFF
--- a/src/components/z-offcanvas/index.tsx
+++ b/src/components/z-offcanvas/index.tsx
@@ -46,6 +46,9 @@ export class ZOffcanvas {
     if (this.open) {
       this.hostElement.style.opacity = "0";
       this.hostElement.style.display = "flex";
+      if (this.variant === OffCanvasVariant.OVERLAY) {
+        document.body.style.overflowY = "hidden";
+      }
     } else if (this.variant === OffCanvasVariant.PUSHCONTENT) {
       this.hostElement.style.display = "none";
       document.body.style.overflowX = "hidden";
@@ -58,6 +61,7 @@ export class ZOffcanvas {
     } else if (this.variant === OffCanvasVariant.OVERLAY) {
       this.hostElement.style.display = "none";
       document.body.style.overflowX = "initial";
+      document.body.style.overflowY = "initial";
     }
   }
 

--- a/src/components/z-offcanvas/styles.css
+++ b/src/components/z-offcanvas/styles.css
@@ -128,6 +128,11 @@
   overflow-x: hidden;
 }
 
+:host([variant="overlay"]) > .canvas-container > .canvas-content {
+  padding: 0 calc(var(--space-unit) * 2) calc(var(--space-unit) * 2) calc(var(--space-unit) * 2);
+  margin: calc(var(--space-unit) * 2) calc(var(--space-unit) / 2) 0 0;
+}
+
 .canvas-container .canvas-content::-webkit-scrollbar {
   width: 10px;
   background: linear-gradient(to right, transparent 0 3px, var(--gray200) 3px 7px, transparent 7px 10px);


### PR DESCRIPTION
### Motivation and Context
While the pushcontent variant is meant to be displayed alongside the content of the page itself, the overlay variant is meant to cover it and only leave the offcanvas contents accessible. The ability to scroll the page's content causes a double scrollbar to appear on the right. this, while useful for the pushcontent variant, is completely unneeded in the overlay variant and is thus being excluded.

### Priority

- [ ] 1 - Highest
- [x] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
