### PR TITLE
Fix - ZPopover - fix parent element finder function when checking shadow root

### DIFF
--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -3,12 +3,12 @@ import {KeyboardCode, PopoverPosition} from "../../beans";
 
 const DOCUMENT_ELEMENT = document.documentElement;
 
-function getParentElement(element: Element): ShadowRoot["host"] {
-  if ((element.parentNode as ShadowRoot).host) {
-    return (element.parentNode as ShadowRoot).host;
+function getParentElement(element: Element): Element {
+  if (element.parentNode === element.shadowRoot) {
+    return element.shadowRoot.host;
   }
 
-  return element.parentNode as Element;
+  return element.parentElement;
 }
 
 /**


### PR DESCRIPTION
<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
This PR fixes the `getParentElement` function of the ZPopover component: the old condition to get the `host` of a `shadowRoot` did not consider the existence of the `host` field of anchor HTML elements, so when the `parentNode` is an anchor, the URL's host was considered a `shadowRoot`'s host.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)