### PR TITLE
fix - z-tag - improve CSS variables usage

### DIFF
--- a/src/components/z-tag/index.spec.ts
+++ b/src/components/z-tag/index.spec.ts
@@ -6,20 +6,20 @@ describe("Suite test ZTag", () => {
   it("Test render z-tag empty", async () => {
     const page = await newSpecPage({
       components: [ZTag],
-      html: `<z-tag class="body-5-sb"></z-tag>`,
+      html: `<z-tag></z-tag>`,
     });
 
-    expect(page.root).toEqualHtml(`<z-tag class="body-5-sb"><div></div></z-tag>`);
+    expect(page.root).toEqualHtml(`<z-tag><div></div></z-tag>`);
   });
 
   it("Test render z-tag with icon", async () => {
     const page = await newSpecPage({
       components: [ZTag],
-      html: `<z-tag class="body-5-sb" icon="gear"></z-tag>`,
+      html: `<z-tag icon="gear"></z-tag>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-tag class="body-5-sb" icon="gear">
+      <z-tag icon="gear">
         <z-icon name="gear"></z-icon>
         <div></div>
       </z-tag>`);
@@ -28,11 +28,11 @@ describe("Suite test ZTag", () => {
   it("Test render z-tag with text", async () => {
     const page = await newSpecPage({
       components: [ZTag],
-      html: `<z-tag class="body-5-sb">my custom element</z-tag>`,
+      html: `<z-tag>my custom element</z-tag>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-tag class="body-5-sb">
+      <z-tag>
       <div>my custom element</div>
       </z-tag>
     `);
@@ -41,11 +41,11 @@ describe("Suite test ZTag", () => {
   it("Test render z-tag with icon and text", async () => {
     const page = await newSpecPage({
       components: [ZTag],
-      html: `<z-tag class="body-5-sb" icon="gear">my custom element</z-tag>`,
+      html: `<z-tag icon="gear">my custom element</z-tag>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-tag class="body-5-sb" icon="gear" >
+      <z-tag icon="gear" >
         <z-icon name="gear"></z-icon>
         <div>my custom element</div>
       </z-tag>
@@ -55,11 +55,11 @@ describe("Suite test ZTag", () => {
   it("Test render z-tag with icon and text with Token", async () => {
     const page = await newSpecPage({
       components: [ZTag],
-      html: `<z-tag class="body-5-sb" icon="gear" style="--iconTextToken: var(--color-white); --bgToken: var(--avatar-C19);">my custom element</z-tag>`,
+      html: `<z-tag icon="gear" style="--z-tag-text-color: var(--color-white); --z-tag-bg: var(--avatar-C19);">my custom element</z-tag>`,
     });
 
     expect(page.root).toEqualHtml(`
-      <z-tag class="body-5-sb" icon="gear" style="--iconTextToken: var(--color-white); --bgToken: var(--avatar-C19);">
+      <z-tag icon="gear" style="--z-tag-text-color: var(--color-white); --z-tag-bg: var(--avatar-C19);">
         <z-icon name="gear"></z-icon>
         <div>my custom element</div>
       </z-tag>

--- a/src/components/z-tag/index.tsx
+++ b/src/components/z-tag/index.tsx
@@ -25,8 +25,7 @@ export class ZTag {
     return (
       <Host
         class={{
-          "body-5-sb": true,
-          "expandable": this.expandable && !!this.icon,
+          expandable: this.expandable && !!this.icon,
         }}
       >
         {this.icon && <z-icon name={this.icon} />}

--- a/src/components/z-tag/styles.css
+++ b/src/components/z-tag/styles.css
@@ -1,35 +1,32 @@
 :host {
   --z-icon-width: 14px;
   --z-icon-height: 14px;
-  --z-tag-text-color: var(--color-primary03);
-  --z-tag-bg: var(--color-hover-primary);
 
   display: flex;
   width: fit-content;
   max-width: inherit;
   height: fit-content;
   max-height: inherit;
+  align-items: flex-start;
   padding: calc(var(--space-unit) / 2);
-  background-color: var(--z-tag-bg);
+  background-color: var(--z-tag-bg, var(--color-hover-primary));
   border-radius: var(--border-radius);
-  color: var(--z-tag-text-color);
-  fill: var(--z-tag-text-color);
+  color: var(--z-tag-text-color, var(--color-text-inverse));
+  fill: currentcolor;
   font-family: var(--font-family-sans);
+  font-size: var(--font-size-1);
+  font-weight: var(--font-sb);
+  letter-spacing: 0.32px;
   line-height: 14px;
   text-transform: uppercase;
 }
 
-:host > z-icon {
-  margin-right: var(--space-unit);
-}
-
 :host(.expandable) > z-icon {
-  margin-right: 0;
   transition: margin-right 0.3s ease-out;
 }
 
-:host(:not(.expandable)) > z-icon:not(:last-child),
-:host(.expandable:hover) > z-icon:not(:last-child) {
+:host(:not(.expandable)) > z-icon,
+:host(.expandable:hover) > z-icon {
   margin-right: var(--space-unit);
   transition: margin-right 0.3s ease-out 0s;
 }


### PR DESCRIPTION
# fix - z-tag - improve CSS variables usage

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context
This PR improves the way the `z-tag` component uses the `--z-tag-bg` and `--z-tag-text-color` to set the style, allowing the apps to change the value without using `!important` in a selector with less specificity of the scoping css class set by stencil. Also, the `body-5-sb` typography class has been removed, setting the relative styles directly, as setting a different class (for example `body-3-sb`) wouldn't work.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [x] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
