### PR TITLE
Fix z-file-upload

### DIFF
--- a/src/components/file-upload/z-file-upload/index.tsx
+++ b/src/components/file-upload/z-file-upload/index.tsx
@@ -113,7 +113,7 @@ export class ZFileUpload {
   /** Listen `removeFile` event sent from z-file component */
   @Listen("removeFile")
   onFileRemoved(e: CustomEvent): void {
-    this.removeFile(e.detail);
+    this.removeFile(e.detail.fileName);
   }
 
   /** Listen fileDropped event sent from z-dragdrop-area component */

--- a/src/components/file-upload/z-file-upload/index.tsx
+++ b/src/components/file-upload/z-file-upload/index.tsx
@@ -93,6 +93,10 @@ export class ZFileUpload {
   @State()
   invalidFiles: Map<string, ZFileUploadError[]> = new Map<string, ZFileUploadError[]>();
 
+  /** Input ref */
+  @State()
+  private input: HTMLInputElement;
+
   /** Emitted when user select one or more files */
   @Event()
   fileInput: EventEmitter<File>;
@@ -105,8 +109,6 @@ export class ZFileUpload {
   fileError: EventEmitter<{file: string; errors: ZFileUploadError[]}>;
 
   @Element() host: HTMLZFileUploadElement;
-
-  private input: HTMLInputElement;
 
   private errorModal: HTMLZModalElement;
 


### PR DESCRIPTION
# Fix - z-file-upload - Get the name of the file to delete using `fileName`

## Motivation and Context
The component failed to delete an uploaded file, because the method `removeFile`received an object instead of the string identifying the file name


## Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
