### PR TITLE
Fix/z modal

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -780,6 +780,10 @@ export namespace Components {
          */
         "alertdialog"?: boolean;
         /**
+          * if true, the modal is closable (optional, default is true)
+         */
+        "closable"?: boolean;
+        /**
           * close modal
          */
         "close": () => Promise<void>;
@@ -3372,6 +3376,10 @@ declare namespace LocalJSX {
           * add role "alertdialog" to dialog (optional, default is false)
          */
         "alertdialog"?: boolean;
+        /**
+          * if true, the modal is closable (optional, default is true)
+         */
+        "closable"?: boolean;
         /**
           * aria-label for close button (optional)
          */

--- a/src/components/modal/z-modal/index.stories.mdx
+++ b/src/components/modal/z-modal/index.stories.mdx
@@ -24,6 +24,9 @@ import "./index.stories.css";
     alertdialog: {
       control: {type: "boolean"},
     },
+    closable: {
+      control: {type: "boolean"},
+    },
   }}
   args={{
     modalid: "my-modal",
@@ -31,6 +34,7 @@ import "./index.stories.css";
     modalsubtitle: "My modal subtitle",
     closeButtonLabel: "chiudi modale",
     alertdialog: false,
+    closable: true,
   }}
   decorators={[
     (Story) => html`
@@ -61,6 +65,7 @@ import "./index.stories.css";
         modalsubtitle=${args.modalsubtitle}
         close-button-label=${args.closeButtonLabel}
         alertdialog=${args.alertdialog}
+        closable=${args.closable}
       >
         <div slot="modalContent">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -85,6 +90,7 @@ import "./index.stories.css";
         modalsubtitle=${args.modalsubtitle}
         close-button-label=${args.closeButtonLabel}
         alertdialog=${args.alertdialog}
+        closable=${args.closable}
       >
         <div slot="modalContent">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
@@ -204,6 +210,7 @@ import "./index.stories.css";
         modalsubtitle=${args.modalsubtitle}
         close-button-label=${args.closeButtonLabel}
         alertdialog=${args.alertdialog}
+        closable=${args.closable}
       >
         <div slot="modalContent">
           <div>Contenuto dello <b>slot</b></div>

--- a/src/components/modal/z-modal/index.tsx
+++ b/src/components/modal/z-modal/index.tsx
@@ -34,6 +34,10 @@ export class ZModal {
   @Prop()
   alertdialog?: boolean = false;
 
+  /** if true, the modal is closable (optional, default is true) */
+  @Prop()
+  closable?: boolean = true;
+
   private dialog: HTMLDialogElement;
 
   @Element() host: HTMLZModalElement;
@@ -43,7 +47,9 @@ export class ZModal {
   modalClose: EventEmitter;
 
   private emitModalClose(): void {
-    this.modalClose.emit({modalid: this.modalid});
+    if (this.closable) {
+      this.modalClose.emit({modalid: this.modalid});
+    }
   }
 
   /** emitted on modal header click, returns modalid */
@@ -59,7 +65,9 @@ export class ZModal {
   modalBackgroundClick: EventEmitter;
 
   private emitBackgroundClick(): void {
-    this.modalBackgroundClick.emit({modalid: this.modalid});
+    if (this.closable) {
+      this.modalBackgroundClick.emit({modalid: this.modalid});
+    }
   }
 
   componentDidLoad(): void {
@@ -75,7 +83,9 @@ export class ZModal {
   /** close modal */
   @Method()
   async close(): Promise<void> {
-    this.dialog?.close();
+    if (this.closable) {
+      this.dialog?.close();
+    }
   }
 
   /**
@@ -114,6 +124,26 @@ export class ZModal {
     }
   }
 
+  private closeButtonSlot(): HTMLElement | void {
+    if (this.closable) {
+      return (
+        <slot name="modalCloseButton">
+          <button
+            aria-label={this.closeButtonLabel}
+            onClick={() => this.close()}
+          >
+            <z-icon name="multiply-circle-filled"></z-icon>
+          </button>
+        </slot>
+      );
+    }
+  }
+
+  private preventEscape(e: KeyboardEvent): void {
+    if (this.closable) return;
+    e.preventDefault();
+  }
+
   render(): HTMLZModalElement {
     return (
       <dialog
@@ -122,6 +152,8 @@ export class ZModal {
         role={this.alertdialog ? "alertdialog" : undefined}
         ref={(el) => (this.dialog = el as HTMLDialogElement)}
         onClose={() => this.emitModalClose()}
+        // @ts-ignore
+        onCancel={(e) => this.preventEscape(e)}
       >
         <div
           class="modal-container"
@@ -132,14 +164,7 @@ export class ZModal {
               {this.modaltitle && <h1 id="modal-title">{this.modaltitle}</h1>}
               {this.modalsubtitle && <h2 id="modal-subtitle">{this.modalsubtitle}</h2>}
             </div>
-            <slot name="modalCloseButton">
-              <button
-                aria-label={this.closeButtonLabel}
-                onClick={() => this.close()}
-              >
-                <z-icon name="multiply-circle-filled"></z-icon>
-              </button>
-            </slot>
+            {this.closeButtonSlot()}
           </header>
 
           <div

--- a/src/components/modal/z-modal/readme.md
+++ b/src/components/modal/z-modal/readme.md
@@ -18,6 +18,7 @@
 | Property           | Attribute            | Description                                                   | Type      | Default           |
 | ------------------ | -------------------- | ------------------------------------------------------------- | --------- | ----------------- |
 | `alertdialog`      | `alertdialog`        | add role "alertdialog" to dialog (optional, default is false) | `boolean` | `false`           |
+| `closable`         | `closable`           | if true, the modal is closable (optional, default is true)    | `boolean` | `true`            |
 | `closeButtonLabel` | `close-button-label` | aria-label for close button (optional)                        | `string`  | `"chiudi modale"` |
 | `modalid`          | `modalid`            | unique id                                                     | `string`  | `undefined`       |
 | `modalsubtitle`    | `modalsubtitle`      | subtitle (optional)                                           | `string`  | `undefined`       |


### PR DESCRIPTION
# Fix: add `closable` prop to `z-modal`

## The new `closable` prop gives the option to prevent the default behaviour of a `dialog` element when the user try to close it

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

### Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

### Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

### Abstract

<!--- Refers to Design System Abstract sheets or collections -->
<!--- Add Screenshots if appropriate -->

### Screenshots

### Note

<!-- Adds description, notes, any blocks -->

## <!-- Free field, not mandatory -->

## Component and Fix approval flow to Master branch

A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another from a member of the dst dev team other than the team representative.
