### PR TITLE
Fix - ZCarousel - nav buttons' visibility

### DIFF
--- a/src/components/z-carousel/index.stories.css
+++ b/src/components/z-carousel/index.stories.css
@@ -32,40 +32,44 @@
   height: 265px;
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 1) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-9) .carousel-box {
   background: var(--avatar-C01);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 2) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-8) .carousel-box {
   background: var(--avatar-C07);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 3) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-7) .carousel-box {
   background: var(--avatar-C10);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 4) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-6) .carousel-box {
   background: var(--avatar-C15);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 5) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-5) .carousel-box {
   background: var(--avatar-C03);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 6) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-4) .carousel-box {
   background: var(--avatar-C06);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 7) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-3) .carousel-box {
   background: var(--avatar-C07);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 8) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-2) .carousel-box {
   background: var(--avatar-C11);
 }
 
-.z-carousel-story-container z-carousel li:nth-child(n + 9) .carousel-box {
+.z-carousel-story-container z-carousel li:nth-child(10n-1) .carousel-box {
   background: var(--avatar-C17);
+}
+
+.z-carousel-story-container z-carousel li:nth-child(10n) .carousel-box {
+  background: var(--avatar-C14);
 }
 
 .z-carousel-story-container z-carousel .carousel-box-loading {

--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -180,19 +180,14 @@ export class ZCarousel {
   }
 
   /**
-   * Check if navigation buttons can be enabled and set the relative local states.
+   * Check if navigation buttons can be enabled and set the related local states.
    */
   private checkNavigationValidity(): void {
-    if (this.infinite) {
-      this.canNavigateNext = true;
-      this.canNavigatePrev = true;
+    if (this.single) {
+      this.canNavigatePrev = this.current > 0;
+      this.canNavigateNext = this.current < this.items.length - 1;
 
       return;
-    }
-
-    if (this.single) {
-      this.canNavigatePrev = this.current > 1;
-      this.canNavigateNext = this.current < this.items.length - 1;
     }
 
     this.canNavigatePrev = this.itemsContainer.scrollLeft > 0;
@@ -289,7 +284,7 @@ export class ZCarousel {
               data-direction="prev"
               icon="arrow-left"
               onClick={this.onPrev.bind(this)}
-              disabled={!this.canNavigatePrev}
+              disabled={!this.infinite && !this.canNavigatePrev}
               hidden={this.arrowsPosition !== CarouselArrowsPosition.OVER || !this.canNavigate}
               ariaLabel={this.single ? "Mostra l'elemento precedente" : "Mostra gli elementi precedenti"}
             />
@@ -307,7 +302,7 @@ export class ZCarousel {
               data-direction="next"
               icon="arrow-right"
               onClick={this.onNext.bind(this)}
-              disabled={!this.canNavigateNext}
+              disabled={!this.infinite && !this.canNavigateNext}
               hidden={this.arrowsPosition !== CarouselArrowsPosition.OVER || !this.canNavigate}
               ariaLabel={this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"}
             />
@@ -322,7 +317,7 @@ export class ZCarousel {
                 variant={ButtonVariant.TERTIARY}
                 icon="arrow-left"
                 onClick={this.onPrev.bind(this)}
-                disabled={!this.canNavigatePrev}
+                disabled={!this.infinite && !this.canNavigatePrev}
                 ariaLabel={this.single ? "Mostra l'elemento precedente" : "Mostra gli elementi precedenti"}
               />
             )}
@@ -353,7 +348,7 @@ export class ZCarousel {
                 variant={ButtonVariant.TERTIARY}
                 icon="arrow-right"
                 onClick={this.onNext.bind(this)}
-                disabled={!this.canNavigateNext}
+                disabled={!this.infinite && !this.canNavigateNext}
                 ariaLabel={this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"}
               />
             )}


### PR DESCRIPTION
# Fix - ZCarousel - nav buttons' visibility

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
This PR fixes the visibility of navigation buttons for the `infinite` mode.
Now the validity check doesn't assume the navigation buttons should be always visible when `infinite` is set to `true`, instead it follows the conditions set for `single` and default mode, then the render function decides whether to show or not the buttons and takes into account the `infinite` prop to set the `disabled` attribute.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [x] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
