### PR TITLE
fix: info reveal position on mobile

### DIFF
--- a/src/components/z-info-reveal/styles.css
+++ b/src/components/z-info-reveal/styles.css
@@ -75,7 +75,7 @@ button:focus:focus-visible {
 
 .z-info-reveal-panel {
   position: absolute;
-  z-index: 99;
+  z-index: 19;
   display: flex;
   width: var(--z-info-reveal-panel-width);
   height: fit-content;
@@ -122,12 +122,9 @@ button:focus:focus-visible {
 
 @media (max-width: 767px) {
   .z-info-reveal-panel {
-    position: fixed;
     top: auto !important;
     bottom: auto !important;
-    left: var(--grid-margin) !important;
-    width: calc(100% - (var(--grid-margin) * 2)) !important;
-    max-width: none !important;
+    width: calc(var(--z-info-reveal-panel-width) - (var(--grid-margin) * 4)) !important;
     margin-top: calc(var(--trigger-size) * -1);
   }
 }


### PR DESCRIPTION
# Fix - z-info-reveal- Fixed position on mobile
## Motivation and Context

This PR fixes the positioning of the `z-info-reveal` component on mobile viewports.
Previously, the component was using `position: fixed`, causing it to stay fixed during page scroll

It also changes the z-index of said component to avoid overlapping the `z-app-header`

## Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

