### PR TITLE
fix: empty input value before validation when clicking content deleti…

### DIFF
--- a/src/components/inputs/z-input/index.tsx
+++ b/src/components/inputs/z-input/index.tsx
@@ -114,6 +114,8 @@ export class ZInput {
 
   private typingtimeout = 300;
 
+  private inputRef: HTMLInputElement;
+
   @Listen("inputCheck", {target: "document"})
   inputCheckListener(e: CustomEvent): void {
     const data = e.detail;
@@ -278,6 +280,7 @@ export class ZInput {
           <input
             type={type === InputType.PASSWORD && !this.passwordHidden ? InputType.TEXT : type}
             {...attr}
+            ref={(el) => (this.inputRef = el)}
           />
           {this.renderIcons()}
         </div>
@@ -345,7 +348,10 @@ export class ZInput {
         type="button"
         class={`icon-button reset-icon ${hidden ? "hidden" : ""}`}
         aria-label="cancella il contenuto dell'input"
-        onClick={() => this.emitInputChange("")}
+        onClick={() => {
+          this.inputRef.value = "";
+          this.emitInputChange("");
+        }}
       >
         <z-icon
           name="multiply"


### PR DESCRIPTION
# fix - z-input - validation not triggered upon clicking x icon

## Motivation and Context
A bug arised where emptying an input by clicking the x icon would create a discrepancy
between the values of the input validation and the inputChanged event contents.
This was due to the validation getting triggered before the actual input value was emptied.

## Priority
- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)