### PR TITLE
Fix - z-file-upload

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,4 @@ loader
 internals
 stencil.config.ts
 **/*.js
-**/*.spec.ts
 **/*.e2e.ts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -140,6 +140,12 @@
         ],
         "no-duplicate-imports": "off"
       }
+    },
+    {
+      "files": ["*.spec.ts"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off"
+      }
     }
   ]
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -772,7 +772,7 @@ export namespace Components {
          */
         "fileMaxSize"?: number;
         /**
-          * get array of uploaded files
+          * Get the list of uploaded files
          */
         "getFiles": () => Promise<File[]>;
         /**
@@ -780,11 +780,15 @@ export namespace Components {
          */
         "hasFileSection"?: boolean;
         /**
+          * Value to set on the file input's `name` attribute (for use with forms)
+         */
+        "inputName"?: string;
+        /**
           * Title
          */
         "mainTitle"?: string;
         /**
-          * remove file from the array
+          * Remove a previously uploaded file
          */
         "removeFile": (fileName: string) => Promise<void>;
         /**
@@ -4399,6 +4403,10 @@ declare namespace LocalJSX {
           * uploaded files history rendering
          */
         "hasFileSection"?: boolean;
+        /**
+          * Value to set on the file input's `name` attribute (for use with forms)
+         */
+        "inputName"?: string;
         /**
           * Title
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,9 +7,11 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { AccordionVariant, AvatarSize, BookCardDeprecatedVariant, BookCardTag, BookCardVariant, BreadcrumbHomepageVariant, BreadcrumbPath, BreadcrumbPathStyle, ButtonSize, ButtonType, ButtonVariant, CardVariant, CarouselArrowsPosition, CarouselProgressMode, ComboItem, ControlSize, CoverHeroContentPosition, CoverHeroVariant, DictionaryData, DividerOrientation, DividerSize, ExpandableListButtonAlign, ExpandableListStyle, InfoRevealPosition, InputStatus, InputType, LabelPosition, ListDividerType, ListSize, ListType, NavigationTabsOrientation, NavigationTabsSize, NotificationType, OffCanvasVariant, PopoverPosition, SearchbarItem, SelectItem, SkipToContentLink, SortDirection, ThemeVariant, ToastNotification, ToastNotificationPosition, ToastNotificationTransition, TransitionDirection, VisibilityCondition, ZAriaAlertMode, ZChipType, ZDatePickerMode, ZFileUploadType, ZRangePickerMode, ZSectionTitleDividerPosition } from "./beans";
 import { AlertType, LicenseType } from "./beans/index";
+import { ZFileUploadError } from "./components/file-upload/z-file-upload/index";
 import { ListItem } from "./beans/index.js";
 export { AccordionVariant, AvatarSize, BookCardDeprecatedVariant, BookCardTag, BookCardVariant, BreadcrumbHomepageVariant, BreadcrumbPath, BreadcrumbPathStyle, ButtonSize, ButtonType, ButtonVariant, CardVariant, CarouselArrowsPosition, CarouselProgressMode, ComboItem, ControlSize, CoverHeroContentPosition, CoverHeroVariant, DictionaryData, DividerOrientation, DividerSize, ExpandableListButtonAlign, ExpandableListStyle, InfoRevealPosition, InputStatus, InputType, LabelPosition, ListDividerType, ListSize, ListType, NavigationTabsOrientation, NavigationTabsSize, NotificationType, OffCanvasVariant, PopoverPosition, SearchbarItem, SelectItem, SkipToContentLink, SortDirection, ThemeVariant, ToastNotification, ToastNotificationPosition, ToastNotificationTransition, TransitionDirection, VisibilityCondition, ZAriaAlertMode, ZChipType, ZDatePickerMode, ZFileUploadType, ZRangePickerMode, ZSectionTitleDividerPosition } from "./beans";
 export { AlertType, LicenseType } from "./beans/index";
+export { ZFileUploadError } from "./components/file-upload/z-file-upload/index";
 export { ListItem } from "./beans/index.js";
 export namespace Components {
     /**
@@ -791,6 +793,10 @@ export namespace Components {
           * Remove a previously uploaded file
          */
         "removeFile": (fileName: string) => Promise<void>;
+        /**
+          * Whether to show errors in the internal modal or leave the handling to the app. Errors will still be emitted.
+         */
+        "showErrors": boolean;
         /**
           * Prop indicating the file upload type - can be default or dragdrop
          */
@@ -2721,7 +2727,8 @@ declare global {
         new (): HTMLZFileElement;
     };
     interface HTMLZFileUploadElementEventMap {
-        "fileInput": any;
+        "fileInput": File;
+        "fileError": {file: string; errors: ZFileUploadError[]};
     }
     interface HTMLZFileUploadElement extends Components.ZFileUpload, HTMLStencilElement {
         addEventListener<K extends keyof HTMLZFileUploadElementEventMap>(type: K, listener: (this: HTMLZFileUploadElement, ev: ZFileUploadCustomEvent<HTMLZFileUploadElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4412,9 +4419,17 @@ declare namespace LocalJSX {
          */
         "mainTitle"?: string;
         /**
+          * Emits an array of error messages related to one or more files not allowed. Emitted when some file is dropped or selected.
+         */
+        "onFileError"?: (event: ZFileUploadCustomEvent<{file: string; errors: ZFileUploadError[]}>) => void;
+        /**
           * Emitted when user select one or more files
          */
-        "onFileInput"?: (event: ZFileUploadCustomEvent<any>) => void;
+        "onFileInput"?: (event: ZFileUploadCustomEvent<File>) => void;
+        /**
+          * Whether to show errors in the internal modal or leave the handling to the app. Errors will still be emitted.
+         */
+        "showErrors"?: boolean;
         /**
           * Prop indicating the file upload type - can be default or dragdrop
          */

--- a/src/components/deprecated/z-book-card-deprecated/index.spec.ts
+++ b/src/components/deprecated/z-book-card-deprecated/index.spec.ts
@@ -677,7 +677,7 @@ describe("Suite test ZBookCard", () => {
   });
 });
 
-const mockMatchMedia = (matches: boolean = false) => {
+const mockMatchMedia = (matches = false) => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: jest.fn().mockImplementation((query) => ({

--- a/src/components/file-upload/z-dragdrop-area/index.spec.ts
+++ b/src/components/file-upload/z-dragdrop-area/index.spec.ts
@@ -11,14 +11,10 @@ describe("Suite test ZDragdropArea", () => {
     expect(page.root).toEqualHtml(`
       <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
         <mock:shadow-root>
-          <div class="dragdrop" tabindex="0">
-            <div class="dragover-container">
-              <div class="dragover-message">
-                <span class="body-2-sb">Rilascia i file in questa area per allegarli.</span>
-              </div>
-            </div>
-            <slot></slot>
+          <div class="dragover-container">
+            <z-button>Rilascia i file in questa area per allegarli.</z-button>
           </div>
+          <slot></slot>
         </mock:shadow-root>
       </z-dragdrop-area>
     `);
@@ -36,14 +32,10 @@ describe("Suite test ZDragdropArea", () => {
     expect(page.root).toEqualHtml(`
       <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
         <mock:shadow-root>
-          <div class="dragdrop" tabindex="0">
-            <div class="dragover-container">
-              <div class="dragover-message">
-                <span class="body-2-sb">Rilascia i file in questa area per allegarli.</span>
-              </div>
-            </div>
-            <slot></slot>
+          <div class="dragover-container">
+            <z-button>Rilascia i file in questa area per allegarli.</z-button>
           </div>
+          <slot></slot>
         </mock:shadow-root>
         <span slot="description">
           Vuoi allegare un file per chiarire meglio la tua richiesta?

--- a/src/components/file-upload/z-dragdrop-area/index.spec.ts
+++ b/src/components/file-upload/z-dragdrop-area/index.spec.ts
@@ -1,5 +1,4 @@
 import {newSpecPage} from "@stencil/core/testing";
-
 import {ZDragdropArea} from "./index";
 
 describe("Suite test ZDragdropArea", () => {
@@ -10,7 +9,7 @@ describe("Suite test ZDragdropArea", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <z-dragdrop-area  drag-and-drop-label="Rilascia i file in questa area per allegarli.\">
+      <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
         <mock:shadow-root>
           <div class="dragdrop" tabindex="0">
             <div class="dragover-container">
@@ -29,10 +28,9 @@ describe("Suite test ZDragdropArea", () => {
     const page = await newSpecPage({
       components: [ZDragdropArea],
       html: `<z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
-              <span slot="description">Vuoi allegare un file per chiarire meglio la tua richiesta?</span>
-              <span slot="file-format">Puoi allegare file nei formati PDF, PNG, JPG, TIFF, DOC, per un
-                  massimo di 50Mb di peso.</span>
-             </z-dragdrop-area>`,
+        <span slot="description">Vuoi allegare un file per chiarire meglio la tua richiesta?</span>
+        <span slot="file-format">Puoi allegare file nei formati PDF, PNG, JPG, TIFF, DOC, per un massimo di 50Mb di peso.</span>
+      </z-dragdrop-area>`,
     });
 
     expect(page.root).toEqualHtml(`

--- a/src/components/file-upload/z-dragdrop-area/index.tsx
+++ b/src/components/file-upload/z-dragdrop-area/index.tsx
@@ -1,4 +1,4 @@
-import {Component, Event, EventEmitter, Prop, h} from "@stencil/core";
+import {Component, Event, EventEmitter, Host, Prop, State, h} from "@stencil/core";
 
 @Component({
   tag: "z-dragdrop-area",
@@ -10,50 +10,40 @@ export class ZDragdropArea {
   @Prop()
   dragAndDropLabel: string;
 
+  /** State that indicates if the user is dragging a file over the drag & drop area */
+  @State()
+  dragging = false;
+
   /** Emitted when user drop one or more files */
   @Event()
   fileDropped: EventEmitter;
 
-  private fileDroppedHandler(files: FileList): void {
-    this.fileDropped.emit(files);
+  private onDrop(e: DragEvent): void {
+    e.preventDefault();
+    this.dragging = false;
+    if (e.dataTransfer.files.length) {
+      this.fileDropped.emit(e.dataTransfer.files);
+    }
   }
 
-  private dragDropContainer: HTMLDivElement;
-
-  private renderOnDragOverMessage(): HTMLDivElement {
+  render(): HTMLZDragdropAreaElement {
     return (
-      <div class="dragover-container">
-        <div class="dragover-message">
-          <span class="body-2-sb">{this.dragAndDropLabel}</span>
-        </div>
-      </div>
-    );
-  }
-
-  render(): HTMLDivElement {
-    return (
-      <div
-        tabIndex={0}
-        ref={(val) => (this.dragDropContainer = val)}
-        class="dragdrop"
+      <Host
+        class={{dragover: this.dragging}}
         onDragOver={(e) => {
           e.preventDefault();
-          this.dragDropContainer.classList.add("dragover");
+          this.dragging = true;
         }}
         onDragLeave={() => {
-          this.dragDropContainer.classList.remove("dragover");
+          this.dragging = false;
         }}
-        onDrop={(e) => {
-          e.preventDefault();
-          if (e.dataTransfer.files.length) {
-            this.dragDropContainer.classList.remove("dragover");
-            this.fileDroppedHandler(e.dataTransfer.files);
-          }
-        }}
+        onDrop={this.onDrop.bind(this)}
       >
-        {this.renderOnDragOverMessage()}
+        <div class="dragover-container">
+          <z-button>{this.dragAndDropLabel}</z-button>
+        </div>
         <slot />
-      </div>
+      </Host>
     );
   }
 }

--- a/src/components/file-upload/z-dragdrop-area/readme.md
+++ b/src/components/file-upload/z-dragdrop-area/readme.md
@@ -23,9 +23,15 @@
 
  - [z-file-upload](../z-file-upload)
 
+### Depends on
+
+- [z-button](../../z-button)
+
 ### Graph
 ```mermaid
 graph TD;
+  z-dragdrop-area --> z-button
+  z-button --> z-icon
   z-file-upload --> z-dragdrop-area
   style z-dragdrop-area fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/file-upload/z-dragdrop-area/styles.css
+++ b/src/components/file-upload/z-dragdrop-area/styles.css
@@ -1,12 +1,54 @@
 :host {
   position: relative;
   display: flex;
-  height: 220px;
+  max-width: 100%;
+  height: 242px;
   flex-direction: column;
   align-items: center;
   padding: calc(var(--space-unit) * 3);
-  border: var(--border-size-medium) dashed var(--color-active-surface);
   background-color: var(--color-surface02);
+  background-image: repeating-linear-gradient(
+      0deg,
+      var(--color-active-surface),
+      var(--color-active-surface) 12px,
+      transparent 12px,
+      transparent 21px,
+      var(--color-active-surface) 21px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      var(--color-active-surface),
+      var(--color-active-surface) 12px,
+      transparent 12px,
+      transparent 21px,
+      var(--color-active-surface) 21px
+    ),
+    repeating-linear-gradient(
+      var(--color-active-surface),
+      var(--color-active-surface) 12px,
+      transparent 12px,
+      transparent 21px,
+      var(--color-active-surface) 21px
+    ),
+    repeating-linear-gradient(
+      270deg,
+      var(--color-active-surface),
+      var(--color-active-surface) 12px,
+      transparent 12px,
+      transparent 21px,
+      var(--color-active-surface) 21px
+    );
+  background-position:
+    0 0,
+    0 0,
+    100% 0,
+    0 100%;
+  background-repeat: no-repeat;
+  background-size:
+    2px 100%,
+    100% 2px,
+    2px 100%,
+    100% 2px;
   border-radius: var(--border-radius-small);
   color: var(--color-default-text);
   font-family: var(--font-family-sans);

--- a/src/components/file-upload/z-dragdrop-area/styles.css
+++ b/src/components/file-upload/z-dragdrop-area/styles.css
@@ -1,42 +1,40 @@
 :host {
   position: relative;
   display: flex;
+  width: 772px;
   max-width: 100%;
-  height: 242px;
+  height: 232px;
   flex-direction: column;
   align-items: center;
   padding: calc(var(--space-unit) * 3);
   background-color: var(--color-surface02);
   background-image: repeating-linear-gradient(
       0deg,
-      var(--color-active-surface),
-      var(--color-active-surface) 12px,
+      var(--color-surface03),
+      var(--color-surface03) 12px,
       transparent 12px,
-      transparent 21px,
-      var(--color-active-surface) 21px
+      transparent 20px
     ),
     repeating-linear-gradient(
       90deg,
-      var(--color-active-surface),
-      var(--color-active-surface) 12px,
+      var(--color-surface03),
+      var(--color-surface03) 12px,
       transparent 12px,
-      transparent 21px,
-      var(--color-active-surface) 21px
+      transparent 20px
     ),
     repeating-linear-gradient(
-      var(--color-active-surface),
-      var(--color-active-surface) 12px,
+      180deg,
+      var(--color-surface03),
+      var(--color-surface03) 12px,
       transparent 12px,
-      transparent 21px,
-      var(--color-active-surface) 21px
+      transparent 20px
     ),
     repeating-linear-gradient(
       270deg,
-      var(--color-active-surface),
-      var(--color-active-surface) 12px,
+      var(--color-surface03),
+      var(--color-surface03) 12px,
       transparent 12px,
-      transparent 21px,
-      var(--color-active-surface) 21px
+      transparent 20px
     );
   background-position:
     0 0,

--- a/src/components/file-upload/z-dragdrop-area/styles.css
+++ b/src/components/file-upload/z-dragdrop-area/styles.css
@@ -1,39 +1,31 @@
 :host {
+  position: relative;
+  display: flex;
+  height: 220px;
+  flex-direction: column;
+  align-items: center;
+  padding: calc(var(--space-unit) * 3);
+  border: var(--border-size-medium) dashed var(--color-active-surface);
+  background-color: var(--color-surface02);
+  border-radius: var(--border-radius-small);
+  color: var(--color-default-text);
   font-family: var(--font-family-sans);
   font-weight: var(--font-rg);
 }
 
-:host > .dragdrop {
-  position: relative;
-  display: flex;
-  height: 228px;
-  flex-direction: column;
-  padding: calc(var(--space-unit) * 2);
-  border-color: var(--color-surface04);
-  background-color: var(--color-background);
-
-  /* Native CSS properties don't support the customization of border-style.
-  Therefore, we use a trick with an SVG image inside background-image property.
-  The SVG features give us the ability to change the distance between dashed lines, set custom pattern, add dash offset or even change a line cap.
-  Generated SVG image is vector and it fills width and height of elements by 100%, so it doesn't matter what size elements have. */
-  background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='2' ry='2' stroke='%23CACCCEFF' stroke-width='2' stroke-dasharray='15%2c 10%2c 14%2c 11' stroke-dashoffset='3' stroke-linecap='square'/%3e%3c/svg%3e");
-  border-radius: 2px;
-  color: var(--color-default-text);
-}
-
-:host > .dragdrop:focus-visible {
-  box-shadow: var(--shadow-focus-primary);
-  outline: none !important;
+:host,
+* {
+  box-sizing: border-box;
 }
 
 /* https://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element */
-:host > .dragdrop.dragover * {
+:host(.dragover) * {
   pointer-events: none;
 }
 
-:host > .dragdrop .dragover-container {
+.dragover-container {
   position: absolute;
-  z-index: 10;
+  z-index: 1;
   top: 0;
   left: 0;
   display: none;
@@ -43,13 +35,7 @@
   box-shadow: var(--shadow-focus-primary);
 }
 
-:host > .dragdrop .dragover-container .dragover-message {
-  padding: 10px 28px;
-  background-color: var(--color-primary01);
-  color: var(--color-text-inverse);
-}
-
-:host > .dragdrop.dragover .dragover-container {
+:host(.dragover) .dragover-container {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/file-upload/z-file-upload/index.spec.ts
+++ b/src/components/file-upload/z-file-upload/index.spec.ts
@@ -7,42 +7,40 @@ describe("Suite test ZFileUpload", () => {
     const page = await newSpecPage({
       components: [ZFileUpload],
       html: `<z-file-upload type="default"
-                            variant="primary"
-                            main-title="Allega un file"
-                            description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
-                            accepted-format= ".pdf, .doc, .tiff, .png, .jpg, .jpeg"
-                            file-max-size="50">>
-             </z-file-upload>`,
+        variant="primary"
+        main-title="Allega un file"
+        description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
+        accepted-format= ".pdf, .doc, .tiff, .png, .jpg, .jpeg"
+        file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
     <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="default" variant="primary">
       <mock:shadow-root>
-       <div class="container default">
-         <span id="title">
-           Allega un file
-         </span>
-         <span class="body-3-sb">
-           Vuoi allegare un file per chiarire meglio la tua richiesta?
-         </span>
-         <span class="body-3">
-           Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
-         </span>
-         <section class="files-container hidden">
-          <span class="heading-4-sb">
-            File appena caricati
+        <div class="container default">
+          <span id="title">
+            Allega un file
           </span>
-          <div class="files-wrapper">
-            <slot name="files"></slot>
-          </div>
-          <z-divider size="medium"></z-divider>
-         </section>
-         <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" id="file-elem" multiple="" type="file">
-         <z-button icon="upload" id="fileSelect">
-           allega
-         </z-button>
-       </div>
+          <span class="body-3-sb">
+            Vuoi allegare un file per chiarire meglio la tua richiesta?
+          </span>
+          <span class="body-3">
+            Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
+          </span>
+          <section class="files-container hidden">
+            <span class="heading-4-sb">
+              File appena caricati
+            </span>
+            <div class="files-wrapper">
+              <slot name="files"></slot>
+            </div>
+            <z-divider size="medium"></z-divider>
+          </section>
+          <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" type="file">
+          <z-button icon="upload" id="fileSelect">
+            allega
+          </z-button>
+        </div>
       </mock:shadow-root>
-      &gt;
     </z-file-upload>`);
   });
 
@@ -50,46 +48,46 @@ describe("Suite test ZFileUpload", () => {
     const page = await newSpecPage({
       components: [ZFileUpload],
       html: `<z-file-upload type="dragdrop"
-                            main-title="Allega un file"
-                            description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
-                            accepted-format= ".pdf, .doc, .tiff, .png, .jpg, .jpeg"
-                            file-max-size="50">>
-             </z-file-upload>`,
+        main-title="Allega un file"
+        description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
+        accepted-format= ".pdf, .doc, .tiff, .png, .jpg, .jpeg"
+        file-max-size="50">
+      </z-file-upload>`,
     });
     expect(page.root)
-      .toEqualHtml(`     <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="dragdrop">
-       <mock:shadow-root>
-       <div class="container dragdrop">
-         <span id="title">
-           Allega un file
-         </span>
-         <section class="files-container hidden">
-          <span class="heading-4-sb">
-            File appena caricati
+      .toEqualHtml(`<z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="dragdrop">
+        <mock:shadow-root>
+        <div class="container dragdrop">
+          <span id="title">
+            Allega un file
           </span>
-          <div class="files-wrapper">
-            <slot name="files"></slot>
-          </div>
-          <z-divider size="medium"></z-divider>
-         </section>
-         <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
-           <div class="text-container">
-             <span class="body-1">
-               Vuoi allegare un file per chiarire meglio la tua richiesta?
-             </span>
-             <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" id="file-elem" multiple="" type="file">
-             <span class="body-1 upload-link-text">
-               <span class="body-1-sb upload-link" tabindex="0">
-                 Carica
-               </span>
-               o trascina dal tuo computer
-             </span>
-             <span class="body-3">
-               Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
-             </span>
-           </div>
-         </z-dragdrop-area>
-       </div>
+          <section class="files-container hidden">
+            <span class="heading-4-sb">
+              File appena caricati
+            </span>
+            <div class="files-wrapper">
+              <slot name="files"></slot>
+            </div>
+            <z-divider size="medium"></z-divider>
+          </section>
+          <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
+            <div class="text-container">
+              <span class="body-1">
+                Vuoi allegare un file per chiarire meglio la tua richiesta?
+              </span>
+              <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" type="file">
+              <span class="body-1 upload-link-text">
+                <span class="body-1-sb upload-link" tabindex="0">
+                  Carica
+                </span>
+                o trascina dal tuo computer
+              </span>
+              <span class="body-3">
+                Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
+              </span>
+            </div>
+          </z-dragdrop-area>
+        </div>
       </mock:shadow-root>
       &gt;
       </z-file-upload>`);
@@ -99,38 +97,37 @@ describe("Suite test ZFileUpload", () => {
     const page = await newSpecPage({
       components: [ZFileUpload],
       html: `<z-file-upload type="default"
-                            variant="primary"
-                            description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
-                            accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg"
-                            upload-btn-label="testo custom"
-                            drag-and-drop-label="drag and drop custom label"
-                            file-max-size="50">>
-             </z-file-upload>`,
+        variant="primary"
+        description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
+        accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg"
+        upload-btn-label="testo custom"
+        drag-and-drop-label="drag and drop custom label"
+        file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
     <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" upload-btn-label="testo custom" drag-and-drop-label="drag and drop custom label" type="default" variant="primary">
-      <mock:shadow-root>
-       <div class="container default">
-         <span class="body-3-sb">
-           Vuoi allegare un file per chiarire meglio la tua richiesta?
-         </span>
-         <span class="body-3">
-           Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
-         </span>
-         <section class="files-container hidden">
-          <span class="heading-4-sb">
-            File appena caricati
+        <mock:shadow-root>
+        <div class="container default">
+          <span class="body-3-sb">
+            Vuoi allegare un file per chiarire meglio la tua richiesta?
           </span>
-          <div class="files-wrapper">
-            <slot name="files"></slot>
-          </div>
-          <z-divider size="medium"></z-divider>
-         </section>
-         <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" id="file-elem" multiple="" type="file">
-         <z-button icon="upload" id="fileSelect">
-           testo custom
-         </z-button>
-       </div>
+          <span class="body-3">
+            Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
+          </span>
+          <section class="files-container hidden">
+            <span class="heading-4-sb">
+              File appena caricati
+            </span>
+            <div class="files-wrapper">
+              <slot name="files"></slot>
+            </div>
+            <z-divider size="medium"></z-divider>
+          </section>
+          <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" type="file">
+          <z-button icon="upload" id="fileSelect">
+            testo custom
+          </z-button>
+        </div>
       </mock:shadow-root>
       &gt;
     </z-file-upload>`);

--- a/src/components/file-upload/z-file-upload/index.spec.ts
+++ b/src/components/file-upload/z-file-upload/index.spec.ts
@@ -14,34 +14,28 @@ describe("Suite test ZFileUpload", () => {
         file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
-    <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="default" variant="primary">
-      <mock:shadow-root>
-        <div class="container default">
-          <span id="title">
-            Allega un file
-          </span>
-          <span class="body-3-sb">
-            Vuoi allegare un file per chiarire meglio la tua richiesta?
-          </span>
-          <span class="body-3">
-            Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
-          </span>
-          <section class="files-container hidden">
-            <span class="heading-4-sb">
-              File appena caricati
-            </span>
-            <div class="files-wrapper">
-              <slot name="files"></slot>
-            </div>
-            <z-divider size="medium"></z-divider>
-          </section>
-          <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" type="file">
-          <z-button icon="upload" id="fileSelect">
-            allega
-          </z-button>
+      <z-file-upload class="default" accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="default" variant="primary">
+        <div class="heading-3-sb" id="title">
+          Allega un file
         </div>
-      </mock:shadow-root>
-    </z-file-upload>`);
+        <span class="body-3-sb" id="description">
+          Vuoi allegare un file per chiarire meglio la tua richiesta?
+        </span>
+        <span class="allowed-files-message body-3">
+          Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
+        </span>
+        <section class="files-container hidden">
+          <span class="heading-3-sb uploaded-files-label">
+            File appena caricati
+          </span>
+          <div class="files-wrapper"></div>
+        </section>
+        <z-button icon="upload" id="fileSelect">
+          allega
+        </z-button>
+        <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" name="z-file-upload" type="file">
+      </z-file-upload>
+    `);
   });
 
   it("Test render ZFileUpload dragdrop", async () => {
@@ -51,46 +45,33 @@ describe("Suite test ZFileUpload", () => {
         main-title="Allega un file"
         description="Vuoi allegare un file per chiarire meglio la tua richiesta?"
         accepted-format= ".pdf, .doc, .tiff, .png, .jpg, .jpeg"
-        file-max-size="50">
-      </z-file-upload>`,
+        file-max-size="50"></z-file-upload>`,
     });
-    expect(page.root)
-      .toEqualHtml(`<z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="dragdrop">
-        <mock:shadow-root>
-        <div class="container dragdrop">
-          <span id="title">
-            Allega un file
+    expect(page.root).toEqualHtml(`
+      <z-file-upload class="dragdrop" accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="dragdrop">
+        <div class="heading-3-sb" id="title">Allega un file</div>
+        <section class="files-container hidden">
+          <span class="heading-3-sb uploaded-files-label">
+            File appena caricati
           </span>
-          <section class="files-container hidden">
-            <span class="heading-4-sb">
-              File appena caricati
+          <div class="files-wrapper"></div>
+        </section>
+        <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
+          <div class="text-container">
+            <span class="body-1" id="description">
+              Vuoi allegare un file per chiarire meglio la tua richiesta?
             </span>
-            <div class="files-wrapper">
-              <slot name="files"></slot>
-            </div>
-            <z-divider size="medium"></z-divider>
-          </section>
-          <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
-            <div class="text-container">
-              <span class="body-1">
-                Vuoi allegare un file per chiarire meglio la tua richiesta?
-              </span>
-              <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" type="file">
-              <span class="body-1 upload-link-text">
-                <span class="body-1-sb upload-link" tabindex="0">
-                  Carica
-                </span>
-                o trascina dal tuo computer
-              </span>
-              <span class="body-3">
-                Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
-              </span>
-            </div>
-          </z-dragdrop-area>
-        </div>
-      </mock:shadow-root>
-      &gt;
-      </z-file-upload>`);
+            <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" name="z-file-upload" type="file">
+            <span class="body-1 upload-link-text">
+              <span class="body-1-sb upload-link" tabindex="0">Carica</span> o trascina dal tuo computer
+            </span>
+            <span class="allowed-files-message body-3">
+              Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
+            </span>
+          </div>
+        </z-dragdrop-area>
+      </z-file-upload>
+    `);
   });
 
   it("Test render ZFileUpload with custom label and not main-title", async () => {
@@ -105,31 +86,24 @@ describe("Suite test ZFileUpload", () => {
         file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
-    <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" upload-btn-label="testo custom" drag-and-drop-label="drag and drop custom label" type="default" variant="primary">
-        <mock:shadow-root>
-        <div class="container default">
-          <span class="body-3-sb">
-            Vuoi allegare un file per chiarire meglio la tua richiesta?
+      <z-file-upload class="default" accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" upload-btn-label="testo custom" drag-and-drop-label="drag and drop custom label" type="default" variant="primary">
+        <span class="body-3-sb" id="description">
+          Vuoi allegare un file per chiarire meglio la tua richiesta?
+        </span>
+        <span class="allowed-files-message body-3">
+          Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
+        </span>
+        <section class="files-container hidden">
+          <span class="heading-3-sb uploaded-files-label">
+            File appena caricati
           </span>
-          <span class="body-3">
-            Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
-          </span>
-          <section class="files-container hidden">
-            <span class="heading-4-sb">
-              File appena caricati
-            </span>
-            <div class="files-wrapper">
-              <slot name="files"></slot>
-            </div>
-            <z-divider size="medium"></z-divider>
-          </section>
-          <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" type="file">
-          <z-button icon="upload" id="fileSelect">
-            testo custom
-          </z-button>
-        </div>
-      </mock:shadow-root>
-      &gt;
-    </z-file-upload>`);
+          <div class="files-wrapper"></div>
+        </section>
+        <z-button icon="upload" id="fileSelect">
+          testo custom
+        </z-button>
+        <input accept=".pdf, .doc, .tiff, .png, .jpg, .jpeg" multiple="" name="z-file-upload" type="file">
+      </z-file-upload>
+    `);
   });
 });

--- a/src/components/file-upload/z-file-upload/index.spec.ts
+++ b/src/components/file-upload/z-file-upload/index.spec.ts
@@ -14,7 +14,7 @@ describe("Suite test ZFileUpload", () => {
         file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
-      <z-file-upload class="default" accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="default" variant="primary">
+      <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="default" variant="primary">
         <div class="heading-3-sb" id="title">
           Allega un file
         </div>
@@ -25,9 +25,9 @@ describe("Suite test ZFileUpload", () => {
           Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
         </span>
         <section class="files-container hidden">
-          <span class="heading-3-sb uploaded-files-label">
+          <div class="heading-3-sb uploaded-files-label">
             File appena caricati
-          </span>
+          </div>
           <div class="files-wrapper"></div>
         </section>
         <z-button icon="upload" id="fileSelect">
@@ -48,12 +48,12 @@ describe("Suite test ZFileUpload", () => {
         file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
-      <z-file-upload class="dragdrop" accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="dragdrop">
+      <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" main-title="Allega un file" type="dragdrop">
         <div class="heading-3-sb" id="title">Allega un file</div>
         <section class="files-container hidden">
-          <span class="heading-3-sb uploaded-files-label">
+          <div class="heading-3-sb uploaded-files-label">
             File appena caricati
-          </span>
+          </div>
           <div class="files-wrapper"></div>
         </section>
         <z-dragdrop-area drag-and-drop-label="Rilascia i file in questa area per allegarli.">
@@ -86,7 +86,7 @@ describe("Suite test ZFileUpload", () => {
         file-max-size="50"></z-file-upload>`,
     });
     expect(page.root).toEqualHtml(`
-      <z-file-upload class="default" accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" upload-btn-label="testo custom" drag-and-drop-label="drag and drop custom label" type="default" variant="primary">
+      <z-file-upload accepted-format=".pdf, .doc, .tiff, .png, .jpg, .jpeg" description="Vuoi allegare un file per chiarire meglio la tua richiesta?" file-max-size="50" upload-btn-label="testo custom" drag-and-drop-label="drag and drop custom label" type="default" variant="primary">
         <span class="body-3-sb" id="description">
           Vuoi allegare un file per chiarire meglio la tua richiesta?
         </span>
@@ -94,9 +94,9 @@ describe("Suite test ZFileUpload", () => {
           Puoi allegare file nei formati PDF, DOC, TIFF, PNG, JPG, JPEG per un massimo di 50MB di peso.
         </span>
         <section class="files-container hidden">
-          <span class="heading-3-sb uploaded-files-label">
+          <div class="heading-3-sb uploaded-files-label">
             File appena caricati
-          </span>
+          </div>
           <div class="files-wrapper"></div>
         </section>
         <z-button icon="upload" id="fileSelect">

--- a/src/components/file-upload/z-file-upload/index.stories.ts
+++ b/src/components/file-upload/z-file-upload/index.stories.ts
@@ -56,8 +56,7 @@ export const Default = {
       >
       </z-file-upload>
       <script>
-        let uploaderDefault = document.querySelector("z-file-upload");
-        let fileNumber = 0;
+        fileNumber = 0;
         document.addEventListener("fileInput", (e) => {
           fileNumber++;
           const item = e.detail;
@@ -65,7 +64,7 @@ export const Default = {
           chip.setAttribute("slot", "files");
           chip.setAttribute("file-number", fileNumber);
           chip.setAttribute("file-name", item.name);
-          uploaderDefault.appendChild(chip);
+          document.querySelector("z-file-upload")?.appendChild(chip);
         });
       </script>`,
 } satisfies Story;
@@ -91,14 +90,13 @@ export const Dragdrop = {
       >
       </z-file-upload>
       <script>
-        const uploaderDragdrop = document.querySelector("z-file-upload");
         document.addEventListener("fileInput", (e) => {
           const item = e.detail;
           const chip = document.createElement("Z-FILE");
           chip.setAttribute("slot", "files");
           chip.setAttribute("filetype", item.type);
           chip.setAttribute("file-name", item.name);
-          uploaderDragdrop.appendChild(chip);
+          document.querySelector("z-file-upload")?.appendChild(chip);
         });
       </script>`,
 } satisfies Story;
@@ -140,14 +138,13 @@ export const DragdropEnglish = {
       >
       </z-file-upload>
       <script>
-        const uploaderDragdrop = document.querySelector("z-file-upload");
         document.addEventListener("fileInput", (e) => {
           const item = e.detail;
           const chip = document.createElement("Z-FILE");
           chip.setAttribute("slot", "files");
           chip.setAttribute("filetype", item.type);
           chip.setAttribute("file-name", item.name);
-          uploaderDragdrop.appendChild(chip);
+          document.querySelector("z-file-upload")?.appendChild(chip);
         });
       </script>`,
 } satisfies Story;

--- a/src/components/file-upload/z-file-upload/index.stories.ts
+++ b/src/components/file-upload/z-file-upload/index.stories.ts
@@ -28,6 +28,7 @@ const StoryMeta = {
     description: "Vuoi allegare un file per chiarire meglio la tua richiesta?",
     uploadBtnLabel: "allega",
     hasFileSection: true,
+    showErrors: true,
   },
 } satisfies Meta<ZFileUpload>;
 
@@ -46,6 +47,7 @@ export const Default = {
       </h4>
       <z-file-upload
         type=${ZFileUploadType.DEFAULT}
+        .showErrors=${args.showErrors}
         .hasFileSection=${args.hasFileSection}
         description="${args.description}"
         .buttonVariant=${args.buttonVariant}
@@ -53,8 +55,7 @@ export const Default = {
         .acceptedFormat=${args.acceptedFormat}
         .mainTitle=${args.mainTitle}
         .uploadBtnLabel=${args.uploadBtnLabel}
-      >
-      </z-file-upload>
+      />
       <script>
         fileNumber = 0;
         document.addEventListener("fileInput", (e) => {
@@ -81,14 +82,14 @@ export const Dragdrop = {
       <br />
       <z-file-upload
         type=${ZFileUploadType.DRAGDROP}
+        .showErrors=${args.showErrors}
         .hasFileSection=${args.hasFileSection}
         description="${args.description}"
         .fileMaxSize=${args.fileMaxSize}
         .acceptedFormat=${args.acceptedFormat}
         .mainTitle=${args.mainTitle}
         .dragAndDropLabel=${args.dragAndDropLabel}
-      >
-      </z-file-upload>
+      />
       <script>
         document.addEventListener("fileInput", (e) => {
           const item = e.detail;
@@ -122,6 +123,7 @@ export const DragdropEnglish = {
       <br />
       <z-file-upload
         type=${ZFileUploadType.DRAGDROP}
+        .showErrors=${args.showErrors}
         .hasFileSection=${args.hasFileSection}
         description="${args.description}"
         .fileMaxSize=${args.fileMaxSize}
@@ -135,8 +137,7 @@ export const DragdropEnglish = {
         .errorModalMessage=${args.errorModalMessage}
         .uploadedFilesLabel=${args.uploadedFilesLabel}
         .uploadBtnLabel=${args.uploadBtnLabel}
-      >
-      </z-file-upload>
+      />
       <script>
         document.addEventListener("fileInput", (e) => {
           const item = e.detail;

--- a/src/components/file-upload/z-file-upload/readme.md
+++ b/src/components/file-upload/z-file-upload/readme.md
@@ -5,31 +5,33 @@
 
 ## Properties
 
-| Property                 | Attribute                  | Description                                                            | Type                                                                         | Default                                           |
-| ------------------------ | -------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
-| `acceptedFormat`         | `accepted-format`          | Prop indicating the accepted file type: ex ".pdf, .doc, .jpg"          | `string`                                                                     | `undefined`                                       |
-| `allowedFilesMessage`    | `allowed-files-message`    | allowed file message                                                   | `string`                                                                     | `undefined`                                       |
-| `buttonVariant`          | `button-variant`           | Prop indicating the button variant                                     | `ButtonVariant.PRIMARY \| ButtonVariant.SECONDARY \| ButtonVariant.TERTIARY` | `undefined`                                       |
-| `description`            | `description`              | Description                                                            | `string`                                                                     | `undefined`                                       |
-| `dragAndDropLabel`       | `drag-and-drop-label`      | drag & drop button label                                               | `string`                                                                     | `"Rilascia i file in questa area per allegarli."` |
-| `errorModalMessage`      | `error-modal-message`      | error modal message                                                    | `string`                                                                     | `undefined`                                       |
-| `errorModalTitle`        | `error-modal-title`        | error modal title                                                      | `string`                                                                     | `"Errore di caricamento"`                         |
-| `fileMaxSize`            | `file-max-size`            | Max file dimension in Megabyte                                         | `number`                                                                     | `undefined`                                       |
-| `hasFileSection`         | `has-file-section`         | uploaded files history rendering                                       | `boolean`                                                                    | `true`                                            |
-| `inputName`              | `input-name`               | Value to set on the file input's `name` attribute (for use with forms) | `string`                                                                     | `"z-file-upload"`                                 |
-| `mainTitle`              | `main-title`               | Title                                                                  | `string`                                                                     | `undefined`                                       |
-| `type`                   | `type`                     | Prop indicating the file upload type - can be default or dragdrop      | `ZFileUploadType.DEFAULT \| ZFileUploadType.DRAGDROP`                        | `ZFileUploadType.DEFAULT`                         |
-| `uploadBtnLabel`         | `upload-btn-label`         | upoload button label                                                   | `string`                                                                     | `"allega"`                                        |
-| `uploadClickableMessage` | `upload-clickable-message` | upload clickable message                                               | `string`                                                                     | `"Carica"`                                        |
-| `uploadMessage`          | `upload-message`           | upload message                                                         | `string`                                                                     | `"o trascina dal tuo computer"`                   |
-| `uploadedFilesLabel`     | `uploaded-files-label`     | loaded files label                                                     | `string`                                                                     | `"File appena caricati"`                          |
+| Property                 | Attribute                  | Description                                                                                                  | Type                                                                         | Default                                           |
+| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| `acceptedFormat`         | `accepted-format`          | Prop indicating the accepted file type: ex ".pdf, .doc, .jpg"                                                | `string`                                                                     | `undefined`                                       |
+| `allowedFilesMessage`    | `allowed-files-message`    | allowed file message                                                                                         | `string`                                                                     | `undefined`                                       |
+| `buttonVariant`          | `button-variant`           | Prop indicating the button variant                                                                           | `ButtonVariant.PRIMARY \| ButtonVariant.SECONDARY \| ButtonVariant.TERTIARY` | `undefined`                                       |
+| `description`            | `description`              | Description                                                                                                  | `string`                                                                     | `undefined`                                       |
+| `dragAndDropLabel`       | `drag-and-drop-label`      | drag & drop button label                                                                                     | `string`                                                                     | `"Rilascia i file in questa area per allegarli."` |
+| `errorModalMessage`      | `error-modal-message`      | error modal message                                                                                          | `string`                                                                     | `undefined`                                       |
+| `errorModalTitle`        | `error-modal-title`        | error modal title                                                                                            | `string`                                                                     | `"Errore di caricamento"`                         |
+| `fileMaxSize`            | `file-max-size`            | Max file dimension in Megabyte                                                                               | `number`                                                                     | `undefined`                                       |
+| `hasFileSection`         | `has-file-section`         | uploaded files history rendering                                                                             | `boolean`                                                                    | `true`                                            |
+| `inputName`              | `input-name`               | Value to set on the file input's `name` attribute (for use with forms)                                       | `string`                                                                     | `"z-file-upload"`                                 |
+| `mainTitle`              | `main-title`               | Title                                                                                                        | `string`                                                                     | `undefined`                                       |
+| `showErrors`             | `show-errors`              | Whether to show errors in the internal modal or leave the handling to the app. Errors will still be emitted. | `boolean`                                                                    | `true`                                            |
+| `type`                   | `type`                     | Prop indicating the file upload type - can be default or dragdrop                                            | `ZFileUploadType.DEFAULT \| ZFileUploadType.DRAGDROP`                        | `ZFileUploadType.DEFAULT`                         |
+| `uploadBtnLabel`         | `upload-btn-label`         | upoload button label                                                                                         | `string`                                                                     | `"allega"`                                        |
+| `uploadClickableMessage` | `upload-clickable-message` | upload clickable message                                                                                     | `string`                                                                     | `"Carica"`                                        |
+| `uploadMessage`          | `upload-message`           | upload message                                                                                               | `string`                                                                     | `"o trascina dal tuo computer"`                   |
+| `uploadedFilesLabel`     | `uploaded-files-label`     | loaded files label                                                                                           | `string`                                                                     | `"File appena caricati"`                          |
 
 
 ## Events
 
-| Event       | Description                                | Type               |
-| ----------- | ------------------------------------------ | ------------------ |
-| `fileInput` | Emitted when user select one or more files | `CustomEvent<any>` |
+| Event       | Description                                                                                                               | Type                                                         |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `fileError` | Emits an array of error messages related to one or more files not allowed. Emitted when some file is dropped or selected. | `CustomEvent<{ file: string; errors: ZFileUploadError[]; }>` |
+| `fileInput` | Emitted when user select one or more files                                                                                | `CustomEvent<File>`                                          |
 
 
 ## Methods
@@ -65,7 +67,6 @@ Type: `Promise<void>`
 
 ### Depends on
 
-- [z-divider](../../z-divider)
 - [z-button](../../z-button)
 - [z-dragdrop-area](../z-dragdrop-area)
 - [z-modal](../../z-modal)
@@ -73,11 +74,11 @@ Type: `Promise<void>`
 ### Graph
 ```mermaid
 graph TD;
-  z-file-upload --> z-divider
   z-file-upload --> z-button
   z-file-upload --> z-dragdrop-area
   z-file-upload --> z-modal
   z-button --> z-icon
+  z-dragdrop-area --> z-button
   z-modal --> z-icon
   style z-file-upload fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/file-upload/z-file-upload/readme.md
+++ b/src/components/file-upload/z-file-upload/readme.md
@@ -5,23 +5,24 @@
 
 ## Properties
 
-| Property                 | Attribute                  | Description                                                       | Type                                                                         | Default                                           |
-| ------------------------ | -------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
-| `acceptedFormat`         | `accepted-format`          | Prop indicating the accepted file type: ex ".pdf, .doc, .jpg"     | `string`                                                                     | `undefined`                                       |
-| `allowedFilesMessage`    | `allowed-files-message`    | allowed file message                                              | `string`                                                                     | `undefined`                                       |
-| `buttonVariant`          | `button-variant`           | Prop indicating the button variant                                | `ButtonVariant.PRIMARY \| ButtonVariant.SECONDARY \| ButtonVariant.TERTIARY` | `undefined`                                       |
-| `description`            | `description`              | Description                                                       | `string`                                                                     | `undefined`                                       |
-| `dragAndDropLabel`       | `drag-and-drop-label`      | drag & drop button label                                          | `string`                                                                     | `"Rilascia i file in questa area per allegarli."` |
-| `errorModalMessage`      | `error-modal-message`      | error modal message                                               | `string`                                                                     | `undefined`                                       |
-| `errorModalTitle`        | `error-modal-title`        | error modal title                                                 | `string`                                                                     | `"Errore di caricamento"`                         |
-| `fileMaxSize`            | `file-max-size`            | Max file dimension in Megabyte                                    | `number`                                                                     | `undefined`                                       |
-| `hasFileSection`         | `has-file-section`         | uploaded files history rendering                                  | `boolean`                                                                    | `true`                                            |
-| `mainTitle`              | `main-title`               | Title                                                             | `string`                                                                     | `undefined`                                       |
-| `type`                   | `type`                     | Prop indicating the file upload type - can be default or dragdrop | `ZFileUploadType.DEFAULT \| ZFileUploadType.DRAGDROP`                        | `ZFileUploadType.DEFAULT`                         |
-| `uploadBtnLabel`         | `upload-btn-label`         | upoload button label                                              | `string`                                                                     | `"allega"`                                        |
-| `uploadClickableMessage` | `upload-clickable-message` | upload clickable message                                          | `string`                                                                     | `"Carica"`                                        |
-| `uploadMessage`          | `upload-message`           | upload message                                                    | `string`                                                                     | `"o trascina dal tuo computer"`                   |
-| `uploadedFilesLabel`     | `uploaded-files-label`     | loaded files label                                                | `string`                                                                     | `"File appena caricati"`                          |
+| Property                 | Attribute                  | Description                                                            | Type                                                                         | Default                                           |
+| ------------------------ | -------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| `acceptedFormat`         | `accepted-format`          | Prop indicating the accepted file type: ex ".pdf, .doc, .jpg"          | `string`                                                                     | `undefined`                                       |
+| `allowedFilesMessage`    | `allowed-files-message`    | allowed file message                                                   | `string`                                                                     | `undefined`                                       |
+| `buttonVariant`          | `button-variant`           | Prop indicating the button variant                                     | `ButtonVariant.PRIMARY \| ButtonVariant.SECONDARY \| ButtonVariant.TERTIARY` | `undefined`                                       |
+| `description`            | `description`              | Description                                                            | `string`                                                                     | `undefined`                                       |
+| `dragAndDropLabel`       | `drag-and-drop-label`      | drag & drop button label                                               | `string`                                                                     | `"Rilascia i file in questa area per allegarli."` |
+| `errorModalMessage`      | `error-modal-message`      | error modal message                                                    | `string`                                                                     | `undefined`                                       |
+| `errorModalTitle`        | `error-modal-title`        | error modal title                                                      | `string`                                                                     | `"Errore di caricamento"`                         |
+| `fileMaxSize`            | `file-max-size`            | Max file dimension in Megabyte                                         | `number`                                                                     | `undefined`                                       |
+| `hasFileSection`         | `has-file-section`         | uploaded files history rendering                                       | `boolean`                                                                    | `true`                                            |
+| `inputName`              | `input-name`               | Value to set on the file input's `name` attribute (for use with forms) | `string`                                                                     | `"z-file-upload"`                                 |
+| `mainTitle`              | `main-title`               | Title                                                                  | `string`                                                                     | `undefined`                                       |
+| `type`                   | `type`                     | Prop indicating the file upload type - can be default or dragdrop      | `ZFileUploadType.DEFAULT \| ZFileUploadType.DRAGDROP`                        | `ZFileUploadType.DEFAULT`                         |
+| `uploadBtnLabel`         | `upload-btn-label`         | upoload button label                                                   | `string`                                                                     | `"allega"`                                        |
+| `uploadClickableMessage` | `upload-clickable-message` | upload clickable message                                               | `string`                                                                     | `"Carica"`                                        |
+| `uploadMessage`          | `upload-message`           | upload message                                                         | `string`                                                                     | `"o trascina dal tuo computer"`                   |
+| `uploadedFilesLabel`     | `uploaded-files-label`     | loaded files label                                                     | `string`                                                                     | `"File appena caricati"`                          |
 
 
 ## Events
@@ -35,7 +36,7 @@
 
 ### `getFiles() => Promise<File[]>`
 
-get array of uploaded files
+Get the list of uploaded files
 
 #### Returns
 
@@ -45,7 +46,7 @@ Type: `Promise<File[]>`
 
 ### `removeFile(fileName: string) => Promise<void>`
 
-remove file from the array
+Remove a previously uploaded file
 
 #### Parameters
 

--- a/src/components/file-upload/z-file-upload/styles.css
+++ b/src/components/file-upload/z-file-upload/styles.css
@@ -9,9 +9,10 @@
 
 :host .modal-wrapper {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   justify-content: center;
   padding: calc(var(--space-unit) * 2);
+  row-gap: calc(var(--space-unit) * 2);
 }
 
 :host .modal-wrapper > .files-wrapper {
@@ -25,15 +26,13 @@
   display: flex;
   flex-direction: column;
   margin: auto;
-}
-
-:host .text-container .body-1 {
   text-align: center;
 }
 
 :host .text-container .upload-link {
   color: var(--color-text-link-blue);
   cursor: pointer;
+  text-decoration: underline;
 }
 
 :host .text-container .upload-link:focus-visible {
@@ -49,12 +48,16 @@
   display: none;
 }
 
-:host #title + * {
-  margin-top: var(--space-unit);
+:host #title:not(:last-child) {
+  margin-bottom: var(--space-unit);
 }
 
 :host > * + z-button {
   margin-top: calc(var(--space-unit) * 3);
+}
+
+:host > .files-container {
+  margin-bottom: calc(var(--space-unit) * 3);
 }
 
 :host > .files-container.hidden {
@@ -63,12 +66,12 @@
 
 :host > .files-container > .uploaded-files-label {
   display: inline-block;
-  margin: calc(var(--space-unit) * 3) 0;
+  margin: calc(var(--space-unit) * 2) 0;
 }
 
 :host([type="dragdrop"]) > .files-container > .uploaded-files-label {
   margin-top: 0;
-  margin-bottom: calc(var(--space-unit) * 3);
+  margin-bottom: calc(var(--space-unit) * 2);
 }
 
 :host > .files-container > .files-wrapper {
@@ -76,15 +79,6 @@
   flex-wrap: wrap;
   column-gap: calc(var(--space-unit) * 2);
   row-gap: calc(var(--space-unit) * 2);
-}
-
-:host > .files-container > z-divider {
-  margin-top: calc(var(--space-unit) * 3);
-  margin-bottom: 0;
-}
-
-:host([type="dragdrop"]) > .files-container > z-divider {
-  margin: calc(var(--space-unit) * 3) 0;
 }
 
 /* Tablet breakpoint */

--- a/src/components/file-upload/z-file-upload/styles.css
+++ b/src/components/file-upload/z-file-upload/styles.css
@@ -1,12 +1,10 @@
 :host {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   color: var(--color-default-text);
   font-family: var(--font-family-sans);
   font-weight: var(--font-rg);
-}
-
-:host > .container {
-  display: flex;
-  flex-direction: column;
 }
 
 :host .modal-wrapper {
@@ -47,68 +45,50 @@
   margin-bottom: var(--space-unit);
 }
 
-input#file-elem {
+:host input[type="file"] {
   display: none;
 }
 
-#title {
-  display: inline-block;
-  margin: calc(var(--space-unit) * 2.5) 0 calc(var(--space-unit) * 4);
-  font-size: calc(var(--space-unit) * 3);
-  font-weight: var(--font-sb);
+:host #title + * {
+  margin-top: var(--space-unit);
 }
 
-:host > .container > z-button {
-  display: inline-block;
+:host > * + z-button {
   margin-top: calc(var(--space-unit) * 3);
 }
 
-:host > .container > .files-container.hidden {
+:host > .files-container.hidden {
   display: none;
 }
 
-:host > .container > .files-container > .heading-4-sb {
+:host > .files-container > .uploaded-files-label {
   display: inline-block;
   margin: calc(var(--space-unit) * 3) 0;
-  font-size: calc(var(--space-unit) * 2);
-  font-weight: var(--font-sb);
 }
 
-:host([type="dragdrop"]) > .container > .files-container > .heading-4-sb {
+:host([type="dragdrop"]) > .files-container > .uploaded-files-label {
   margin-top: 0;
   margin-bottom: calc(var(--space-unit) * 3);
 }
 
-:host > .container > .files-container > .files-wrapper {
+:host > .files-container > .files-wrapper {
   display: flex;
   flex-wrap: wrap;
   column-gap: calc(var(--space-unit) * 2);
   row-gap: calc(var(--space-unit) * 2);
 }
 
-:host > .container > .files-container > z-divider {
+:host > .files-container > z-divider {
   margin-top: calc(var(--space-unit) * 3);
   margin-bottom: 0;
 }
 
-:host([type="dragdrop"]) > .container > .files-container > z-divider {
+:host([type="dragdrop"]) > .files-container > z-divider {
   margin: calc(var(--space-unit) * 3) 0;
 }
 
-:host .error-message {
-  font-size: 14px;
-  font-weight: 400;
-  letter-spacing: 0.16%;
-  line-height: 20px;
-  text-align: left;
-}
-
-:host .error-message > .file-name {
-  font-weight: 600;
-}
-
 /* Tablet breakpoint */
-@media only screen and (min-width: 768px) {
+@media (min-width: 768px) {
   :host > .container > z-button {
     align-self: flex-start;
   }
@@ -118,7 +98,7 @@ input#file-elem {
   }
 }
 
-@media only screen and (min-width: 1152px) {
+@media (min-width: 1152px) {
   :host .modal-wrapper {
     padding: calc(var(--space-unit) * 4);
   }

--- a/src/components/file-upload/z-file-upload/styles.css
+++ b/src/components/file-upload/z-file-upload/styles.css
@@ -48,16 +48,14 @@
   display: none;
 }
 
-:host #title:not(:last-child) {
-  margin-bottom: var(--space-unit);
+:host #title + #description {
+  margin-top: var(--space-unit);
 }
 
-:host > * + z-button {
+:host > * + z-button,
+:host > .files-container + *,
+:host > .files-container:not(:first-child) {
   margin-top: calc(var(--space-unit) * 3);
-}
-
-:host > .files-container {
-  margin-bottom: calc(var(--space-unit) * 3);
 }
 
 :host > .files-container.hidden {
@@ -65,12 +63,6 @@
 }
 
 :host > .files-container > .uploaded-files-label {
-  display: inline-block;
-  margin: calc(var(--space-unit) * 2) 0;
-}
-
-:host([type="dragdrop"]) > .files-container > .uploaded-files-label {
-  margin-top: 0;
   margin-bottom: calc(var(--space-unit) * 2);
 }
 

--- a/src/components/file-upload/z-file-upload/test.e2e.ts
+++ b/src/components/file-upload/z-file-upload/test.e2e.ts
@@ -19,7 +19,7 @@ describe("z-file-upload test end2end", () => {
     await page.waitForChanges();
 
     // simulate upload of file
-    const button = await page.find("z-file-upload >>> div z-button >>> button");
+    const button = await page.find("z-file-upload z-button button");
     button.click();
     const fileChooser = await page.waitForFileChooser();
 
@@ -46,7 +46,7 @@ describe("z-file-upload test end2end", () => {
     const zfu = await page.find("z-file-upload");
 
     // simulate upload of file
-    const button = await page.find("z-file-upload >>> div z-button >>> button");
+    const button = await page.find("z-file-upload z-button button");
     button.click();
     const fileChooser = await page.waitForFileChooser();
 

--- a/src/components/z-button/readme.md
+++ b/src/components/z-button/readme.md
@@ -38,6 +38,7 @@
  - [z-app-header-deprecated](../deprecated/z-app-header-deprecated)
  - [z-book-card](../book-card/z-book-card)
  - [z-carousel](../z-carousel)
+ - [z-dragdrop-area](../file-upload/z-dragdrop-area)
  - [z-file-upload](../file-upload/z-file-upload)
  - [z-myz-card-dictionary](../../snowflakes/myz/card/z-myz-card-dictionary)
  - [z-pagination](../z-pagination)
@@ -58,6 +59,7 @@ graph TD;
   z-app-header-deprecated --> z-button
   z-book-card --> z-button
   z-carousel --> z-button
+  z-dragdrop-area --> z-button
   z-file-upload --> z-button
   z-myz-card-dictionary --> z-button
   z-pagination --> z-button

--- a/src/components/z-divider/readme.md
+++ b/src/components/z-divider/readme.md
@@ -17,7 +17,6 @@
 ### Used by
 
  - [z-breadcrumb](../z-breadcrumb)
- - [z-file-upload](../file-upload/z-file-upload)
  - [z-list-element](../list/z-list-element)
  - [z-list-group](../list/z-list-group)
  - [z-section-title](../z-section-title)
@@ -26,7 +25,6 @@
 ```mermaid
 graph TD;
   z-breadcrumb --> z-divider
-  z-file-upload --> z-divider
   z-list-element --> z-divider
   z-list-group --> z-divider
   z-section-title --> z-divider

--- a/src/components/z-searchbar/index.spec.ts
+++ b/src/components/z-searchbar/index.spec.ts
@@ -383,7 +383,7 @@ const resultsItems = () => `
     </z-list-element>
   </z-list-group>`;
 
-const searchHelper = (divider: boolean = true) => `
+const searchHelper = (divider = true) => `
   <z-list-element
     role="option"
     ${divider ? `dividerType="element"` : ``}

--- a/src/utils/storybook-utils.ts
+++ b/src/utils/storybook-utils.ts
@@ -145,7 +145,7 @@ export function getThemeTokenValue(themeClass: string, token: `--${string}`): st
 
   return value instanceof CSSVariableReferenceValue
     ? getComputedStyle(document.documentElement).getPropertyValue(value.variable)
-    : (value?.toString() ?? undefined);
+    : value?.toString() ?? undefined;
 }
 
 /**

--- a/src/utils/storybook-utils.ts
+++ b/src/utils/storybook-utils.ts
@@ -145,7 +145,7 @@ export function getThemeTokenValue(themeClass: string, token: `--${string}`): st
 
   return value instanceof CSSVariableReferenceValue
     ? getComputedStyle(document.documentElement).getPropertyValue(value.variable)
-    : value?.toString() ?? undefined;
+    : (value?.toString() ?? undefined);
 }
 
 /**


### PR DESCRIPTION
## Motivation and Context
This PR fixes some style and removes the shadow to let the file input be visible inside a form.
Also, it introduces 2 new prop, `inputName` to set the value of the `name` attribute of the `input` and `showErrors` that, when set to `false`, allows the apps to manually handle upload errors instead of the ones previously showed by the component inside a `z-modal`. Another related change is the emission of the new `fileError` event, sending to the app the upload errors with an object containing the file name and a list of errors:

```ts
{
  file: string; // file name
  errors: { cause: "size" | "format", messages: string }[];
}
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [x] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design
https://www.figma.com/design/Tu6D9gzAOgOJw9Nf1an91K/Z_main_library_master?node-id=3738-10526&m=dev
