### PR TITLE
Fix/z input safari autocomplete

### DIFF
--- a/src/components/inputs/z-input/index.tsx
+++ b/src/components/inputs/z-input/index.tsx
@@ -335,14 +335,15 @@ export class ZInput {
   }
 
   private renderResetIcon(): HTMLButtonElement {
+    let hidden = false;
     if (!this.hasclearicon || !this.value || this.disabled || this.readonly || this.type == InputType.NUMBER) {
-      return;
+      hidden = true;
     }
 
     return (
       <button
         type="button"
-        class="icon-button reset-icon"
+        class={`icon-button reset-icon ${hidden ? "hidden" : ""}`}
         aria-label="cancella il contenuto dell'input"
         onClick={() => this.emitInputChange("")}
       >

--- a/src/components/inputs/z-input/styles-text.css
+++ b/src/components/inputs/z-input/styles-text.css
@@ -52,6 +52,10 @@
   margin-left: calc(var(--space-unit) * 0.5);
 }
 
+.text-wrapper .icons-wrapper > button.icon-button.hidden {
+  display: none;
+}
+
 .text-wrapper .icons-wrapper > button.icon-button.reset-icon,
 .text-wrapper .icons-wrapper > button.icon-button.toggle-password-icon {
   cursor: pointer;

--- a/src/components/inputs/z-input/test-text.spec.ts
+++ b/src/components/inputs/z-input/test-text.spec.ts
@@ -16,7 +16,11 @@ describe("Suite test ZInput - text", () => {
           <div class="text-wrapper">
             <div>
               <input id="id" class="has-clear-icon" type="text" />
-              <span class="icons-wrapper"></span>
+              <span class="icons-wrapper">
+               <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                <z-icon class="big" name="multiply"></z-icon>
+               </button>
+             </span>
             </div>
           </div>
       </z-input>
@@ -33,7 +37,11 @@ describe("Suite test ZInput - text", () => {
           <div class="text-wrapper">
             <div>
               <input id="id" class="has-clear-icon" type="text" />
-              <span class="icons-wrapper"></span>
+              <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                  <z-icon class="small" name="multiply"></z-icon>
+                </button>
+              </span>
             </div>
           </div>
       </z-input>
@@ -50,7 +58,11 @@ describe("Suite test ZInput - text", () => {
           <div class="text-wrapper">
             <div>
               <input id="id" class="has-clear-icon" type="text" />
-              <span class="icons-wrapper"></span>
+              <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                  <z-icon class="x-small" name="multiply"></z-icon>
+                </button>
+              </span>
             </div>
           </div>
       </z-input>
@@ -111,7 +123,11 @@ describe("Suite test ZInput - text", () => {
             <label class="body-5-sb input-label" htmlfor="test" id="test_label">label</label>
             <div>
               <input disabled class="filled has-clear-icon" type='text' id='test' placeholder='placeholder' value='value' />
-              <span class="icons-wrapper"></span>
+              <span class="icons-wrapper">
+               <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                 <z-icon class="big" name="multiply"></z-icon>
+               </button>
+              </span>
             </div>
           </div>
       </z-input>
@@ -129,7 +145,11 @@ describe("Suite test ZInput - text", () => {
             <label class="body-5-sb input-label" htmlfor="test" id="test_label">label</label>
             <div>
               <input readonly class="filled has-clear-icon" type='text' id='test' placeholder='placeholder' value='value' />
-              <span class="icons-wrapper"></span>
+              <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                   <z-icon class="big" name="multiply"></z-icon>
+                </button>
+              </span>
             </div>
           </div>
       </z-input>
@@ -205,6 +225,9 @@ describe("Suite test ZInput - text", () => {
             <div>
               <input id="id" class="has-clear-icon has-icon" type="password" />
               <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                  <z-icon class="big" name="multiply"></z-icon>
+                </button>
                 <button type="button" class="icon-button toggle-password-icon" aria-label="mostra password">
                   <z-icon class="big" name="view-filled"></z-icon>
                 </button>
@@ -228,6 +251,9 @@ describe("Suite test ZInput - text", () => {
             <div>
               <input id="id" class="has-clear-icon has-icon" type="text" />
               <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                  <z-icon class="big" name="multiply"></z-icon>
+                </button>
                 <button type="button" class="icon-button toggle-password-icon" aria-label="nascondi password">
                   <z-icon class="big" name="view-off-filled"></z-icon>
                 </button>
@@ -274,7 +300,11 @@ describe("Suite test ZInput - text", () => {
           <div class="text-wrapper">
             <div>
               <input id="id" class="filled" type="text" value="value" />
-              <span class="icons-wrapper"></span>
+              <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                  <z-icon class="big" name="multiply"></z-icon>
+                </button>
+              </span>
             </div>
             <z-input-message class="big"></z-input-message>
           </div>
@@ -295,6 +325,9 @@ describe("Suite test ZInput - text", () => {
             <div>
               <input id="id" class="has-icon has-clear-icon" type="text" />
               <span class="icons-wrapper">
+                <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                  <z-icon class="big" name="multiply"></z-icon>
+                </button>
                 <button type="button" class="icon-button input-icon" tabindex="-1">
                   <z-icon class="big" name="pdf"></z-icon>
                 </button>
@@ -316,7 +349,11 @@ describe("Suite test ZInput - text", () => {
         <div class="text-wrapper">
           <div>
             <input id="test" max="10" min="1" step="2" type="number">
-            <span class="icons-wrapper"></span>
+            <span class="icons-wrapper">
+              <button aria-label="cancella il contenuto dell'input" class="hidden icon-button reset-icon" type="button">
+                <z-icon class="big" name="multiply"></z-icon>
+              </button>
+            </span>
           </div>
         </div>
       </z-input>


### PR DESCRIPTION
# Z-input fix safari autocomplete

## Motivation and Context
On Safari when a button is added to the DOM, password autocomplete moves the focus to previous text input. In order to avoid this problem, the button must be already rendered in the DOM.

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)