### PR TITLE
fix: z-searchbar add escape characters to handle nested regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [6.8.1](https://github.com/ZanichelliEditore/design-system/compare/v6.8.0...v6.8.1) (2023-02-03)
+
+
+### Bug Fixes
+
+* z-searchbar add escape characters to handle nested regex ([4a61709](https://github.com/ZanichelliEditore/design-system/commit/4a6170949b9073d9d045c8a26f94cd9a82038576))
+
 ## [6.8.0](https://github.com/ZanichelliEditore/design-system/compare/v6.6.9...v6.8.0) (2023-01-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zanichelli/albe-web-components",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "description": "The Web Components implementation of Albe, the Zanichelli's design system.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/inputs/z-searchbar/index.tsx
+++ b/src/components/inputs/z-searchbar/index.tsx
@@ -355,7 +355,10 @@ export class ZSearchbar {
       return label;
     }
 
-    return label.replace(new RegExp(this.searchString, "gmi"), (found) => `<mark>${found}</mark>`);
+    return label.replace(
+      new RegExp(this.searchString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gmi"),
+      (found) => `<mark>${found}</mark>`
+    );
   }
 
   private renderItemCategory(groupItem: SearchbarGroup): HTMLSpanElement | null {


### PR DESCRIPTION
# Fix - z-searchbar - escaping regex

### Motivation and Context

This PR fixes the situation in which a string containing a "(", followed by at least two character, is typed in the searchbar as a search term avoiding :
`SyntaxError: Invalid regular expression`.

More generally this pull request solves all the situations in which a user enters a regex in the search field performing a string replacement operation on the searchString property by escaping any characters that have a special meaning in a regular expression.

To reproduce the error:

1. create a searchbar with these two properties:
    autocomplete="true" 
    autocomplete-min-chars="3"
2. provide an array of resultsItems with a label, for example:
`[
    {
      "label": "first item ed value"
    }
  ]`

2.  Type in the searchbar _(ed_ and

Expected exception:
`SyntaxError: Invalid regular expression: /(ed/:`



### Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)