### PR TITLE
Fix multiple li in z-carousel

### DIFF
--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -199,7 +199,7 @@ export class ZCarousel {
       return;
     }
 
-    this.items = Array.from(this.itemsContainer.querySelectorAll("li"));
+    this.items = Array.from(this.itemsContainer.querySelectorAll(":scope > li"));
 
     if (this.single) {
       this.setIntersectionObserver();


### PR DESCRIPTION
# Bug with li in there direct of z-carousel container

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->
When the direct li element of the container has a list of other li elements, the component also counts them to add the dots

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
