### PR TITLE
feat: add preview slot to z-book-card-cover

### DIFF
--- a/src/components/book-card/z-book-card/index.stories.ts
+++ b/src/components/book-card/z-book-card/index.stories.ts
@@ -90,7 +90,7 @@ export const Card = {
     ></z-book-card>`,
 } satisfies Story;
 
-export const WithPreviewSlot = {
+export const WithcoverOverlaySlot = {
   render: (args) =>
     html`<z-book-card
       variant=${args.variant}
@@ -111,7 +111,7 @@ export const WithPreviewSlot = {
       class=${args.theme}
     >
       <div
-        slot="preview"
+        slot="coverOverlay"
         style="
             font-family: IBM Plex Sans;
             font-size: 14px;

--- a/src/components/book-card/z-book-card/index.stories.ts
+++ b/src/components/book-card/z-book-card/index.stories.ts
@@ -90,43 +90,6 @@ export const Card = {
     ></z-book-card>`,
 } satisfies Story;
 
-export const WithcoverOverlaySlot = {
-  render: (args) =>
-    html`<z-book-card
-      variant=${args.variant}
-      cover=${args.cover}
-      authors=${args.authors}
-      opera-title=${args.operaTitle}
-      volume-title=${args.volumeTitle}
-      isbn=${args.isbn}
-      isbn-label=${args.isbnLabel}
-      edi=${JSON.stringify(args.edi)}
-      annotated=${JSON.stringify(args.annotated)}
-      teacher-version=${JSON.stringify(args.teacherVersion)}
-      adoption=${args.adoption}
-      catalog-url=${args.catalogUrl}
-      ebook-url=${args.ebookUrl}
-      fallback-cover=${args.fallbackCover}
-      opera-title-html-tag=${args.operaTitleHtmlTag}
-      class=${args.theme}
-    >
-      <div
-        slot="coverOverlay"
-        style="
-            font-family: IBM Plex Sans;
-            font-size: 14px;
-            font-style: normal;
-            font-weight: 600;
-            line-height: 20px;
-            letter-spacing: 0.052px;
-            text-transform: uppercase;
-          "
-      >
-        Anteprima del libro senza risorse multimediali
-      </div>
-    </z-book-card>`,
-} satisfies Story;
-
 export const WithSlottedContent = {
   render: (args) =>
     html`<z-book-card
@@ -194,6 +157,43 @@ export const WithSlottedContent = {
           link="http://localhost"
           style="width:315px; height:47px;; --z-book-card-app-padding-x: 16px;"
         ></z-book-card-app>
+      </div>
+    </z-book-card>`,
+} satisfies Story;
+
+export const WithCoverOverlaySlot = {
+  render: (args) =>
+    html`<z-book-card
+      variant=${args.variant}
+      cover=${args.cover}
+      authors=${args.authors}
+      opera-title=${args.operaTitle}
+      volume-title=${args.volumeTitle}
+      isbn=${args.isbn}
+      isbn-label=${args.isbnLabel}
+      edi=${JSON.stringify(args.edi)}
+      annotated=${JSON.stringify(args.annotated)}
+      teacher-version=${JSON.stringify(args.teacherVersion)}
+      adoption=${args.adoption}
+      catalog-url=${args.catalogUrl}
+      ebook-url=${args.ebookUrl}
+      fallback-cover=${args.fallbackCover}
+      opera-title-html-tag=${args.operaTitleHtmlTag}
+      class=${args.theme}
+    >
+      <div
+        slot="coverOverlay"
+        style="
+                  font-family: IBM Plex Sans;
+                  font-size: 14px;
+                  font-style: normal;
+                  font-weight: 600;
+                  line-height: 20px;
+                  letter-spacing: 0.052px;
+                  text-transform: uppercase;
+                "
+      >
+        Anteprima del libro senza risorse multimediali
       </div>
     </z-book-card>`,
 } satisfies Story;

--- a/src/components/book-card/z-book-card/index.stories.ts
+++ b/src/components/book-card/z-book-card/index.stories.ts
@@ -90,6 +90,43 @@ export const Card = {
     ></z-book-card>`,
 } satisfies Story;
 
+export const WithPreviewSlot = {
+  render: (args) =>
+    html`<z-book-card
+      variant=${args.variant}
+      cover=${args.cover}
+      authors=${args.authors}
+      opera-title=${args.operaTitle}
+      volume-title=${args.volumeTitle}
+      isbn=${args.isbn}
+      isbn-label=${args.isbnLabel}
+      edi=${JSON.stringify(args.edi)}
+      annotated=${JSON.stringify(args.annotated)}
+      teacher-version=${JSON.stringify(args.teacherVersion)}
+      adoption=${args.adoption}
+      catalog-url=${args.catalogUrl}
+      ebook-url=${args.ebookUrl}
+      fallback-cover=${args.fallbackCover}
+      opera-title-html-tag=${args.operaTitleHtmlTag}
+      class=${args.theme}
+    >
+      <div
+        slot="preview"
+        style="
+            font-family: IBM Plex Sans;
+            font-size: 14px;
+            font-style: normal;
+            font-weight: 600;
+            line-height: 20px;
+            letter-spacing: 0.052px;
+            text-transform: uppercase;
+          "
+      >
+        Anteprima del libro senza risorse multimediali
+      </div>
+    </z-book-card>`,
+} satisfies Story;
+
 export const WithSlottedContent = {
   render: (args) =>
     html`<z-book-card

--- a/src/components/book-card/z-book-card/index.tsx
+++ b/src/components/book-card/z-book-card/index.tsx
@@ -215,6 +215,7 @@ export class ZBookCard {
           }}
           aria-hidden="true"
         />
+        <slot name="preview"></slot>
       </div>
     );
   }

--- a/src/components/book-card/z-book-card/index.tsx
+++ b/src/components/book-card/z-book-card/index.tsx
@@ -5,6 +5,7 @@ import {BookCardTag, BookCardTagEvent, BookCardTagStatus, BookCardVariant, Contr
  * @slot cta - to the right of authors and title (e.g. bookmark icon)
  * @slot ebook - main action slot on the card (as default, it shows laZ ebook link)
  * @slot apps - list of card-related apps
+ * @slot coverOverlay - to be shown on top of book cover
  */
 @Component({
   tag: "z-book-card",
@@ -215,7 +216,7 @@ export class ZBookCard {
           }}
           aria-hidden="true"
         />
-        <slot name="preview"></slot>
+        <slot name="coverOverlay"></slot>
       </div>
     );
   }

--- a/src/components/book-card/z-book-card/styles.css
+++ b/src/components/book-card/z-book-card/styles.css
@@ -37,19 +37,20 @@
   align-self: end;
 }
 
-::slotted([slot="preview"]) {
+::slotted([slot="coverOverlay"]) {
   position: absolute;
   bottom: 0;
   overflow: hidden;
-  width: calc(100% - var(--space-unit) * 2);
+  width: 100%;
+  box-sizing: border-box;
   padding: var(--space-unit);
   background-color: var(--avatar-C19);
   color: var(--color-white);
 }
 
-:host > article .main-content .cover ::slotted([slot="preview"]) {
+:host > article .main-content .cover ::slotted([slot="coverOverlay"]) {
   min-height: 80px;
-  max-height: calc(336px - var(--space-unit) * 2);
+  max-height: 336px;
 }
 
 :host > article .main-content .card-info {
@@ -232,9 +233,9 @@
   margin: 0;
 }
 
-:host > article.landscape .main-content .cover ::slotted([slot="preview"]) {
+:host > article.landscape .main-content .cover ::slotted([slot="coverOverlay"]) {
   min-height: 80px;
-  max-height: calc(256px - var(--space-unit) * 2);
+  max-height: 256px;
 }
 
 :host > article.landscape .main-content .card-info .book-data {

--- a/src/components/book-card/z-book-card/styles.css
+++ b/src/components/book-card/z-book-card/styles.css
@@ -53,7 +53,7 @@
 
 :host > article .main-content .cover ::slotted([slot="preview"]) {
   min-height: 80px;
-  max-height: 336px;
+  max-height: calc(336px - var(--space-unit) * 2);
 }
 
 :host > article .main-content .card-info {
@@ -236,9 +236,9 @@
   margin: 0;
 }
 
-:host > article .landscape .main-content .cover ::slotted([slot="preview"]) {
-  min-height: 80px;
-  max-height: 256px;
+:host > article.landscape .main-content .cover ::slotted([slot="preview"]) {
+  max-height: 80px;
+  max-height: calc(256px - var(--space-unit) * 2);
 }
 
 :host > article.landscape .main-content .card-info .book-data {

--- a/src/components/book-card/z-book-card/styles.css
+++ b/src/components/book-card/z-book-card/styles.css
@@ -45,7 +45,6 @@
   padding: var(--space-unit);
   background-color: var(--avatar-C19);
   color: var(--color-white);
-  text-align: center;
 }
 
 :host > article .main-content .cover ::slotted([slot="preview"]) {

--- a/src/components/book-card/z-book-card/styles.css
+++ b/src/components/book-card/z-book-card/styles.css
@@ -23,6 +23,7 @@
 }
 
 :host > article .main-content .cover {
+  position: relative;
   display: flex;
   overflow: hidden;
   height: 378px;
@@ -34,6 +35,25 @@
   max-width: 100%;
   max-height: 100%;
   align-self: end;
+}
+
+::slotted([slot="preview"]) {
+  position: absolute;
+  bottom: 0;
+  display: flex;
+  width: calc(100% - var(--space-unit) * 2);
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--space-unit);
+  background-color: var(--avatar-C19);
+  color: var(--color-white);
+  gap: calc(var(--space-unit) / 4);
+  text-align: center;
+}
+
+:host > article .main-content .cover ::slotted([slot="preview"]) {
+  min-height: 80px;
+  max-height: 336px;
 }
 
 :host > article .main-content .card-info {
@@ -214,6 +234,11 @@
   width: 221px;
   height: auto;
   margin: 0;
+}
+
+:host > article .landscape .main-content .cover ::slotted([slot="preview"]) {
+  min-height: 80px;
+  max-height: 256px;
 }
 
 :host > article.landscape .main-content .card-info .book-data {

--- a/src/components/book-card/z-book-card/styles.css
+++ b/src/components/book-card/z-book-card/styles.css
@@ -40,14 +40,11 @@
 ::slotted([slot="preview"]) {
   position: absolute;
   bottom: 0;
-  display: flex;
+  overflow: hidden;
   width: calc(100% - var(--space-unit) * 2);
-  flex-direction: column;
-  justify-content: center;
   padding: var(--space-unit);
   background-color: var(--avatar-C19);
   color: var(--color-white);
-  gap: calc(var(--space-unit) / 4);
   text-align: center;
 }
 
@@ -237,7 +234,7 @@
 }
 
 :host > article.landscape .main-content .cover ::slotted([slot="preview"]) {
-  max-height: 80px;
+  min-height: 80px;
   max-height: calc(256px - var(--space-unit) * 2);
 }
 

--- a/src/pages/book-cards.html
+++ b/src/pages/book-cards.html
@@ -79,6 +79,69 @@
 
       <z-book-card
         variant="landscape"
+        cover="https://s3-eu-west-1.amazonaws.com/staticmy.zanichelli.it/copertine/dashboard/m40066.9788808930552.jpg"
+        authors="Massimo Bergamini, Anna Trifone, Graziella Barozzi"
+        opera-title="Matematica.azzurro"
+        volume-title="Volume 3 con Tutor"
+        isbn="9788808930552"
+        catalog-url="https://www.zanichelli.it"
+        ebook-url="https://my.zanichelli.it"
+      >
+        <div
+          slot="preview"
+          style="
+            font-family: IBM Plex Sans;
+            font-size: 14px;
+            font-style: normal;
+            font-weight: 600;
+            line-height: 20px;
+            letter-spacing: 0.052px;
+            text-transform: uppercase;
+          "
+        >
+          Anteprima del libro senza risorse multimediali
+        </div>
+        <div
+          slot="apps"
+          style="display: flex; flex-wrap: wrap; border-top: 1px solid #d6d6d6"
+        >
+          <z-book-card-app
+            name="Risorse per l'insegnante"
+            link="http://localhost"
+            laz="false"
+            style="
+              width: 315px;
+              height: 47px;
+              border-right: 1px solid #d6d6d6;
+              border-bottom: 1px solid #d6d6d6;
+              --z-book-card-app-padding-x: 16px;
+            "
+          ></z-book-card-app>
+          <z-book-card-app
+            logo="https://placehold.co/24"
+            name="Tutor di matematica"
+            info="test test"
+            link="http://localhost"
+            style="width: 315px; height: 47px; border-bottom: 1px solid #d6d6d6; --z-book-card-app-padding-x: 16px"
+          ></z-book-card-app>
+          <z-book-card-app
+            name="Intelligenza Artificiale"
+            info="sadsa"
+            logo="https://appswitcher-configurations.s3.eu-west-1.amazonaws.com/icons/6752c3a3478ba_sito_del_libro.svg"
+            link="http://localhost"
+            style="width: 315px; height: 47px; border-right: 1px solid #d6d6d6; --z-book-card-app-padding-x: 16px"
+          ></z-book-card-app>
+          <z-book-card-app
+            logo="https://placehold.co/24"
+            name="Scrittura"
+            link="http://localhost"
+            style="width: 315px; height: 47px; --z-book-card-app-padding-x: 16px"
+          ></z-book-card-app>
+        </div>
+      </z-book-card>
+
+      <z-book-card
+        variant="landscape"
         cover="https://s3-eu-west-1.amazonaws.com/staticmy.zanichelli.it/copertine/dashboard/m40001.9788808404619.jpg"
         authors="Massimo Bergamini, Anna Trifone, Graziella Barozzi, Massimo Bergamini, Anna Trifone, Graziella Barozzi"
         opera-title="Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro"
@@ -170,6 +233,49 @@
 
       <z-book-card
         variant="portrait"
+        cover="https://s3-eu-west-1.amazonaws.com/staticmy.zanichelli.it/copertine/dashboard/m40001.9788808404619.jpg"
+        authors="Massimo Bergamini, Anna Trifone, Graziella Barozzi, Massimo Bergamini, Anna Trifone, Graziella Barozzi"
+        opera-title="Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro Matematica.azzurro"
+        volume-title="Volume 3 con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor con Tutor"
+        isbn="9788808930552 9788808930552 9788808930552 9788808930552 9788808930552 9788808930552 9788808930552"
+        edi='{"status":"active","interactive":true}'
+        annotated='{"status":"disabled","interactive":true}'
+        teacher-version='{"status":"active","interactive":false}'
+        adoption="true"
+        catalog-url="https://www.zanichelli.it"
+        ebook-url="https://my.zanichelli.it"
+      >
+        <div slot="preview">
+          <div
+            style="
+              font-family: IBM Plex Sans;
+              font-size: 14px;
+              font-style: normal;
+              font-weight: 600;
+              line-height: 20px;
+              letter-spacing: 0.052px;
+              text-transform: uppercase;
+            "
+          >
+            Anteprima del libro senza risorse multimediali
+          </div>
+          <div
+            style="
+              font-family: IBM Plex Sans;
+              font-size: 14px;
+              font-style: normal;
+              font-weight: 400;
+              line-height: 18px; /* 128.571% */
+              letter-spacing: 0.052px;
+            "
+          >
+            Capitolo 8 - Le frazioni algebriche e le equazioni fratte
+          </div>
+        </div>
+      </z-book-card>
+
+      <z-book-card
+        variant="portrait"
         cover="http://dizionari.zanichelli.it/images/opere/ZING2024/ZING2024_copertina.jpg"
         authors="Massimo Bergamini, Anna Trifone, Graziella Barozzi"
         opera-title="Matematica.azzurro"
@@ -177,6 +283,19 @@
         isbn="9788808930552"
         ebook-url="https://my.zanichelli.it"
       >
+        <div slot="ebook">EBOOK SLOT</div>
+      </z-book-card>
+
+      <z-book-card
+        variant="portrait"
+        cover="http://dizionari.zanichelli.it/images/opere/ZING2024/ZING2024_copertina.jpg"
+        authors="Massimo Bergamini, Anna Trifone, Graziella Barozzi"
+        opera-title="Matematica.azzurro"
+        volume-title="Volume 3 con Tutor"
+        isbn="9788808930552"
+        ebook-url="https://my.zanichelli.it"
+      >
+        <div slot="preview"></div>
         <div slot="ebook">EBOOK SLOT</div>
       </z-book-card>
     </div>

--- a/src/pages/book-cards.html
+++ b/src/pages/book-cards.html
@@ -88,7 +88,7 @@
         ebook-url="https://my.zanichelli.it"
       >
         <div
-          slot="preview"
+          slot="coverOverlay"
           style="
             font-family: IBM Plex Sans;
             font-size: 14px;
@@ -245,7 +245,7 @@
         catalog-url="https://www.zanichelli.it"
         ebook-url="https://my.zanichelli.it"
       >
-        <div slot="preview">
+        <div slot="coverOverlay">
           <div
             style="
               font-family: IBM Plex Sans;
@@ -295,7 +295,7 @@
         isbn="9788808930552"
         ebook-url="https://my.zanichelli.it"
       >
-        <div slot="preview"></div>
+        <div slot="coverOverlay"></div>
         <div slot="ebook">EBOOK SLOT</div>
       </z-book-card>
     </div>


### PR DESCRIPTION
# Feat: add preview slot to z-book-card-cover

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->
In this PR is add a slot inside the z-book-card cover enabling a purple overlay on the cover img, for display purpose
## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [X] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->
[Link to figma](https://www.figma.com/design/To5LlfWLba1S62IkOS3VxM/Book-card-2024?node-id=12122-2630&t=0BpVRVp6WTym0y0D-4)
<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
