### PR TITLE
Feat - section title - CSS classes

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -44,7 +44,7 @@ const preview: Preview = {
     options: {
       storySort: {
         method: "alphabetical",
-        order: ["Migration", "Colors", "Grid", "Iconset", "*", "Snowflakes", "Deprecated"],
+        order: ["Migration", "Colors", "Typography", "Grid", "Iconset", "*", "Snowflakes", "Deprecated"],
       },
     },
     controls: {sort: "alpha"},

--- a/docs/grid/index.stories.ts
+++ b/docs/grid/index.stories.ts
@@ -9,9 +9,16 @@ export default {
 export const Grid = {
   render: () => html`
     <div class="grid-story body-1">
-      <p>This story highlights z-grid column responsive CSS classes from tokens grid system.</p>
-      <p>Changing the viewport size will change the grid layout.</p>
-      <p>Try changing viewport size using Storybook preview tool on Canvas tab.</p>
+      <p><strong>z-grid</strong> column responsive CSS classes.</p>
+      <p>Each "col" class can be used with a viewport prefix:
+        <ul>
+          <li>mobile-col-#</li>
+          <li>tablet-col-#</li>
+          <li>desktop-col-#</li>
+          <li>wide-col-#</li>
+        </ul>
+      </p>
+      <p>The prefix let the class apply its style only on that viewport.</p>
       <div class="container">
         <h3>Responsive columns</h3>
         <div class="z-grid">

--- a/docs/typography/index.stories.css
+++ b/docs/typography/index.stories.css
@@ -7,7 +7,7 @@
 .type-scale {
   display: grid;
   align-items: baseline;
-  column-gap: var(--space-unit);
+  gap: var(--space-unit);
   grid-template-columns: max-content max-content max-content;
   text-align: left;
 }
@@ -25,15 +25,4 @@
 
 .typography-classes > * {
   gap: calc(var(--space-unit) * 2);
-}
-
-.section-title-classes {
-  display: flex;
-  flex-direction: column;
-  gap: calc(var(--space-unit) * 4);
-}
-
-.section-title-classes code {
-  padding: var(--space-unit);
-  color: var(--color-default-text);
 }

--- a/docs/typography/index.stories.css
+++ b/docs/typography/index.stories.css
@@ -1,0 +1,39 @@
+.type-scale,
+.typography-classes,
+.section-title-classes {
+  color: var(--color-default-text);
+}
+
+.type-scale {
+  display: grid;
+  align-items: baseline;
+  column-gap: var(--space-unit);
+  grid-template-columns: max-content max-content max-content;
+  text-align: left;
+}
+
+.typography-classes {
+  display: flex;
+  gap: calc(var(--space-unit) * 8);
+}
+
+.typography-classes > *,
+.typography-classes .typography-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.typography-classes > * {
+  gap: calc(var(--space-unit) * 2);
+}
+
+.section-title-classes {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space-unit) * 4);
+}
+
+.section-title-classes code {
+  padding: var(--space-unit);
+  color: var(--color-default-text);
+}

--- a/docs/typography/index.stories.ts
+++ b/docs/typography/index.stories.ts
@@ -1,0 +1,186 @@
+import {Meta, StoryObj} from "@storybook/web-components";
+import {html} from "lit";
+import "./index.stories.css";
+
+/**
+ * The typographic styles are based on the `IBM Plex` font family.
+ * Some CSS classes and props are provided to apply the typographic styles:
+ * - a set of CSS custom props for font sizes and font weights
+ * - a set of classes for headings, body text, and interactive text
+ * - a set of classes and CSS custom props for section titles
+ */
+export default {
+  title: "Typography",
+  argTypes: {
+    fontFamily: {
+      options: ["--font-family-sans", "--font-family-serif"],
+      control: {type: "inline-radio"},
+    },
+  },
+  args: {
+    fontFamily: "--font-family-sans",
+  },
+} satisfies Meta;
+
+const sampleText = "The quick brown fox jumps over the lazy dog";
+const scaleProps = [
+  "--font-size-1",
+  "--font-size-2",
+  "--font-size-3",
+  "--font-size-4",
+  "--font-size-5",
+  "--font-size-6",
+  "--font-size-7",
+  "--font-size-8",
+  "--font-size-9",
+  "--font-size-10",
+  "--font-size-11",
+  "--font-size-12",
+  "--font-size-13",
+  "--font-size-14",
+  "--font-size-15",
+  "--font-size-16",
+  "--font-size-17",
+];
+
+export const TypeScale = {
+  argTypes: {
+    fontWeight: {
+      options: ["--font-lt", "--font-rg", "--font-sb", "--font-bd"],
+      control: {type: "inline-radio"},
+    },
+  },
+  args: {
+    fontWeight: "--font-rg",
+  },
+  render: (args) =>
+    html`<div class="type-scale">
+      ${scaleProps.map(
+        (prop) => html`
+          <span class="body-5-sb">${prop}</span>
+          <span class="body-5"
+            >${parseFloat(getComputedStyle(document.documentElement).getPropertyValue(prop)) *
+            parseFloat(getComputedStyle(document.documentElement).getPropertyValue("font-size"))}px</span
+          >
+          <span
+            class="sample-text"
+            style="font-size: var(${prop}); font-family: var(${args.fontFamily}); font-weight: var(${args.fontWeight})"
+            >${sampleText}</span
+          >
+        `
+      )}
+    </div>`,
+} satisfies StoryObj;
+
+const headingLevels = 4;
+const bodyLevels = 5;
+const interactiveLevels = 3;
+const getWeightSuffix = (weight: string | null): string => (weight ? `-${weight}` : "");
+
+export const TypographyClasses = {
+  argTypes: {
+    headingWeight: {
+      options: ["lt", null, "sb"],
+      control: {
+        type: "inline-radio",
+        labels: {
+          lt: "Light",
+          null: "Regular",
+          sb: "Semibold",
+        },
+      },
+    },
+    fontWeight: {
+      options: [null, "sb"],
+      control: {
+        type: "inline-radio",
+        labels: {
+          null: "Regular",
+          sb: "Semibold",
+        },
+      },
+    },
+  },
+  args: {
+    headingWeight: null,
+    fontWeight: null,
+  },
+  render: (args) =>
+    html`<div class="typography-classes">
+      <div class="heading-classes">
+        ${Array.from({length: headingLevels}, (_, i) => i + 1).map(
+          (level) => html`
+            <div class="typography-group">
+              <div
+                class="heading-${level}${getWeightSuffix(args.headingWeight)}"
+                style="font-family: var(${args.fontFamily})"
+              >
+                Heading ${level}
+              </div>
+              <div class="body-5-sb">.heading-${level}${getWeightSuffix(args.headingWeight)}</div>
+            </div>
+          `
+        )}
+      </div>
+      <div class="body-classes">
+        ${Array.from({length: bodyLevels}, (_, i) => i + 1).map(
+          (level) => html`
+            <div class="typography-group">
+              <div
+                class="body-${level}${getWeightSuffix(args.fontWeight)}"
+                style="font-family: var(${args.fontFamily})"
+              >
+                Body ${level}
+              </div>
+              <div class="body-5-sb">.body-${level}${getWeightSuffix(args.fontWeight)}</div>
+            </div>
+          `
+        )}
+      </div>
+      <div class="interactive-classes">
+        ${Array.from({length: interactiveLevels}, (_, i) => i + 1).map(
+          (level) =>
+            html`<div class="typography-group">
+              <div
+                class="interactive-${level}${getWeightSuffix(args.fontWeight)}"
+                style="font-family: var(${args.fontFamily})"
+              >
+                Interactive ${level}
+              </div>
+              <div class="body-5-sb">.interactive-${level}${getWeightSuffix(args.fontWeight)}</div>
+            </div>`
+        )}
+      </div>
+      <div class="helper-classes">
+        <div class="typography-group">
+          <div
+            class="helper${getWeightSuffix(args.fontWeight)}"
+            style="font-family: var(${args.fontFamily})"
+          >
+            Helper
+          </div>
+          <div class="body-5-sb">.helper${getWeightSuffix(args.fontWeight)}</div>
+        </div>
+      </div>
+    </div>`,
+} satisfies StoryObj;
+
+const sectionTitleLevels = 6;
+
+export const SectionTitle = {
+  render: () => html`
+    <div class="section-title-classes">
+      ${Array.from({length: sectionTitleLevels}, (_, i) => i + 1).map(
+        (level) =>
+          html`<div>
+            <div class="z-section-title-${level}">Section title ${level}</div>
+            <div class="body-5-sb">.z-section-title-${level} / --z-section-title-${level}</div>
+          </div>`
+      )}
+      <div>
+        <p>The CSS custom properties are meant to be used with the "font" shorthand property. For example:</p>
+        <code class="theme-dark">font: var(--z-section-title-1);</code>
+      </div>
+    </div>
+  `,
+} satisfies StoryObj;

--- a/docs/typography/index.stories.ts
+++ b/docs/typography/index.stories.ts
@@ -44,6 +44,14 @@ const scaleProps = [
 ];
 
 export const TypeScale = {
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        height: "300px",
+      },
+    },
+  },
   argTypes: {
     fontWeight: {
       options: ["--font-lt", "--font-rg", "--font-sb", "--font-bd"],
@@ -75,8 +83,30 @@ export const TypeScale = {
 const headingLevels = 4;
 const bodyLevels = 5;
 const interactiveLevels = 3;
+const sectionTitleLevels = 6;
 const getWeightSuffix = (weight: string | null): string => (weight ? `-${weight}` : "");
 
+/**
+ * `.heading-1` and `.heading-2` classes automatically scale in size starting from desktop viewport.
+ * Typography classes (except for `helper`) can also be used with a viewport prefix (`mobile`, `tablet`, `desktop`, `wide`)
+ * to apply the styles only on specific viewport sizes.
+ * For example:
+ *
+ * ```
+ * <p class="mobile-body-3 tablet-body-2 body-1">Lorem ipsum...</p>
+ * ```
+ *
+ * will apply the `body-3` style on mobile, `body-2` on tablet, and `body-1` on desktop and wide viewports.
+ *
+ * Section titles are also available as CSS custom properties:
+ * those properties are meant to be used with the "font" shorthand property. For example:
+ *
+ * ```
+ * h4 {
+ *  font: var(--z-section-title-4);
+ * }
+ * ```
+ */
 export const TypographyClasses = {
   argTypes: {
     headingWeight: {
@@ -107,6 +137,15 @@ export const TypographyClasses = {
   },
   render: (args) =>
     html`<div class="typography-classes">
+      <div class="section-title-classes">
+        ${Array.from({length: sectionTitleLevels}, (_, i) => i + 1).map(
+          (level) =>
+            html`<div class="typography-group">
+              <div class="z-section-title-${level}">Section title ${level}</div>
+              <div class="body-5-sb">.z-section-title-${level} / --z-section-title-${level}</div>
+            </div>`
+        )}
+      </div>
       <div class="heading-classes">
         ${Array.from({length: headingLevels}, (_, i) => i + 1).map(
           (level) => html`
@@ -162,25 +201,5 @@ export const TypographyClasses = {
           <div class="body-5-sb">.helper${getWeightSuffix(args.fontWeight)}</div>
         </div>
       </div>
-    </div>`,
-} satisfies StoryObj;
-
-const sectionTitleLevels = 6;
-
-export const SectionTitle = {
-  render: () => html`
-    <div class="section-title-classes">
-      ${Array.from({length: sectionTitleLevels}, (_, i) => i + 1).map(
-        (level) =>
-          html`<div>
-            <div class="z-section-title-${level}">Section title ${level}</div>
-            <div class="body-5-sb">.z-section-title-${level} / --z-section-title-${level}</div>
-          </div>`
-      )}
-      <div>
-        <p>The CSS custom properties are meant to be used with the "font" shorthand property. For example:</p>
-        <code class="theme-dark">font: var(--z-section-title-1);</code>
-      </div>
-    </div>
-  `,
+    </div> `,
 } satisfies StoryObj;

--- a/src/tokens/typography.css
+++ b/src/tokens/typography.css
@@ -54,33 +54,11 @@
   line-height: 1.333;
 }
 
-/* for desktop viewports */
-@media (min-width: 1152px) {
-  .heading-1,
-  .heading-1-sb,
-  .heading-1-lt {
-    font-size: var(--font-size-8);
-    font-weight: var(--font-rg);
-    letter-spacing: 0;
-    line-height: 1.25;
-  }
-
-  .heading-2,
-  .heading-2-sb,
-  .heading-2-lt {
-    font-size: var(--font-size-7);
-    font-weight: var(--font-rg);
-    letter-spacing: 0;
-    line-height: 1.28;
-  }
-}
-
 .heading-3,
 .heading-3-sb,
 .heading-3-lt {
   font-size: var(--font-size-6);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
   line-height: 1.333;
 }
 
@@ -89,7 +67,6 @@
 .heading-4-lt {
   font-size: var(--font-size-5);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
   line-height: 1.4;
 }
 
@@ -97,7 +74,6 @@
 .body-1-sb {
   font-size: var(--font-size-5);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
   line-height: 1.4;
 }
 
@@ -105,7 +81,6 @@
 .body-2-sb {
   font-size: var(--font-size-4);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
   line-height: 1.5;
 }
 
@@ -113,7 +88,6 @@
 .body-3-sb {
   font-size: var(--font-size-3);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
   line-height: 1.5;
 }
 
@@ -137,7 +111,6 @@
 .interactive-1-sb {
   font-size: var(--font-size-3);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
   line-height: 1.5;
 }
 
@@ -213,4 +186,496 @@
 
 .z-section-title-6 {
   font: var(--z-section-title-6);
+}
+
+/* heading-1/2 for desktop and wide viewports */
+@media (min-width: 1152px) {
+  .heading-1,
+  .heading-1-sb,
+  .heading-1-lt {
+    font-size: var(--font-size-8);
+    font-weight: var(--font-rg);
+    line-height: 1.25;
+  }
+
+  .heading-2,
+  .heading-2-sb,
+  .heading-2-lt {
+    font-size: var(--font-size-7);
+    font-weight: var(--font-rg);
+    line-height: 1.28;
+  }
+}
+
+/* viewport classes */
+@media (max-width: 767px) {
+  .mobile-heading-1,
+  .mobile-heading-1-sb,
+  .mobile-heading-1-lt {
+    font-size: var(--font-size-7);
+    font-weight: var(--font-rg);
+    line-height: 1.28;
+  }
+
+  .mobile-heading-2,
+  .mobile-heading-2-sb,
+  .mobile-heading-2-lt {
+    font-size: var(--font-size-6);
+    font-weight: var(--font-rg);
+    line-height: 1.333;
+  }
+
+  .mobile-heading-3,
+  .mobile-heading-3-sb,
+  .mobile-heading-3-lt {
+    font-size: var(--font-size-6);
+    font-weight: var(--font-rg);
+    line-height: 1.333;
+  }
+
+  .mobile-heading-4,
+  .mobile-heading-4-sb,
+  .mobile-heading-4-lt {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .mobile-body-1,
+  .mobile-body-1-sb {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .mobile-body-2,
+  .mobile-body-2-sb {
+    font-size: var(--font-size-4);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .mobile-body-3,
+  .mobile-body-3-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .mobile-body-4,
+  .mobile-body-4-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .mobile-body-5,
+  .mobile-body-5-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .mobile-interactive-1,
+  .mobile-interactive-1-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .mobile-interactive-2,
+  .mobile-interactive-2-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .mobile-interactive-3,
+  .mobile-interactive-3-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .mobile-z-section-title-1 {
+    font: var(--z-section-title-1);
+  }
+
+  .mobile-z-section-title-2 {
+    font: var(--z-section-title-2);
+  }
+
+  .mobile-z-section-title-3 {
+    font: var(--z-section-title-3);
+  }
+
+  .mobile-z-section-title-4 {
+    font: var(--z-section-title-4);
+  }
+
+  .mobile-z-section-title-5 {
+    font: var(--z-section-title-5);
+  }
+
+  .mobile-z-section-title-6 {
+    font: var(--z-section-title-6);
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1151px) {
+  .tablet-heading-1,
+  .tablet-heading-1-sb,
+  .tablet-heading-1-lt {
+    font-size: var(--font-size-7);
+    font-weight: var(--font-rg);
+    line-height: 1.28;
+  }
+
+  .tablet-heading-2,
+  .tablet-heading-2-sb,
+  .tablet-heading-2-lt {
+    font-size: var(--font-size-6);
+    font-weight: var(--font-rg);
+    line-height: 1.333;
+  }
+
+  .tablet-heading-3,
+  .tablet-heading-3-sb,
+  .tablet-heading-3-lt {
+    font-size: var(--font-size-6);
+    font-weight: var(--font-rg);
+    line-height: 1.333;
+  }
+
+  .tablet-heading-4,
+  .tablet-heading-4-sb,
+  .tablet-heading-4-lt {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .tablet-body-1,
+  .tablet-body-1-sb {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .tablet-body-2,
+  .tablet-body-2-sb {
+    font-size: var(--font-size-4);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .tablet-body-3,
+  .tablet-body-3-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .tablet-body-4,
+  .tablet-body-4-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .tablet-body-5,
+  .tablet-body-5-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .tablet-interactive-1,
+  .tablet-interactive-1-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .tablet-interactive-2,
+  .tablet-interactive-2-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .tablet-interactive-3,
+  .tablet-interactive-3-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .tablet-z-section-title-1 {
+    font: var(--z-section-title-1);
+  }
+
+  .tablet-z-section-title-2 {
+    font: var(--z-section-title-2);
+  }
+
+  .tablet-z-section-title-3 {
+    font: var(--z-section-title-3);
+  }
+
+  .tablet-z-section-title-4 {
+    font: var(--z-section-title-4);
+  }
+
+  .tablet-z-section-title-5 {
+    font: var(--z-section-title-5);
+  }
+
+  .tablet-z-section-title-6 {
+    font: var(--z-section-title-6);
+  }
+}
+
+@media (min-width: 1152px) and (max-width: 1365px) {
+  .desktop-heading-1,
+  .desktop-heading-1-sb,
+  .desktop-heading-1-lt {
+    font-size: var(--font-size-8);
+    font-weight: var(--font-rg);
+    line-height: 1.25;
+  }
+
+  .desktop-heading-2,
+  .desktop-heading-2-sb,
+  .desktop-heading-2-lt {
+    font-size: var(--font-size-7);
+    font-weight: var(--font-rg);
+    line-height: 1.28;
+  }
+
+  .desktop-heading-3,
+  .desktop-heading-3-sb,
+  .desktop-heading-3-lt {
+    font-size: var(--font-size-6);
+    font-weight: var(--font-rg);
+    line-height: 1.333;
+  }
+
+  .desktop-heading-4,
+  .desktop-heading-4-sb,
+  .desktop-heading-4-lt {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .desktop-body-1,
+  .desktop-body-1-sb {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .desktop-body-2,
+  .desktop-body-2-sb {
+    font-size: var(--font-size-4);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .desktop-body-3,
+  .desktop-body-3-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .desktop-body-4,
+  .desktop-body-4-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .desktop-body-5,
+  .desktop-body-5-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .desktop-interactive-1,
+  .desktop-interactive-1-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .desktop-interactive-2,
+  .desktop-interactive-2-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .desktop-interactive-3,
+  .desktop-interactive-3-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .desktop-z-section-title-1 {
+    font: var(--z-section-title-1);
+  }
+
+  .desktop-z-section-title-2 {
+    font: var(--z-section-title-2);
+  }
+
+  .desktop-z-section-title-3 {
+    font: var(--z-section-title-3);
+  }
+
+  .desktop-z-section-title-4 {
+    font: var(--z-section-title-4);
+  }
+
+  .desktop-z-section-title-5 {
+    font: var(--z-section-title-5);
+  }
+
+  .desktop-z-section-title-6 {
+    font: var(--z-section-title-6);
+  }
+}
+
+@media (min-width: 1366px) {
+  .wide-heading-1,
+  .wide-heading-1-sb,
+  .wide-heading-1-lt {
+    font-size: var(--font-size-8);
+    font-weight: var(--font-rg);
+    line-height: 1.25;
+  }
+
+  .wide-heading-2,
+  .wide-heading-2-sb,
+  .wide-heading-2-lt {
+    font-size: var(--font-size-7);
+    font-weight: var(--font-rg);
+    line-height: 1.28;
+  }
+
+  .wide-heading-3,
+  .wide-heading-3-sb,
+  .wide-heading-3-lt {
+    font-size: var(--font-size-6);
+    font-weight: var(--font-rg);
+    line-height: 1.333;
+  }
+
+  .wide-heading-4,
+  .wide-heading-4-sb,
+  .wide-heading-4-lt {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .wide-body-1,
+  .wide-body-1-sb {
+    font-size: var(--font-size-5);
+    font-weight: var(--font-rg);
+    line-height: 1.4;
+  }
+
+  .wide-body-2,
+  .wide-body-2-sb {
+    font-size: var(--font-size-4);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .wide-body-3,
+  .wide-body-3-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .wide-body-4,
+  .wide-body-4-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .wide-body-5,
+  .wide-body-5-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .wide-interactive-1,
+  .wide-interactive-1-sb {
+    font-size: var(--font-size-3);
+    font-weight: var(--font-rg);
+    line-height: 1.5;
+  }
+
+  .wide-interactive-2,
+  .wide-interactive-2-sb {
+    font-size: var(--font-size-2);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.16px;
+    line-height: 1.4;
+  }
+
+  .wide-interactive-3,
+  .wide-interactive-3-sb {
+    font-size: var(--font-size-1);
+    font-weight: var(--font-rg);
+    letter-spacing: 0.32px;
+    line-height: 1.333;
+  }
+
+  .wide-z-section-title-1 {
+    font: var(--z-section-title-1);
+  }
+
+  .wide-z-section-title-2 {
+    font: var(--z-section-title-2);
+  }
+
+  .wide-z-section-title-3 {
+    font: var(--z-section-title-3);
+  }
+
+  .wide-z-section-title-4 {
+    font: var(--z-section-title-4);
+  }
+
+  .wide-z-section-title-5 {
+    font: var(--z-section-title-5);
+  }
+
+  .wide-z-section-title-6 {
+    font: var(--z-section-title-6);
+  }
 }

--- a/src/tokens/typography.css
+++ b/src/tokens/typography.css
@@ -27,40 +27,51 @@
   --font-size-15: 4.75rem; /* 76px */
   --font-size-16: 5.25rem; /* 84px */
   --font-size-17: 5.75rem; /* 92px */
+
+  /* cssprops to use with `font` shorthand property */
+  --z-section-title-1: var(--font-sb) var(--font-size-11) / 0.9166 var(--font-family-serif);
+  --z-section-title-2: var(--font-sb) var(--font-size-10) / 1.1904 var(--font-family-serif);
+  --z-section-title-3: var(--font-sb) var(--font-size-9) / 1.222 var(--font-family-serif);
+  --z-section-title-4: var(--font-sb) var(--font-size-8) / 1.25 var(--font-family-serif);
+  --z-section-title-5: var(--font-sb) var(--font-size-7) / 1.2857 var(--font-family-serif);
+  --z-section-title-6: var(--font-sb) var(--font-size-6) / 1.333 var(--font-family-serif);
 }
 
 /* Typography classes */
 .heading-1,
 .heading-1-sb,
 .heading-1-lt {
-  font-size: var(--font-size-8);
+  font-size: var(--font-size-7);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
-  line-height: 1.25;
+  line-height: 1.28;
 }
 
 .heading-2,
 .heading-2-sb,
 .heading-2-lt {
-  font-size: var(--font-size-7);
+  font-size: var(--font-size-6);
   font-weight: var(--font-rg);
-  letter-spacing: 0;
-  line-height: 1.28;
+  line-height: 1.333;
 }
 
-@media (max-width: 1151px) {
+/* for desktop viewports */
+@media (min-width: 1152px) {
   .heading-1,
   .heading-1-sb,
   .heading-1-lt {
-    font-size: var(--font-size-7);
-    line-height: 1.28;
+    font-size: var(--font-size-8);
+    font-weight: var(--font-rg);
+    letter-spacing: 0;
+    line-height: 1.25;
   }
 
   .heading-2,
   .heading-2-sb,
   .heading-2-lt {
-    font-size: var(--font-size-6);
-    line-height: 1.333;
+    font-size: var(--font-size-7);
+    font-weight: var(--font-rg);
+    letter-spacing: 0;
+    line-height: 1.28;
   }
 }
 
@@ -177,4 +188,29 @@
 .interactive-3-sb,
 .helper-sb {
   font-weight: var(--font-sb);
+}
+
+/* section title */
+.z-section-title-1 {
+  font: var(--z-section-title-1);
+}
+
+.z-section-title-2 {
+  font: var(--z-section-title-2);
+}
+
+.z-section-title-3 {
+  font: var(--z-section-title-3);
+}
+
+.z-section-title-4 {
+  font: var(--z-section-title-4);
+}
+
+.z-section-title-5 {
+  font: var(--z-section-title-5);
+}
+
+.z-section-title-6 {
+  font: var(--z-section-title-6);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "jsxFactory": "h",
     "skipLibCheck": true
   },
-  "include": ["src"],
+  "include": ["src", "docs"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Motivation and Context
This PR adds CSS classes for the new `z-section-title` and viewport based classes also for the other typography classes. The `z-section-title` style is also provided by some CSS custom property to be used with the `font` CSS shorthand (e.g.: `font: var(--z-section-title-1);`).
In addition there are now stories to show typography classes and type scale.

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [x] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

https://www.figma.com/design/JoeEpdjSgHg4UvLFAWTLnA/DS-617-%7C-Titoli-e-link?node-id=9247-84&t=okJfoVZ3jIpwbrm2-4