### PR TITLE
Bugfix/z input readonly status

### DIFF
--- a/src/components/inputs/z-input/styles-general.css
+++ b/src/components/inputs/z-input/styles-general.css
@@ -44,7 +44,7 @@ textarea,
 
 /* FOCUS */
 :host:not(.active-select) input:focus:focus-visible,
-.textarea-wrapper:focus-within {
+:host([readonly="false"]) .textarea-wrapper:focus-within {
   box-shadow: var(--shadow-focus-primary);
 }
 

--- a/src/components/inputs/z-input/styles-general.css
+++ b/src/components/inputs/z-input/styles-general.css
@@ -90,7 +90,7 @@ textarea:focus:focus-visible {
 }
 
 /* HOVER */
-input:hover,
+input:not([readonly]):hover,
 .textarea-wrapper:hover {
   outline: var(--border-size-medium) solid var(--color-surface04);
   outline-offset: -2px;


### PR DESCRIPTION
# Z-Input - readonly status

## Motivation and Context

During testing on the Z-Exercises platform, we noticed a graphical issue that occurred in the scenario of a Z-input component associated with a label and in readonly mode.
In this configuration, when hovering over the label, the Z-input component assumed a graphical state that made it appear "active". Also, the textarea field was mistakenly selectable while in readonly mode.

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
