### PR TITLE
fix: focus on active tab by default

### DIFF
--- a/src/components/navigation/tabs/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/tabs/z-navigation-tabs/index.tsx
@@ -1,5 +1,10 @@
 import {Component, Prop, h, Listen, Element, State, Watch, Host} from "@stencil/core";
-import {NavigationTabsSize, NavigationTabsOrientation, NavigationTabsKeyboardEvents} from "../../../../beans";
+import {
+  NavigationTabsSize,
+  NavigationTabsOrientation,
+  NavigationTabsKeyboardEvents,
+  KeyboardCode,
+} from "../../../../beans";
 
 /**
  * Navigation tabs component.
@@ -165,12 +170,26 @@ export class ZNavigationTabs {
    */
   @Listen("keydown")
   private navigateThroughTabs(e: KeyboardEvent): void | boolean {
+    const children = Array.from(this.host.children);
+
+    if (e.key === KeyboardCode.TAB) {
+      children.forEach((child, i) => {
+        if (
+          child.hasAttribute("selected") &&
+          (e.target as HTMLButtonElement)?.offsetParent?.nodeName === "Z-NAVIGATION-TABS"
+        ) {
+          this.tabFocus = i;
+        }
+      });
+
+      return;
+    }
+
     if (!this.isArrowNavigation(e)) {
       return true;
     }
 
     e.preventDefault();
-    const children = Array.from(this.host.children);
     children[this.tabFocus].querySelector('[role="tab"]').setAttribute("tabindex", "-1");
     // Move forward
     if (
@@ -212,6 +231,7 @@ export class ZNavigationTabs {
     if (children.length > 0) {
       children.forEach((child, i) => {
         child.hasAttribute("aria-selected") && (this.tabFocus = i);
+        child.querySelector('[role="tab"]')?.setAttribute("tabindex", "-1");
       });
       children[this.tabFocus].querySelector('[role="tab"]')?.setAttribute("tabindex", "0");
     }


### PR DESCRIPTION
# Focus on active tab by default

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
PR per correggere un comportamento della  navigazione da tastiera sulla z-navigation-tabs.
Con questo fix all'atterraggio sulla z-navigation-tabs da tastiera il focus viene sempre impostato sulla tab attiva (se esiste)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
