### PR TITLE
Feat - ZAnchorNavigation - manual anchor highlight

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -66,7 +66,7 @@ export namespace Components {
         "type": AlertType;
     }
     /**
-     * * Anchor navigation component.
+     * Anchor navigation component.
      * @example ```
      * <z-anchor-navigation>
      *  <div>
@@ -79,6 +79,10 @@ export namespace Components {
      * ```
      */
     interface ZAnchorNavigation {
+        /**
+          * Enables automatic inference of the current item, listening for hash change and checking the `href` of the slotted anchors. When disabled, the highlight of current item must be handled manually by setting the `data-current` attribute to the correct slotted items and the `aria-current` attribute to the anchors.
+         */
+        "autoCurrent": boolean;
         /**
           * If enabled, the text of each anchor will be hidden unless for the current one or the one the user is hovering.
          */
@@ -2146,7 +2150,7 @@ declare global {
         new (): HTMLZAlertElement;
     };
     /**
-     * * Anchor navigation component.
+     * Anchor navigation component.
      * @example ```
      * <z-anchor-navigation>
      *  <div>
@@ -3366,7 +3370,7 @@ declare namespace LocalJSX {
         "type"?: AlertType;
     }
     /**
-     * * Anchor navigation component.
+     * Anchor navigation component.
      * @example ```
      * <z-anchor-navigation>
      *  <div>
@@ -3379,6 +3383,10 @@ declare namespace LocalJSX {
      * ```
      */
     interface ZAnchorNavigation {
+        /**
+          * Enables automatic inference of the current item, listening for hash change and checking the `href` of the slotted anchors. When disabled, the highlight of current item must be handled manually by setting the `data-current` attribute to the correct slotted items and the `aria-current` attribute to the anchors.
+         */
+        "autoCurrent"?: boolean;
         /**
           * If enabled, the text of each anchor will be hidden unless for the current one or the one the user is hovering.
          */
@@ -5538,7 +5546,7 @@ declare module "@stencil/core" {
             "z-accordion": LocalJSX.ZAccordion & JSXBase.HTMLAttributes<HTMLZAccordionElement>;
             "z-alert": LocalJSX.ZAlert & JSXBase.HTMLAttributes<HTMLZAlertElement>;
             /**
-             * * Anchor navigation component.
+             * Anchor navigation component.
              * @example ```
              * <z-anchor-navigation>
              *  <div>

--- a/src/components/z-anchor-navigation/index.stories.css
+++ b/src/components/z-anchor-navigation/index.stories.css
@@ -35,6 +35,15 @@
   top: 56px;
 }
 
+.z-anchor-navigation-demo-sections {
+  scroll-snap-type: y mandatory;
+}
+
+.z-anchor-navigation-demo-sections > .section {
+  scroll-margin-top: 56px;
+  scroll-snap-align: start;
+}
+
 @media (min-width: 768px) {
   .z-anchor-navigation-story-wrapper {
     display: inline-flex;

--- a/src/components/z-anchor-navigation/index.stories.css
+++ b/src/components/z-anchor-navigation/index.stories.css
@@ -17,6 +17,24 @@
   background-color: var(--blue300);
 }
 
+.z-anchor-navigation-story-wrapper z-anchor-navigation nav > * > * {
+  right: 8px;
+}
+
+.z-anchor-navigation-manual-current {
+  position: sticky;
+  top: 0;
+  display: flex;
+  padding: 8px 0 16px;
+  margin-bottom: calc(var(--space-unit) * 3);
+  background: #fff;
+  column-gap: calc(var(--space-unit) * 2);
+}
+
+.z-anchor-navigation-manual-current + .z-anchor-navigation-story-wrapper z-anchor-navigation {
+  top: 56px;
+}
+
 @media (min-width: 768px) {
   .z-anchor-navigation-story-wrapper {
     display: inline-flex;
@@ -29,7 +47,7 @@
   }
 }
 
-@media (min-width: 1151px) {
+@media (min-width: 1152px) {
   .z-anchor-navigation-story-wrapper z-anchor-navigation {
     max-width: 15%;
   }

--- a/src/components/z-anchor-navigation/index.stories.ts
+++ b/src/components/z-anchor-navigation/index.stories.ts
@@ -29,6 +29,7 @@ export const Default = {
           <z-button
             variant="tertiary"
             icon="share"
+            size="x-small"
           ></z-button>
         </div>
         <div>
@@ -37,10 +38,6 @@ export const Default = {
             target="_self"
             >Second section</a
           >
-          <z-icon
-            name="share"
-            tabindex="0"
-          ></z-icon>
         </div>
         <div>
           <a
@@ -59,6 +56,183 @@ export const Default = {
         <a
           href="#fourth-section"
           target="_self"
+          >Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
+          Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
+        </a>
+      </z-anchor-navigation>
+      <div>
+        <div id="first-section">
+          <h4>First section</h4>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
+            Archimede, qui dum in pulvere quaedam describit attentius, ne patriam quidem captam esse senserit?
+            Possumusne ergo in vita summum bonum dicere, cum id ne in cena quidem posse videamur? Morbo gravissimo
+            affectus, exul, orbus, egens, torqueatur eculeo: quem hunc appellas, Zeno? Nam memini etiam quae nolo,
+            oblivisci non possum quae volo. Nec vero sum nescius esse utilitatem in historia, non modo voluptatem. Duo
+            Reges: constructio interrete. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Hoc autem
+            loco tantum explicemus haec honesta, quae dico, praeterquam quod nosmet ipsos diligamus, praeterea suapte
+            natura per se esse expetenda. Te enim iudicem aequum puto, modo quae dicat ille bene noris. Si enim Zenoni
+            licuit, cum rem aliquam invenisset inusitatam, inauditum quoque ei rei nomen inponere, cur non liceat
+            Catoni? Ita cum ea volunt retinere, quae superiori sententiae conveniunt, in Aristonem incidunt; Istam
+            voluptatem perpetuam quis potest praestare sapienti? Urgent tamen et nihil remittunt. Sin te auctoritas
+            commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas? Stuprata per vim Lucretia a regis
+            filio testata civis se ipsa interemit. Sin autem ad animum, falsum est, quod negas animi ullum esse gaudium,
+            quod non referatur ad corpus.
+          </p>
+        </div>
+        <div class="separator"></div>
+        <div id="second-section">
+          <h4>Second section</h4>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
+            Archimede, qui dum in pulvere quaedam describit attentius, ne patriam quidem captam esse senserit?
+            Possumusne ergo in vita summum bonum dicere, cum id ne in cena quidem posse videamur? Morbo gravissimo
+            affectus, exul, orbus, egens, torqueatur eculeo: quem hunc appellas, Zeno? Nam memini etiam quae nolo,
+            oblivisci non possum quae volo. Nec vero sum nescius esse utilitatem in historia, non modo voluptatem. Duo
+            Reges: constructio interrete. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Hoc autem
+            loco tantum explicemus haec honesta, quae dico, praeterquam quod nosmet ipsos diligamus, praeterea suapte
+            natura per se esse expetenda. Te enim iudicem aequum puto, modo quae dicat ille bene noris. Si enim Zenoni
+            licuit, cum rem aliquam invenisset inusitatam, inauditum quoque ei rei nomen inponere, cur non liceat
+            Catoni? Ita cum ea volunt retinere, quae superiori sententiae conveniunt, in Aristonem incidunt; Istam
+            voluptatem perpetuam quis potest praestare sapienti? Urgent tamen et nihil remittunt. Sin te auctoritas
+            commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas? Stuprata per vim Lucretia a regis
+            filio testata civis se ipsa interemit. Sin autem ad animum, falsum est, quod negas animi ullum esse gaudium,
+            quod non referatur ad corpus.
+          </p>
+        </div>
+        <div class="separator"></div>
+        <div id="third-section">
+          <h4>Third section</h4>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
+            Archimede, qui dum in pulvere quaedam describit attentius, ne patriam quidem captam esse senserit?
+            Possumusne ergo in vita summum bonum dicere, cum id ne in cena quidem posse videamur? Morbo gravissimo
+            affectus, exul, orbus, egens, torqueatur eculeo: quem hunc appellas, Zeno? Nam memini etiam quae nolo,
+            oblivisci non possum quae volo. Nec vero sum nescius esse utilitatem in historia, non modo voluptatem. Duo
+            Reges: constructio interrete. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Hoc autem
+            loco tantum explicemus haec honesta, quae dico, praeterquam quod nosmet ipsos diligamus, praeterea suapte
+            natura per se esse expetenda. Te enim iudicem aequum puto, modo quae dicat ille bene noris. Si enim Zenoni
+            licuit, cum rem aliquam invenisset inusitatam, inauditum quoque ei rei nomen inponere, cur non liceat
+            Catoni? Ita cum ea volunt retinere, quae superiori sententiae conveniunt, in Aristonem incidunt; Istam
+            voluptatem perpetuam quis potest praestare sapienti? Urgent tamen et nihil remittunt. Sin te auctoritas
+            commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas? Stuprata per vim Lucretia a regis
+            filio testata civis se ipsa interemit. Sin autem ad animum, falsum est, quod negas animi ullum esse gaudium,
+            quod non referatur ad corpus.
+          </p>
+        </div>
+        <div class="separator"></div>
+        <div id="fourth-section">
+          <h4>Fourth section</h4>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
+            Archimede, qui dum in pulvere quaedam describit attentius, ne patriam quidem captam esse senserit?
+            Possumusne ergo in vita summum bonum dicere, cum id ne in cena quidem posse videamur? Morbo gravissimo
+            affectus, exul, orbus, egens, torqueatur eculeo: quem hunc appellas, Zeno? Nam memini etiam quae nolo,
+            oblivisci non possum quae volo. Nec vero sum nescius esse utilitatem in historia, non modo voluptatem. Duo
+            Reges: constructio interrete. Plane idem, inquit, et maxima quidem, qua fieri nulla maior potest. Hoc autem
+            loco tantum explicemus haec honesta, quae dico, praeterquam quod nosmet ipsos diligamus, praeterea suapte
+            natura per se esse expetenda. Te enim iudicem aequum puto, modo quae dicat ille bene noris. Si enim Zenoni
+            licuit, cum rem aliquam invenisset inusitatam, inauditum quoque ei rei nomen inponere, cur non liceat
+            Catoni? Ita cum ea volunt retinere, quae superiori sententiae conveniunt, in Aristonem incidunt; Istam
+            voluptatem perpetuam quis potest praestare sapienti? Urgent tamen et nihil remittunt. Sin te auctoritas
+            commovebat, nobisne omnibus et Platoni ipsi nescio quem illum anteponebas? Stuprata per vim Lucretia a regis
+            filio testata civis se ipsa interemit. Sin autem ad animum, falsum est, quod negas animi ullum esse gaudium,
+            quod non referatur ad corpus.
+          </p>
+        </div>
+        <div class="separator"></div>
+      </div>
+    </div>
+  `,
+} satisfies StoryObj<ZAnchorNavigation>;
+
+/**
+ * Manual activation of the `current` item on click setting `autoCurrent` to false.
+ */
+export const AutoCurrent = {
+  args: {
+    autoCurrent: false,
+  },
+  parameters: {
+    controls: {
+      exclude: ["autoCurrent"],
+    },
+  },
+  render: (args) => html`
+    <script>
+      const onClick = (ev) => {
+        const sectionID = ev.target.closest("z-button")?.dataset.to;
+        const current = document.querySelector("#" + sectionID + "-anchor");
+        const nav = current?.closest("nav");
+        Array.from(nav?.children ?? []).forEach((item) => {
+          const isCurrent = item.contains(current);
+          if (isCurrent) {
+            item.setAttribute("data-current", "");
+          } else {
+            item.removeAttribute("data-current");
+          }
+          const anchor = item.tagName === "A" ? item : item.querySelector("a");
+          item?.setAttribute("aria-current", isCurrent.toString());
+        });
+        const section = document.querySelector("#" + sectionID);
+        section?.scrollIntoView();
+      };
+
+      const buttons = document.querySelectorAll(".z-anchor-navigation-manual-current z-button");
+      Array.from(buttons).forEach((item) => item.addEventListener("click", onClick));
+    </script>
+
+    <div class="z-anchor-navigation-manual-current">
+      <z-button
+        size="x-small"
+        data-to="first-section"
+        >To first section</z-button
+      >
+      <z-button
+        size="x-small"
+        data-to="second-section"
+        >To second section</z-button
+      >
+      <z-button
+        size="x-small"
+        data-to="third-section"
+        >To third section</z-button
+      >
+      <z-button
+        size="x-small"
+        data-to="fourth-section"
+        >Highlight fourth section</z-button
+      >
+    </div>
+    <div class="z-anchor-navigation-story-wrapper">
+      <z-anchor-navigation
+        .hideUnselected=${args.hideUnselected}
+        .autoCurrent=${args.autoCurrent}
+      >
+        <div>
+          <a id="first-section-anchor">First section</a>
+          <z-button
+            variant="tertiary"
+            icon="share"
+            size="x-small"
+          ></z-button>
+        </div>
+        <div>
+          <a id="second-section-anchor">Second section</a>
+        </div>
+        <div>
+          <a id="third-section-anchor"
+            >Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
+            Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
+          </a>
+          <button
+            type="button"
+            aria-label="share"
+          >
+            <z-icon name="share" />
+          </button>
+        </div>
+        <a id="fourth-section-anchor"
           >Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
           Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
         </a>

--- a/src/components/z-anchor-navigation/index.stories.ts
+++ b/src/components/z-anchor-navigation/index.stories.ts
@@ -147,9 +147,11 @@ export const Default = {
 } satisfies StoryObj<ZAnchorNavigation>;
 
 /**
- * Manual activation of the `current` item on click setting `autoCurrent` to false.
+ * Setting `autoCurrent` to `false` disables the automatic highlighting of the current section in the anchor navigation
+ * and allows manual handling.
+ * In this story, for example, the highlighting of the current section is done by clicking on the related button.
  */
-export const AutoCurrent = {
+export const AutoCurrentDisabling = {
   args: {
     autoCurrent: false,
   },

--- a/src/components/z-anchor-navigation/index.stories.ts
+++ b/src/components/z-anchor-navigation/index.stories.ts
@@ -160,26 +160,25 @@ export const AutoCurrent = {
   },
   render: (args) => html`
     <script>
-      const onClick = (ev) => {
-        const sectionID = ev.target.closest("z-button")?.dataset.to;
-        const current = document.querySelector("#" + sectionID + "-anchor");
-        const nav = current?.closest("nav");
-        Array.from(nav?.children ?? []).forEach((item) => {
-          const isCurrent = item.contains(current);
-          if (isCurrent) {
-            item.setAttribute("data-current", "");
-          } else {
-            item.removeAttribute("data-current");
-          }
-          const anchor = item.tagName === "A" ? item : item.querySelector("a");
-          item?.setAttribute("aria-current", isCurrent.toString());
-        });
-        const section = document.querySelector("#" + sectionID);
-        section?.scrollIntoView();
-      };
-
-      const buttons = document.querySelectorAll(".z-anchor-navigation-manual-current z-button");
-      Array.from(buttons).forEach((item) => item.addEventListener("click", onClick));
+      Array.from(document.querySelectorAll(".z-anchor-navigation-manual-current z-button")).forEach((item) =>
+        item.addEventListener("click", (ev) => {
+          const sectionID = ev.target.closest("z-button")?.dataset.to;
+          const current = document.querySelector("#" + sectionID + "-anchor");
+          const nav = current?.closest("nav");
+          Array.from(nav?.children ?? []).forEach((item) => {
+            const isCurrent = item.contains(current);
+            if (isCurrent) {
+              item.setAttribute("data-current", "");
+            } else {
+              item.removeAttribute("data-current");
+            }
+            const anchor = item.tagName === "A" ? item : item.querySelector("a");
+            item?.setAttribute("aria-current", isCurrent.toString());
+          });
+          const section = document.querySelector("#" + sectionID);
+          section?.scrollIntoView();
+        })
+      );
     </script>
 
     <div class="z-anchor-navigation-manual-current">
@@ -237,8 +236,11 @@ export const AutoCurrent = {
           Third section with a very very long title and an icon and the title is repeated so it can go over 2 lines
         </a>
       </z-anchor-navigation>
-      <div>
-        <div id="first-section">
+      <div class="z-anchor-navigation-demo-sections">
+        <div
+          class="section"
+          id="first-section"
+        >
           <h4>First section</h4>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
@@ -258,7 +260,10 @@ export const AutoCurrent = {
           </p>
         </div>
         <div class="separator"></div>
-        <div id="second-section">
+        <div
+          class="section"
+          id="second-section"
+        >
           <h4>Second section</h4>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
@@ -278,7 +283,10 @@ export const AutoCurrent = {
           </p>
         </div>
         <div class="separator"></div>
-        <div id="third-section">
+        <div
+          class="section"
+          id="third-section"
+        >
           <h4>Third section</h4>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in
@@ -298,7 +306,10 @@ export const AutoCurrent = {
           </p>
         </div>
         <div class="separator"></div>
-        <div id="fourth-section">
+        <div
+          class="section"
+          id="fourth-section"
+        >
           <h4>Fourth section</h4>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quem enim ardorem studii censetis fuisse in

--- a/src/components/z-anchor-navigation/readme.md
+++ b/src/components/z-anchor-navigation/readme.md
@@ -7,20 +7,21 @@
 
 ## Overview
 
-* Anchor navigation component.
+Anchor navigation component.
 
 ## Properties
 
-| Property         | Attribute         | Description                                                                                                    | Type      | Default |
-| ---------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `hideUnselected` | `hide-unselected` | If enabled, the text of each anchor will be hidden unless for the current one or the one the user is hovering. | `boolean` | `false` |
+| Property         | Attribute         | Description                                                                                                                                                                                                                                                                                                            | Type      | Default |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `autoCurrent`    | `auto-current`    | Enables automatic inference of the current item, listening for hash change and checking the `href` of the slotted anchors. When disabled, the highlight of current item must be handled manually by setting the `data-current` attribute to the correct slotted items and the `aria-current` attribute to the anchors. | `boolean` | `true`  |
+| `hideUnselected` | `hide-unselected` | If enabled, the text of each anchor will be hidden unless for the current one or the one the user is hovering.                                                                                                                                                                                                         | `boolean` | `false` |
 
 
 ## Slots
 
-| Slot                                                                                                                  | Description |
-| --------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `"Main slot. Put some `<a>` tags inside. If you need an action button/icon, wrap it and the <a> inside another tag."` |             |
+| Slot | Description                                                                                                                      |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------- |
+|      | Anchor navigation items. Use `<a>` elements inside. If you need an extra action element, use a wrapper around it and the anchor. |
 
 
 ## Dependencies

--- a/src/components/z-anchor-navigation/styles.css
+++ b/src/components/z-anchor-navigation/styles.css
@@ -59,7 +59,7 @@ z-anchor-navigation nav > [data-current] {
   font-weight: var(--font-sb);
 }
 
-z-anchor-navigation nav > * > *:is(z-button, button, z-icon) {
+z-anchor-navigation nav > * > *:is(z-button, button) {
   position: absolute;
   top: 50%;
   right: 0;
@@ -67,20 +67,17 @@ z-anchor-navigation nav > * > *:is(z-button, button, z-icon) {
   transition: opacity 0.3s ease-in-out;
 }
 
+z-anchor-navigation nav > *:focus:focus-visible,
+z-anchor-navigation nav > * > *:focus:focus-visible {
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
+}
+
 z-anchor-navigation nav button {
   padding: 0;
   border: none;
   margin: 0;
   background-color: transparent;
-}
-
-z-anchor-navigation nav z-icon {
-  --z-icon-width: 16px;
-  --z-icon-height: 16px;
-
-  display: flex;
-  padding: calc(var(--space-unit) * 1.5);
-  fill: var(--color-default-icon);
 }
 
 @media (min-width: 768px) {
@@ -92,11 +89,19 @@ z-anchor-navigation nav z-icon {
     display: flex;
   }
 
-  z-anchor-navigation nav a {
-    outline: none;
+  /* hide anchor actions by default... */
+  z-anchor-navigation nav > * > :is(z-button, button) {
+    opacity: 0;
+    pointer-events: none;
   }
 
   @media (hover: hover) {
+    /* ...show them only hovering/focusing the anchor */
+    z-anchor-navigation nav > :is([data-current], :hover, :focus, :focus-within) > :is(z-button, button) {
+      opacity: 1;
+      pointer-events: unset;
+    }
+
     z-anchor-navigation nav > *:hover {
       border-left-color: var(--color-hover-secondary);
       background-color: var(--color-hover-surface);
@@ -104,28 +109,8 @@ z-anchor-navigation nav z-icon {
     }
   }
 
-  z-anchor-navigation nav > *:is(:focus, :focus-within),
-  z-anchor-navigation nav :is(z-icon, button):focus:focus-visible {
-    box-shadow: var(--shadow-focus-primary);
-    outline: none;
-  }
-
   z-anchor-navigation[hide-unselected] nav > *:not([data-current], :hover, :focus, :focus-within) {
     color: transparent;
-  }
-
-  z-anchor-navigation
-    nav
-    > *:not([data-current], :hover, :focus, :focus-within)
-    > *:is(z-button, button, z-icon):not(:focus:focus-visible) {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  @media (hover: none) {
-    z-anchor-navigation:not([hide-unselected]) nav > * > *:is(z-button, button, z-icon) {
-      opacity: 1;
-      pointer-events: all;
-    }
+    fill: transparent;
   }
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -141,3 +141,17 @@ export function colorFromId(id: number): string {
 
   return `${prefix}${color.toString().padStart(2, "0")}`;
 }
+
+/**
+ * Check if the passed CSS selector is valid.
+ * @param selector CSS selector to validate
+ */
+export function isSelectorValid(selector: string): boolean {
+  try {
+    document.createDocumentFragment().querySelector(selector);
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -4,6 +4,7 @@ import {reactOutputTarget} from "@stencil/react-output-target";
 export const config: Config = {
   namespace: "web-components-library",
   globalStyle: "src/global.css",
+  buildEs5: true,
   outputTargets: [
     {
       type: "dist",


### PR DESCRIPTION
# Feat - ZAnchorNavigation - manual anchor highlight

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
This PR adds a prop named `autoCurrent` to the `ZAnchorNavigation` component, to allow disabling the default behavior on highlighting the current anchor. By setting `autoCurrent` to `false`, highlighting a slotted child can be done by setting the `data-current` attribute. NB: the `aria-current` attribute on the `<a>` elements, if needed, must be set manually.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)