### PR TITLE
Fix - z-card - skip click event emission also for children of a slotted `action`

### DIFF
--- a/src/components/z-card/index.tsx
+++ b/src/components/z-card/index.tsx
@@ -51,7 +51,7 @@ export class ZCard {
   @Listen("click")
   onClick(ev: MouseEvent): void {
     // Do nothing for clicks on actions.
-    if ((ev.target as HTMLElement).getAttribute("slot") === "action") {
+    if ((ev.target as HTMLElement).closest("[slot=action]")) {
       return;
     }
 


### PR DESCRIPTION
## Motivation and Context
PR che fixa un bug della z-card su un check per decidere se emittare o meno l'evento click. Questo causava l'emit dell'evento `click` quando quest'ultimo veniva da un element figlio di uno slot `action`, mentre veniva correttamente skippato solo per gli element con l'attributo `slot=action`.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)