### PR TITLE
Whitespace on breadcrumb mobile

### DIFF
--- a/src/components/z-breadcrumb/index.tsx
+++ b/src/components/z-breadcrumb/index.tsx
@@ -292,9 +292,7 @@ export class ZBreadcrumb {
               this.popoverEllipsisOpen = false;
             }
           }}
-          innerHTML={
-            mobile ? `<z-icon fill="color-link-primary" name="chevron-left"></z-icon> ${item.text}` : item.text
-          }
+          innerHTML={mobile ? `<z-icon fill="color-link-primary" name="chevron-left"></z-icon>${item.text}` : item.text}
         />
       </li>
     );


### PR DESCRIPTION
Very simple PR that just removes an unwanted whitespace on breadcrumb template only on mobile viewport.