### PR TITLE
Fix/z searchbar close on click

### DIFF
--- a/src/components/z-searchbar/index.spec.ts
+++ b/src/components/z-searchbar/index.spec.ts
@@ -93,7 +93,7 @@ describe("Suite test ZSearchbar", () => {
       >
         <mock:shadow-root>
           <div class="input-container">
-            <z-input size="big"></z-input>
+            <z-input size="big" value="item"></z-input>
             <div class="results-wrapper">
               <div class="results">
                 <z-list role="listbox" id="list-my-id">
@@ -134,7 +134,7 @@ describe("Suite test ZSearchbar", () => {
       >
         <mock:shadow-root>
           <div class="input-container">
-            <z-input size="big"></z-input>
+            <z-input size="big" value="item"></z-input>
             <div class="results-wrapper">
               <div class="results">
                 <z-list role="listbox" id="list-my-id">
@@ -189,7 +189,7 @@ describe("Suite test ZSearchbar", () => {
       >
         <mock:shadow-root>
           <div class="input-container">
-            <z-input size="big"></z-input>
+            <z-input size="big" value="item"></z-input>
             <div class="results-wrapper">
               <div class="results">
                 <z-list role="listbox" id="list-my-id">
@@ -229,7 +229,7 @@ describe("Suite test ZSearchbar", () => {
       >
         <mock:shadow-root>
           <div class="input-container">
-            <z-input size="big"></z-input>
+            <z-input size="big" value="item"></z-input>
             <div class="results-wrapper">
               <div class="results">
                 <span class="item item-no-results">
@@ -274,7 +274,7 @@ describe("Suite test ZSearchbar", () => {
       >
         <mock:shadow-root>
           <div class="input-container">
-            <z-input size="big"></z-input>
+            <z-input size="big" value="item"></z-input>
             <div class="results-wrapper">
               <div class="results">
                 <z-list role="listbox" id="list-my-id">

--- a/src/components/z-searchbar/index.tsx
+++ b/src/components/z-searchbar/index.tsx
@@ -90,6 +90,9 @@ export class ZSearchbar {
   @State()
   isMobile = false;
 
+  @State()
+  selectedItem?: SearchbarItem;
+
   @Element() element: HTMLZSearchbarElement;
 
   private resultsItemsList: SearchbarItem[] | undefined = null;
@@ -122,6 +125,8 @@ export class ZSearchbar {
 
   private emitSearchItemClick(item: SearchbarItem): void {
     this.searchItemClick.emit(item);
+    this.selectedItem = item;
+    this.searchString = "";
   }
 
   @Watch("resultsItems")
@@ -272,7 +277,7 @@ export class ZSearchbar {
           handleEnterKeydSubmit(e, () => this.handleSubmit());
           this.handleArrowsNavigation(e);
         }}
-        value={this.value}
+        value={this.searchString || this.selectedItem?.label}
         ariaLabel={this.placeholder}
         size={this.size}
       />

--- a/src/components/z-searchbar/index.tsx
+++ b/src/components/z-searchbar/index.tsx
@@ -235,6 +235,7 @@ export class ZSearchbar {
   private handleStopTyping(e: CustomEvent): void {
     e.stopPropagation();
     this.searchString = e.detail.value;
+    if (this.selectedItem) this.selectedItem = undefined;
   }
 
   private handleSubmit(): void {


### PR DESCRIPTION
# Fix - z searchbar - close on click item

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context

This update implements the ability for the z-searchbar to close when an item is clicked. 
After the selection of the item, its label will be displayed in the input field and the list will close.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
