### PR TITLE
Fix/z navigation tabs a11y

### DIFF
--- a/src/components/navigation/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/z-navigation-tabs/index.tsx
@@ -215,9 +215,11 @@ export class ZNavigationTabs {
 
     if (event.key === KeyboardCode.TAB) {
       this.focusedTab = this.selectedTab || 0;
+      const ariaSelected = !this.selectedTab ? 0 : this.selectedTab;
+
       this.tabs[this.focusedTab].focus({preventScroll: true});
       this.tabs.forEach((tab, index) => {
-        tab.tabIndex = index === this.selectedTab ? 0 : -1;
+        tab.tabIndex = index === ariaSelected ? 0 : -1;
       });
 
       return;
@@ -272,11 +274,15 @@ export class ZNavigationTabs {
       tab.tabIndex = -1;
     });
 
+    let activeTab = 0;
+
     // pre-selected tab (a11y purpose)
     const preselectedTab = this.tabs.findIndex((tab) => tab.ariaSelected === "true");
-    const activeTab = preselectedTab > 0 ? preselectedTab : 0;
+    if (preselectedTab > 0) {
+      activeTab = preselectedTab;
+      this.selectedTab = this.focusedTab = activeTab;
+    }
 
-    this.selectedTab = this.focusedTab = activeTab;
     this.tabs[activeTab].tabIndex = 0;
 
     if (this.selectedTab !== undefined) {

--- a/src/components/navigation/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/z-navigation-tabs/index.tsx
@@ -1,5 +1,10 @@
 import {Component, Prop, h, Listen, Element, State, Watch, Host, Event, EventEmitter} from "@stencil/core";
-import {NavigationTabsSize, NavigationTabsOrientation, NavigationTabsKeyboardEvents} from "../../../beans";
+import {
+  NavigationTabsSize,
+  NavigationTabsOrientation,
+  NavigationTabsKeyboardEvents,
+  KeyboardCode,
+} from "../../../beans";
 
 /**
  * Navigation tabs component.
@@ -206,6 +211,16 @@ export class ZNavigationTabs {
   private navigateThroughTabs(event: KeyboardEvent): void | boolean {
     if (!this.tabs.some((tab) => tab.contains(event.target as HTMLElement))) {
       return true;
+    }
+
+    if (event.key === KeyboardCode.TAB) {
+      this.focusedTab = this.selectedTab || 0;
+      this.tabs[this.focusedTab].focus({preventScroll: true});
+      this.tabs.forEach((tab, index) => {
+        tab.tabIndex = index === this.selectedTab ? 0 : -1;
+      });
+
+      return;
     }
 
     if (!this.isArrowNavigation(event)) {

--- a/src/components/navigation/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/z-navigation-tabs/index.tsx
@@ -1,10 +1,5 @@
 import {Component, Prop, h, Listen, Element, State, Watch, Host, Event, EventEmitter} from "@stencil/core";
-import {
-  NavigationTabsSize,
-  NavigationTabsOrientation,
-  NavigationTabsKeyboardEvents,
-  KeyboardCode,
-} from "../../../beans";
+import {NavigationTabsSize, NavigationTabsOrientation, NavigationTabsKeyboardEvents} from "../../../beans";
 
 /**
  * Navigation tabs component.
@@ -213,13 +208,6 @@ export class ZNavigationTabs {
       return true;
     }
 
-    if (event.key === KeyboardCode.TAB) {
-      this.focusedTab = this.selectedTab || 0;
-      this.tabs[this.focusedTab].focus({preventScroll: true});
-
-      return;
-    }
-
     if (!this.isArrowNavigation(event)) {
       return true;
     }
@@ -268,7 +256,13 @@ export class ZNavigationTabs {
       tab.setAttribute("role", "tab");
       tab.tabIndex = -1;
     });
-    this.tabs[0].tabIndex = 0;
+
+    // pre-selected tab (a11y purpose)
+    const preselectedTab = this.tabs.findIndex((tab) => tab.ariaSelected === "true");
+    const activeTab = preselectedTab > 0 ? preselectedTab : 0;
+
+    this.selectedTab = this.focusedTab = activeTab;
+    this.tabs[activeTab].tabIndex = 0;
 
     if (this.selectedTab !== undefined) {
       this.onTabSelected();

--- a/src/components/navigation/z-navigation-tabs/styles.css
+++ b/src/components/navigation/z-navigation-tabs/styles.css
@@ -20,7 +20,7 @@ z-navigation-tabs > nav::-webkit-scrollbar {
   display: none;
 }
 
-.navigation-button {
+z-navigation-tabs .navigation-button {
   position: absolute;
   z-index: 1;
   display: flex;


### PR DESCRIPTION
# Fix - ZNavigationTabs - a11y navigation error on preselected tab 

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
Fix z-navigation-tabs a11y navigation when a tab is already selected. 
Additional fix to `.navigation-button` conflicting with zPagination button class.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
