### PR TITLE
fix: restore css rules for disabled input

### DIFF
--- a/src/components/z-input/styles-general.css
+++ b/src/components/z-input/styles-general.css
@@ -49,13 +49,13 @@ input,
 /* HOVER */
 input:not([readonly]):hover,
 .textarea-wrapper:not(.readonly):hover {
-  outline: var(--border-size-medium) solid var(--color-form-surface04);
+  outline: var(--border-size-medium) solid var(--color-surface04);
   outline-offset: -2px;
 }
 
 /* FOCUS */
 :host:not(.active-select) input:focus:focus-visible,
-.textarea-wrapper:focus-within {
+:host:not([readonly="true"]) .textarea-wrapper:focus-within {
   border-color: var(--color-form-active-primary);
   box-shadow: var(--shadow-focus-primary);
   color: var(--color-form-active-primary);
@@ -79,6 +79,7 @@ input:not([readonly]):hover,
 }
 
 :host input[readonly]:focus:focus-visible {
+  border-color: var(--color-form-surface03);
   box-shadow: none;
 }
 
@@ -126,9 +127,9 @@ input:not([readonly]):hover,
 }
 
 /* DISABLED */
-:host([disabled]) input,
-:host([disabled]) .textarea-wrapper,
-:host([disabled]) z-icon {
+:host([disabled]:not([disabled="false"])) input,
+:host([disabled]:not([disabled="false"])) .textarea-wrapper,
+:host([disabled]:not([disabled="false"])) z-icon {
   border-color: var(--color-form-disabled03);
   box-shadow: none;
   color: var(--color-form-disabled-text);
@@ -136,7 +137,7 @@ input:not([readonly]):hover,
   pointer-events: none;
 }
 
-:host([disabled]) input:hover {
+:host([disabled]:not([disabled="false"])) input:hover {
   border-width: var(--border-size-small);
 }
 
@@ -170,6 +171,6 @@ label.input-label {
   text-transform: uppercase;
 }
 
-:host([disabled]) label.input-label {
+:host([disabled]:not([disabled="false"])) label.input-label {
   color: var(--color-disabled03);
 }


### PR DESCRIPTION
# fix - z-input - disabled state css style

## Motivation and Context
Restore previous component behaviour when in disabled state.

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

