### PR TITLE
Chore - z-carousel - remove wrong roles

### DIFF
--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -237,7 +237,6 @@ export class ZCarousel {
   private setupItems(): void {
     this.items = Array.from(this.host.children) as HTMLLIElement[];
     this.items.forEach((item) => {
-      item.setAttribute("role", "group");
       item.setAttribute("aria-roledescription", "slide");
     });
   }
@@ -273,7 +272,6 @@ export class ZCarousel {
       <Host>
         <div
           class="z-carousel-container"
-          role="group"
           aria-roledescription="carousel"
           aria-label={this.label || "Carousel"}
         >


### PR DESCRIPTION
## Motivation and Context
Remove `group` role from carousel items and items container. The role was not exactly wrong but it's not necessary in a "list context" with `ul` and `li`s. That roles were causing an error with accessibility check tools like **axe DevTools**.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)