### PR TITLE
chore/zSelect a11y improvements

### DIFF
--- a/src/components/inputs/z-select/index.spec.ts
+++ b/src/components/inputs/z-select/index.spec.ts
@@ -144,7 +144,6 @@ describe("Suite test ZSelect", () => {
                   role="listbox"
                   tabindex="0"
                   id="checkid_list"
-                  aria-activedescendant="checkid_1"
                   class="filled"
                   size="medium"
                 >
@@ -481,7 +480,7 @@ describe("Suite test ZSelect", () => {
             <z-input aria-label="" autocomplete="off" class="active-select" hasclearicon="" size="big" htmlid="checkid_select_input" icon="caret-up" id="checkid_input" label="default" placeholder="select here"></z-input>
             <div class="open" tabindex="-1" aria-hidden="false">
               <div class="ul-scroll-wrapper" tabindex="-1">
-                <z-list aria-activedescendant="checkid_0" class="filled" id="checkid_list" role="listbox" size="medium" tabindex="0">
+                <z-list class="filled" id="checkid_list" role="listbox" size="medium" tabindex="0">
                   <z-list-element aria-selected="false" class="reset-item reset-item-margin" clickable="" dividertype="element" size="medium" id="checkid_0" role="option" tabindex="0">
                     <div class="reset-item-content">
                       <z-icon name="multiply-circled"></z-icon>

--- a/src/components/inputs/z-select/index.tsx
+++ b/src/components/inputs/z-select/index.tsx
@@ -86,9 +86,6 @@ export class ZSelect {
   selectedItem: null | SelectItem = null;
 
   @State()
-  selectedItemIndex: null | number = null;
-
-  @State()
   searchString: null | string;
 
   private itemsList: SelectItem[] = [];
@@ -103,11 +100,6 @@ export class ZSelect {
   watchItems(): void {
     this.itemsList = this.getInitialItemsArray();
     this.selectedItem = this.itemsList.find((item: SelectItem) => item.selected);
-  }
-
-  @Watch("selectedItem")
-  watchSelectedItem(): void {
-    this.selectedItemIndex = this.itemsList.indexOf(this.selectedItem);
   }
 
   /** get the input selected options */
@@ -408,7 +400,6 @@ export class ZSelect {
             role="listbox"
             tabindex={this.disabled || this.readonly || !this.isOpen ? -1 : 0}
             id={`${this.htmlid}_list`}
-            aria-activedescendant={this.selectedItem ? `${this.htmlid}_${this.selectedItemIndex}` : undefined}
             aria-multiselectable={false}
             size={this.listSizeType()}
             class={{


### PR DESCRIPTION
# ZSelect:  remove aria-activedescendant attribute

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
