### PR TITLE
Refactor - z-info-reveal - restyling

### DIFF
--- a/src/components/z-info-reveal/index.stories.css
+++ b/src/components/z-info-reveal/index.stories.css
@@ -1,0 +1,14 @@
+.z-info-reveal-story-wrapper {
+  display: flex;
+  width: 600px;
+  height: 600px;
+  align-items: center;
+  justify-content: center;
+  column-gap: var(--space-unit);
+}
+
+@media (max-width: 767px) {
+  .z-info-reveal-story-wrapper {
+    width: 100%;
+  }
+}

--- a/src/components/z-info-reveal/index.stories.mdx
+++ b/src/components/z-info-reveal/index.stories.mdx
@@ -1,19 +1,24 @@
 import {Meta, Canvas, Story, ArgsTable} from "@storybook/addon-docs";
-import {styleMap} from "lit-html/directives/style-map.js";
-import {InfoRevealPosition} from "../../beans";
 import {html} from "lit-html";
+import {ControlSize, InfoRevealPosition} from "../../beans";
+import {ICONS} from "../icons/icons";
 import "./index";
+import "./index.stories.css";
 
 <Meta
   title="ZInfoReveal"
   component="z-info-reveal"
   argTypes={{
-    icon: {control: {type: "text"}},
+    icon: {control: {type: "select"}, options: Object.keys(ICONS).sort()},
     label: {control: {type: "text"}},
+    size: {control: {type: "inline-radio"}, options: Object.values(ControlSize)},
     position: {
       options: Object.values(InfoRevealPosition),
       control: {type: "inline-radio"},
     },
+  }}
+  parameters={{
+    layout: "centered",
   }}
 />
 
@@ -25,40 +30,23 @@ import "./index";
     args={{
       label: "",
       icon: "informationsource",
+      size: ControlSize.BIG,
       position: InfoRevealPosition.TOP_RIGHT,
     }}
   >
     {(args) => html`
-      <style>
-        z-info-reveal {
-          margin-top: 10vw;
-          margin-left: 10vw;
-        }
-      </style>
-      <div style="position: absolute; top: 0; left: 0;">
+      <div class="z-info-reveal-story-wrapper">
+        <z-button .size=${args.size}>Button</z-button>
         <z-info-reveal
-          .position=${args.position}
           .label=${args.label}
           .icon=${args.icon}
-          style=${styleMap({
-            "--z-info-reveal-theme--surface": `var(${args["--z-info-reveal-theme--surface"]})`,
-            "--z-info-reveal-theme--text": `var(${args["--z-info-reveal-theme--text"]})`,
-          })}
+          .size=${args.size}
+          .position=${args.position}
         >
-          <span style="font-style: italic;">Prima frase.</span>
-          <span style="font-style: italic;"
-            >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
-            Archimede, qui dum in pulvere quaedam describit attentius, ne patriam quidem captam esse senserit?</span
-          >
-          <span>
-            <a
-              style="color: inherit;"
-              href="https://google.com"
-              target="_blank"
-            >
-              terza frase che è un link
-            </a>
-          </span>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
+            Archimede, qui dum in pulvere quaedam describit attentius, ne patriam quidem captam esse senserit?
+          </div>
         </z-info-reveal>
       </div>
     `}

--- a/src/components/z-info-reveal/index.tsx
+++ b/src/components/z-info-reveal/index.tsx
@@ -1,80 +1,57 @@
-import {Component, h, Prop, State, Watch, Element, Host} from "@stencil/core";
-import {InfoRevealPosition} from "../../beans";
+import {Component, h, Prop, State, Host} from "@stencil/core";
+import {ControlSize, InfoRevealPosition} from "../../beans";
 
+/**
+ * Info reveal component.
+ *
+ * @slot - content of the info panel.
+ */
 @Component({
   tag: "z-info-reveal",
   styleUrl: "styles.css",
   shadow: true,
 })
-
-/**
- * Info reveal component.
- *
- * @slot - info to display in the info box. If more than one element has been slotted,
- * by clicking on the panel it switches to the next info element.
- * @cssprop --z-info-reveal-theme--surface - background color of the info reveal panel.
- * @cssprop --z-info-reveal-theme--text - foreground color of the info reveal panel.
- * @cssprop --z-info-reveal-shadow - shadow of the info reveal panel.
- * @cssprop --z-info-reveal-max-width - max width of the info reveal panel.
- */
 export class ZInfoReveal {
-  @Element() el: HTMLZInfoRevealElement;
-
-  /** Name of the icon for the open button */
+  /** Name of the icon for the trigger button */
   @Prop()
   icon? = "informationsource";
 
-  /** Info reveal's position */
+  /**
+   * The position of the z-info-reveal in the page. This helps to correctly place the info panel.
+   * The panel will grow in the opposite direction of the position.
+   * For example, with the default position `BOTTOM_RIGHT`, the panel will grow vertically upwards and horizontally to the left.
+   */
   @Prop({reflect: true})
   position?: InfoRevealPosition = InfoRevealPosition.BOTTOM_RIGHT;
 
-  /** Text that appears on closed panel next to the open button. */
+  /** Label of the trigger button. */
   @Prop()
   label?: string;
+
+  /** Aria label of the trigger button. It will be only used when `label` prop is empty. */
+  @Prop()
+  ariaLabel = "Apri pannello informazioni";
+
+  /** Size of the trigger button */
+  @Prop({reflect: true})
+  size?: ControlSize = ControlSize.BIG;
 
   /** Whether the info panel is open. */
   @State()
   open = false;
 
-  /** Current index for the info queue. */
-  @State()
-  currentIndex: number = null;
-
-  @Watch("currentIndex")
-  watchItems(): void {
-    Array.from(this.el.children).forEach((child, index) => {
-      if (this.currentIndex === index) {
-        child.setAttribute("data-current", "");
-      } else {
-        child.removeAttribute("data-current");
-      }
-    });
+  /**
+   * Toggle the open state of the info panel.
+   */
+  private togglePanel(): void {
+    this.open = !this.open;
   }
 
   /**
-   * Open the info box.
+   * Close the info panel.
    */
-  private openInfoBox(): void {
-    this.currentIndex = 0;
-    this.open = true;
-  }
-
-  /**
-   * Close the info box.
-   */
-  private closeInfoBox(): void {
+  private closePanel(): void {
     this.open = false;
-  }
-
-  /**
-   * Navigate slotted info.
-   * It closes the info box after the last info has been navigated.
-   */
-  private next(): void {
-    this.currentIndex = this.currentIndex + 1;
-    if (this.currentIndex === this.el.children.length) {
-      this.closeInfoBox();
-    }
   }
 
   render(): HTMLZInfoRevealElement {
@@ -82,23 +59,26 @@ export class ZInfoReveal {
       <Host open={this.open}>
         <button
           class="z-info-reveal-trigger"
-          onClick={this.openInfoBox.bind(this)}
+          onClick={this.togglePanel.bind(this)}
+          aria-label={!this.label ? this.ariaLabel : undefined}
+          aria-expanded={this.open ? "true" : "false"}
+          aria-controls="z-info-reveal-panel"
         >
+          {this.icon && <z-icon name={this.icon} />}
           {this.label && <span class="z-info-reveal-label">{this.label}</span>}
-          <z-icon name={this.icon}></z-icon>
         </button>
         {this.open && (
           <div
-            class="info-box"
-            onClick={this.next.bind(this)}
-            tabIndex={0}
+            class="z-info-reveal-panel"
+            id="z-info-reveal-panel"
           >
             <slot></slot>
             <button
               class="z-info-reveal-close"
-              onClick={this.closeInfoBox.bind(this)}
+              onClick={this.closePanel.bind(this)}
+              aria-label="Chiudi pannello informazioni"
             >
-              <z-icon name="close"></z-icon>
+              <z-icon name="multiply" />
             </button>
           </div>
         )}

--- a/src/components/z-info-reveal/index.tsx
+++ b/src/components/z-info-reveal/index.tsx
@@ -1,10 +1,11 @@
-import {Component, h, Prop, State, Host} from "@stencil/core";
+import {Component, h, Prop, State, Host, Listen, Watch, Element} from "@stencil/core";
 import {ControlSize, InfoRevealPosition} from "../../beans";
 
 /**
  * Info reveal component.
  *
  * @slot - content of the info panel.
+ * @cssprop --z-info-reveal-panel-width - Width of the info panel.
  */
 @Component({
   tag: "z-info-reveal",
@@ -40,6 +41,31 @@ export class ZInfoReveal {
   @State()
   open = false;
 
+  @Element() host: HTMLZInfoRevealElement;
+
+  private panel: HTMLDivElement;
+
+  /**
+   * Adjust the position of the info panel to prevent exiting the viewport.
+   */
+  @Watch("position")
+  @Watch("open")
+  @Listen("resize", {target: "window", passive: true})
+  adjustPanelPosition(): void {
+    if (!this.open || !this.panel) {
+      return;
+    }
+
+    const rect = this.host.getBoundingClientRect();
+    const gridMargin = parseInt(getComputedStyle(document.documentElement).getPropertyValue("--grid-margin"), 10);
+    const pageWidth = document.documentElement.offsetWidth;
+    // Available space for the info panel to grow towards the edge of the page, based on the `position` prop.
+    const availableSpace = Math.round(
+      (this.position.includes("left") ? pageWidth - rect.left : rect.right) - gridMargin
+    );
+    this.panel.style.maxWidth = `${availableSpace}px`;
+  }
+
   /**
    * Toggle the open state of the info panel.
    */
@@ -54,11 +80,19 @@ export class ZInfoReveal {
     this.open = false;
   }
 
+  @Listen("keydown", {target: "window", capture: true})
+  handleEscapeKey(event: KeyboardEvent): void {
+    if (event.key === "Escape" && this.open) {
+      this.closePanel();
+    }
+  }
+
   render(): HTMLZInfoRevealElement {
     return (
       <Host open={this.open}>
         <button
           class="z-info-reveal-trigger"
+          type="button"
           onClick={this.togglePanel.bind(this)}
           aria-label={!this.label ? this.ariaLabel : undefined}
           aria-expanded={this.open ? "true" : "false"}
@@ -67,21 +101,22 @@ export class ZInfoReveal {
           {this.icon && <z-icon name={this.icon} />}
           {this.label && <span class="z-info-reveal-label">{this.label}</span>}
         </button>
-        {this.open && (
-          <div
-            class="z-info-reveal-panel"
-            id="z-info-reveal-panel"
+        <div
+          class="z-info-reveal-panel"
+          id="z-info-reveal-panel"
+          ref={(el) => (this.panel = el)}
+          hidden={!this.open}
+        >
+          <slot></slot>
+          <button
+            class="z-info-reveal-close"
+            type="button"
+            onClick={this.closePanel.bind(this)}
+            aria-label="Chiudi pannello informazioni"
           >
-            <slot></slot>
-            <button
-              class="z-info-reveal-close"
-              onClick={this.closePanel.bind(this)}
-              aria-label="Chiudi pannello informazioni"
-            >
-              <z-icon name="multiply" />
-            </button>
-          </div>
-        )}
+            <z-icon name="multiply" />
+          </button>
+        </div>
       </Host>
     );
   }

--- a/src/components/z-info-reveal/styles.css
+++ b/src/components/z-info-reveal/styles.css
@@ -1,5 +1,6 @@
 :host {
-  --z-info-reveal-width: 343px; /* defaults to average width of mobile devices */
+  --z-info-reveal-panel-width: 384px; /* defaults half the size of the mobile breakpoint */
+  --trigger-size: 44px;
 
   position: relative;
 }
@@ -9,7 +10,6 @@
 }
 
 button {
-  --trigger-size: 44px;
   --trigger-icon-size: calc(var(--trigger-size) / 2);
 
   display: flex;
@@ -76,7 +76,7 @@ button:focus:focus-visible {
 .z-info-reveal-panel {
   position: absolute;
   display: flex;
-  width: var(--z-info-reveal-width);
+  width: var(--z-info-reveal-panel-width);
   height: fit-content;
   align-items: flex-start;
   padding: calc(var(--space-unit) * 1.5);
@@ -85,6 +85,10 @@ button:focus:focus-visible {
   box-shadow: var(--shadow-4);
   color: var(--color-text04);
   column-gap: var(--space-unit);
+}
+
+.z-info-reveal-panel[hidden] {
+  display: none;
 }
 
 :host([position="top_left"]) .z-info-reveal-panel,
@@ -113,4 +117,16 @@ button:focus:focus-visible {
 
 .z-info-reveal-panel z-icon {
   fill: var(--color-icon03);
+}
+
+@media (max-width: 767px) {
+  .z-info-reveal-panel {
+    position: fixed;
+    top: auto !important;
+    bottom: auto !important;
+    left: var(--grid-margin) !important;
+    width: calc(100% - (var(--grid-margin) * 2)) !important;
+    max-width: none !important;
+    margin-top: calc(var(--trigger-size) * -1);
+  }
 }

--- a/src/components/z-info-reveal/styles.css
+++ b/src/components/z-info-reveal/styles.css
@@ -1,103 +1,116 @@
 :host {
-  --z-info-reveal-theme--surface: var(--color-black);
-  --z-info-reveal-theme--text: var(--color-white);
-  --z-info-reveal-shadow: var(--shadow-2);
-  --z-info-reveal-max-width: 375px; /* defaults to average width of mobile devices */
+  --z-info-reveal-width: 343px; /* defaults to average width of mobile devices */
 
   position: relative;
-  display: flex;
-  width: fit-content;
-  background-color: var(--z-info-reveal-theme--surface);
-  color: var(--z-info-reveal-theme--text);
-  font-size: var(--font-size-3);
-  font-weight: var(--font-rg);
-  letter-spacing: 0;
-  line-height: 1.5;
+}
+
+:host * {
+  box-sizing: border-box;
 }
 
 button {
+  --trigger-size: 44px;
+  --trigger-icon-size: calc(var(--trigger-size) / 2);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   border: none;
   background-color: transparent;
-  border-radius: 0;
-  color: inherit;
   cursor: pointer;
-  fill: currentcolor;
   font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
   letter-spacing: inherit;
-  line-height: inherit;
 }
 
-z-icon {
-  --z-icon-width: calc(var(--space-unit) * 3);
-  --z-icon-height: calc(var(--space-unit) * 3);
-
-  display: flex;
+button:focus:focus-visible {
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
 }
 
 .z-info-reveal-trigger {
+  min-width: var(--trigger-size);
+  height: var(--trigger-size);
+  padding: calc((var(--trigger-size) - var(--trigger-icon-size)) / 2);
+  background-color: var(--color-surface05);
+  border-radius: var(--border-radius);
+  color: var(--color-text04);
+  column-gap: var(--space-unit);
+  font-weight: var(--font-sb);
+  line-height: 1rem;
+}
+
+:host([size="big"]) .z-info-reveal-trigger {
+  font-size: var(--font-size-2);
+}
+
+:host([size="small"]) .z-info-reveal-trigger {
+  --trigger-size: 36px;
+
+  font-size: var(--font-size-2);
+}
+
+:host([size="x-small"]) .z-info-reveal-trigger {
+  --trigger-size: 32px;
+
+  padding: var(--space-unit);
+  font-size: var(--font-size-1);
+}
+
+:host > .z-info-reveal-trigger z-icon {
+  --z-icon-width: var(--trigger-icon-size);
+  --z-icon-height: var(--trigger-icon-size);
+
   display: flex;
-  width: fit-content;
-  height: 100%;
-  align-items: center;
-  padding: calc(var(--space-unit) / 2);
-  box-shadow: var(--z-info-reveal-shadow);
-  column-gap: calc(var(--space-unit) / 2);
+  fill: var(--color-icon03);
 }
 
-:host([position="top_left"]) .z-info-reveal-trigger,
-:host([position="bottom_left"]) .z-info-reveal-trigger {
-  flex-direction: row-reverse;
+:host([size="small"]) > .z-info-reveal-trigger z-icon {
+  --trigger-icon-size: 18px;
 }
 
-:host([open]) .z-info-reveal-trigger {
-  box-shadow: none;
+:host([size="x-small"]) > .z-info-reveal-trigger z-icon {
+  --trigger-icon-size: 16px;
 }
 
-.info-box {
+.z-info-reveal-panel {
   position: absolute;
   display: flex;
-  max-width: var(--z-info-reveal-max-width);
-  padding: calc(var(--space-unit) / 2);
-  background-color: var(--z-info-reveal-theme--surface);
-  box-shadow: var(--z-info-reveal-shadow);
-  column-gap: calc(var(--space-unit) / 2);
-  cursor: pointer;
+  width: var(--z-info-reveal-width);
+  height: fit-content;
+  align-items: flex-start;
+  padding: calc(var(--space-unit) * 1.5);
+  background-color: var(--color-surface05);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-4);
+  color: var(--color-text04);
+  column-gap: var(--space-unit);
 }
 
-:host([position="bottom_left"]) .info-box,
-:host([position="bottom_right"]) .info-box {
+:host([position="top_left"]) .z-info-reveal-panel,
+:host([position="top_right"]) .z-info-reveal-panel {
+  top: 0;
+}
+
+:host([position="bottom_left"]) .z-info-reveal-panel,
+:host([position="bottom_right"]) .z-info-reveal-panel {
   bottom: 0;
 }
 
-:host([position="top_right"]) .info-box,
-:host([position="bottom_right"]) .info-box {
+:host([position="top_right"]) .z-info-reveal-panel,
+:host([position="bottom_right"]) .z-info-reveal-panel {
   right: 0;
 }
 
-:host([position="top_left"]) .info-box,
-:host([position="bottom_left"]) .info-box {
+:host([position="top_left"]) .z-info-reveal-panel,
+:host([position="bottom_left"]) .z-info-reveal-panel {
   left: 0;
-  flex-direction: row-reverse;
 }
 
-::slotted(*) {
-  display: none;
-  width: max-content;
+.z-info-reveal-panel .z-info-reveal-close {
+  margin-left: auto;
 }
 
-::slotted([data-current]) {
-  display: block;
-}
-
-:host([position="top_left"]) .z-info-reveal-close,
-:host([position="top_right"]) .z-info-reveal-close {
-  align-self: flex-start;
-}
-
-:host([position="bottom_left"]) .z-info-reveal-close,
-:host([position="bottom_right"]) .z-info-reveal-close {
-  align-self: flex-end;
+.z-info-reveal-panel z-icon {
+  fill: var(--color-icon03);
 }

--- a/src/components/z-popover/index.stories.css
+++ b/src/components/z-popover/index.stories.css
@@ -11,7 +11,9 @@
   --z-popover-padding: var(--space-unit);
 }
 
-.popover-container z-icon {
+.popover-container z-icon#trigger {
   --z-icon-width: 32px;
   --z-icon-height: 32px;
+
+  cursor: pointer;
 }

--- a/src/components/z-popover/index.stories.mdx
+++ b/src/components/z-popover/index.stories.mdx
@@ -56,19 +56,19 @@ To be sure the AUTO algorithm finds the right container when calculating the pos
             "--z-popover-theme--text": args["--z-popover-theme--text"],
           })}
           .position=${args.position}
-          bind-to="#icon"
+          bind-to="#trigger"
         >
           <div class="container">
-            <z-button icon="gear"> Impostazioni </z-button>
+            <z-button icon="gear">Impostazioni</z-button>
           </div>
         </z-popover>
         <z-icon
-          id="icon"
+          id="trigger"
           name="plus-square-filled"
         ></z-icon>
       </div>
       <script>
-        var iconTrigger = document.querySelector("#icon");
+        var iconTrigger = document.querySelector("#trigger");
         var popover = document.querySelector("z-popover");
         iconTrigger.addEventListener("click", () => {
           if (popover.open) {
@@ -99,19 +99,19 @@ To be sure the AUTO algorithm finds the right container when calculating the pos
           .position=${args.position}
           center="true"
           show-arrow="true"
-          bind-to="#icon"
+          bind-to="#trigger"
         >
           <div class="container">
             <z-button icon="gear"> Impostazioni </z-button>
           </div>
         </z-popover>
         <z-icon
-          id="icon"
+          id="trigger"
           name="plus-square-filled"
         ></z-icon>
       </div>
       <script>
-        document.querySelector("#icon").addEventListener("click", () => {
+        document.querySelector("#trigger").addEventListener("click", () => {
           if (document.querySelector("z-popover").open) {
             document.querySelector("z-popover").open = false;
           } else {


### PR DESCRIPTION
# Refactor - z-info-reveal - restyling
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
Implementation of component restyling. Also handled info panel in non-desktop viewport.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design
https://www.figma.com/file/w51ZwDwLNEt0yamar2sRRQ/branch/Semo75xq0khkRRw15Vt3UC/Nuovi-Componenti-e-Pattern?type=design&node-id=4743%3A8001&mode=design&t=RAenRdhR2YlG6umA-1
<!--- Reference link to Design sheet -->

### Note
Some CSSProp to change the colors of the component (and probably never used), has been removed in favor of the theming semantic CSSProps. Should we consider this change as breaking?

