### PR TITLE
Fix - z-navigation-tabs - component disappearing on resize

### DIFF
--- a/src/components/navigation/z-navigation-tabs/index.tsx
+++ b/src/components/navigation/z-navigation-tabs/index.tsx
@@ -286,7 +286,8 @@ export class ZNavigationTabs {
 
     const preselectedTab = this.selectedTab ?? this.tabs.findIndex((tab) => tab.ariaSelected === "true");
     if (preselectedTab !== -1) {
-      this.selectedTab = this.focusedTab = preselectedTab;
+      this.selectedTab = preselectedTab;
+      this.tabs[preselectedTab].tabIndex = 0;
       this.onTabSelected();
     } else {
       this.tabs[0].tabIndex = 0;

--- a/src/themes/index.stories.css
+++ b/src/themes/index.stories.css
@@ -10,10 +10,9 @@
 }
 
 .themes-story .theme-list {
-  display: flex;
-  width: 400px;
-  flex-direction: column;
   padding: 0;
+  margin: 0;
+  columns: 2;
 }
 
 .themes-story .theme-list > li {
@@ -22,6 +21,7 @@
   justify-content: space-between;
   padding: var(--space-unit) 0;
   border-bottom: 1px solid var(--gray200);
+  font-weight: var(--font-sb);
 }
 
 .themes-story .theme-list > li > code {


### PR DESCRIPTION
# Fix - z-navigation-tabs - component disappearing on resize

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
This PR fixes a bug that caused the component to disappear when resizing the window. The bug was caused by Stencil that, for some reason, wasn't being able to place the slotted elements in their original place after a conditionally rendered element (in this case the first navigation button) and rendered an empty `<nav>` element instead.
Using the `hidden` attribute on the buttons instead of the conditional render, fixed the bug.

This PR also fixes the implementation of the focus and keyboard navigation: when leaving the tabs after a keyboard navigation having a selected tab and then focusing again the tabs, the focus was given to the last focused tab instead of the selected one, as indicated by the [Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)