### PR TITLE
Feat - ZIcon - Add unit dimensions params

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -834,7 +834,7 @@ export namespace Components {
         /**
           * icon height (optional)
          */
-        "height"?: number;
+        "height"?: number | string;
         /**
           * icon id (optional)
          */
@@ -846,7 +846,7 @@ export namespace Components {
         /**
           * icon width (optional)
          */
-        "width"?: number;
+        "width"?: number | string;
     }
     interface ZInfoBox {
         /**
@@ -4484,7 +4484,7 @@ declare namespace LocalJSX {
         /**
           * icon height (optional)
          */
-        "height"?: number;
+        "height"?: number | string;
         /**
           * icon id (optional)
          */
@@ -4496,7 +4496,7 @@ declare namespace LocalJSX {
         /**
           * icon width (optional)
          */
-        "width"?: number;
+        "width"?: number | string;
     }
     interface ZInfoBox {
         /**

--- a/src/components/z-icon/index.spec.ts
+++ b/src/components/z-icon/index.spec.ts
@@ -68,7 +68,7 @@ describe("Suite test ZIcon", () => {
     `);
   });
 
-  it("Test render ZIcon con polygon con dimensioni", async () => {
+  it("Test render ZIcon con polygon con dimensioni pixels", async () => {
     const page = await newSpecPage({
       components: [ZIcon],
       html: `<z-icon name="chevron-down" iconid="zicon" width="10" height="10"></z-icon>`,
@@ -77,6 +77,22 @@ describe("Suite test ZIcon", () => {
       <z-icon name="chevron-down" iconid="zicon" width="10" height="10" aria-hidden="true">
         <mock:shadow-root>
           <svg fill="" viewBox="0 0 1000 1000" width='10' height='10' id="zicon">
+            <path d="${ICONS["chevron-down"]}"></path>
+          </svg>
+        </mock:shadow-root>
+      </z-icon>
+    `);
+  });
+
+  it("Test render ZIcon con polygon con dimensioni rem", async () => {
+    const page = await newSpecPage({
+      components: [ZIcon],
+      html: `<z-icon name="chevron-down" iconid="zicon" width="2rem" height="2rem"></z-icon>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <z-icon name="chevron-down" iconid="zicon" width="2rem" height="2rem" aria-hidden="true">
+        <mock:shadow-root>
+          <svg fill="" viewBox="0 0 1000 1000" width='2rem' height='2rem' id="zicon">
             <path d="${ICONS["chevron-down"]}"></path>
           </svg>
         </mock:shadow-root>

--- a/src/components/z-icon/index.stories.ts
+++ b/src/components/z-icon/index.stories.ts
@@ -1,13 +1,23 @@
-import {Meta} from "@storybook/web-components";
+import {Meta, StoryObj} from "@storybook/web-components";
 import {html} from "lit";
 import {type ZIcon} from ".";
 import {getColorTokens} from "../../utils/storybook-utils";
 import "./index";
 
-export default {
+const StoryMeta = {
   title: "ZIcon",
   component: "z-icon",
   argTypes: {
+    width: {
+      control: {
+        type: "text",
+      },
+    },
+    height: {
+      control: {
+        type: "text",
+      },
+    },
     fill: {
       options: getColorTokens().map((token) => token.replace("--", "")),
       control: {
@@ -23,6 +33,10 @@ export default {
   },
 } satisfies Meta<ZIcon>;
 
+export default StoryMeta;
+
+type Story = StoryObj<ZIcon>;
+
 export const Default = {
   render: (args) =>
     html`<z-icon
@@ -31,4 +45,20 @@ export const Default = {
       width="${args.width}"
       fill="${args.fill}"
     ></z-icon>`,
-};
+} satisfies Story;
+
+export const ZIconRem = {
+  args: {
+    name: "download",
+    height: "1.125rem",
+    width: "1.125rem",
+    fill: "color-primary01",
+  },
+  render: (args) =>
+    html`<z-icon
+      name="${args.name}"
+      height="${args.height}"
+      width="${args.width}"
+      fill="${args.fill}"
+    ></z-icon>`,
+} satisfies Story;

--- a/src/components/z-icon/index.tsx
+++ b/src/components/z-icon/index.tsx
@@ -13,11 +13,11 @@ export class ZIcon {
 
   /** icon height (optional) */
   @Prop()
-  height?: number;
+  height?: number | string;
 
   /** icon width (optional) */
   @Prop()
-  width?: number;
+  width?: number | string;
 
   /** icon id (optional) */
   @Prop()

--- a/src/components/z-icon/readme.md
+++ b/src/components/z-icon/readme.md
@@ -21,13 +21,13 @@
 
 ## Properties
 
-| Property | Attribute | Description            | Type     | Default     |
-| -------- | --------- | ---------------------- | -------- | ----------- |
-| `fill`   | `fill`    | icon fill (optional)   | `string` | `undefined` |
-| `height` | `height`  | icon height (optional) | `number` | `undefined` |
-| `iconid` | `iconid`  | icon id (optional)     | `string` | `undefined` |
-| `name`   | `name`    | icon name              | `string` | `undefined` |
-| `width`  | `width`   | icon width (optional)  | `number` | `undefined` |
+| Property | Attribute | Description            | Type               | Default     |
+| -------- | --------- | ---------------------- | ------------------ | ----------- |
+| `fill`   | `fill`    | icon fill (optional)   | `string`           | `undefined` |
+| `height` | `height`  | icon height (optional) | `number \| string` | `undefined` |
+| `iconid` | `iconid`  | icon id (optional)     | `string`           | `undefined` |
+| `name`   | `name`    | icon name              | `string`           | `undefined` |
+| `width`  | `width`   | icon width (optional)  | `number \| string` | `undefined` |
 
 
 ## Dependencies

--- a/src/components/z-icon/styles.css
+++ b/src/components/z-icon/styles.css
@@ -6,9 +6,9 @@
 }
 
 :host svg:not([width]) {
-  width: var(--z-icon-width, 18px);
+  width: var(--z-icon-width, 1.125rem);
 }
 
 :host svg:not([height]) {
-  height: var(--z-icon-height, 18px);
+  height: var(--z-icon-height, 1.125rem);
 }


### PR DESCRIPTION
# Title
Add unit dimensions params for z-icon. Now you can use `width` and `height` like a number (in pixels by default) or use another unit dimension like `px`, `%`, `em`, `ex`, `pt`,  `pc`, `cm`, `mm`, `in` for ZIcon.

## Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design


### Screenshots


### Note