### PR TITLE
fix: z-modal - remove overflow-y

### DIFF
--- a/src/components/z-modal/index.tsx
+++ b/src/components/z-modal/index.tsx
@@ -1,7 +1,6 @@
 import {Component, Element, Event, EventEmitter, Listen, Method, Prop, h} from "@stencil/core";
 import dialogPolyfill from "dialog-polyfill";
 import {KeyboardCode} from "../../beans";
-import {Breakpoints} from "../../constants/breakpoints";
 
 const FOCUSABLE_ELEMENTS_SELECTOR =
   ':is(button, input, select, textarea, [contenteditable=""], [contenteditable="true"], a[href], [tabindex], summary):not([disabled], [disabled=""], [tabindex="-1"], [aria-hidden="true"], [hidden])';
@@ -77,11 +76,6 @@ export class ZModal {
     }
   }
 
-  private handlePageOverflow(): void {
-    const mobileMediaQuery = window.matchMedia(`(max-width: ${Breakpoints.MOBILE}px)`);
-    document.body.style["overflow-y"] = mobileMediaQuery.matches ? "hidden" : "";
-  }
-
   componentDidLoad(): void {
     if (typeof window.HTMLDialogElement !== "function") {
       /* workaround to fix `registerDialog` in test environment:
@@ -95,8 +89,6 @@ export class ZModal {
     } else {
       this.open();
     }
-
-    this.handlePageOverflow();
   }
 
   /** open modal */


### PR DESCRIPTION
# Fix - z-modal - remove overflow-y

When opening the modal an overflow-y: hidden; was added to the body in mobile view. This caused a problem when closing the modal because the overflow was not removed and the page did not scroll anymore.
The overflow was added in a previous pr to fix the scrolling of the body under the modal when it was open.

## Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
