### PR TITLE
Remove right padding from the placeholder

### DIFF
--- a/src/components/z-input/index.stories.ts
+++ b/src/components/z-input/index.stories.ts
@@ -71,59 +71,63 @@ type Story = StoryObj<ZInput>;
 
 export const AllProps = {
   render: (args) => html`
-    <z-input
-      type=${args.type}
-      label=${args.label}
-      aria-label=${args.ariaLabel}
-      .labelPosition=${args.labelPosition}
-      placeholder=${args.placeholder}
-      value=${args.value}
-      name=${args.name}
-      status=${args.status}
-      message=${args.message}
-      icon=${args.icon}
-      .disabled=${args.disabled}
-      .readonly=${args.readonly}
-      .required=${args.required}
-      .checked=${args.checked}
-      hasclearicon=${args.hasclearicon}
-      htmlid=${args.htmlid}
-      htmltitle=${args.htmltitle}
-      .autocomplete=${args.autocomplete}
-      min=${args.min}
-      minlength=${args.minlength}
-      max=${args.max}
-      maxlength=${args.maxlength}
-      step=${args.step}
-      pattern=${args.pattern}
-      size=${args.size}
-    ></z-input>
+    <div style="width:50%">
+      <z-input
+        type=${args.type}
+        label=${args.label}
+        aria-label=${args.ariaLabel}
+        .labelPosition=${args.labelPosition}
+        placeholder=${args.placeholder}
+        value=${args.value}
+        name=${args.name}
+        status=${args.status}
+        message=${args.message}
+        icon=${args.icon}
+        .disabled=${args.disabled}
+        .readonly=${args.readonly}
+        .required=${args.required}
+        .checked=${args.checked}
+        hasclearicon=${args.hasclearicon}
+        htmlid=${args.htmlid}
+        htmltitle=${args.htmltitle}
+        .autocomplete=${args.autocomplete}
+        min=${args.min}
+        minlength=${args.minlength}
+        max=${args.max}
+        maxlength=${args.maxlength}
+        step=${args.step}
+        pattern=${args.pattern}
+        size=${args.size}
+      ></z-input>
+    </div>
   `,
 } satisfies Story;
 
 export const ZInputText = {
   render: (args) => html`
-    <z-input
-      type=${args.type}
-      label=${args.label}
-      aria-label=${args.ariaLabel}
-      placeholder=${args.placeholder}
-      value=${args.value}
-      name=${args.name}
-      status=${args.status}
-      message=${args.message}
-      icon=${args.icon}
-      .disabled=${args.disabled}
-      .readonly=${args.readonly}
-      .required=${args.required}
-      hasclearicon=${args.hasclearicon}
-      htmlid=${args.htmlid}
-      htmltitle=${args.htmltitle}
-      .autocomplete=${args.autocomplete}
-      size=${args.size}
-      minlength=${args.minlength}
-      maxlength=${args.maxlength}
-    ></z-input>
+    <div style="width:50%">
+      <z-input
+        type=${args.type}
+        label=${args.label}
+        aria-label=${args.ariaLabel}
+        placeholder=${args.placeholder}
+        value=${args.value}
+        name=${args.name}
+        status=${args.status}
+        message=${args.message}
+        icon=${args.icon}
+        .disabled=${args.disabled}
+        .readonly=${args.readonly}
+        .required=${args.required}
+        hasclearicon=${args.hasclearicon}
+        htmlid=${args.htmlid}
+        htmltitle=${args.htmltitle}
+        .autocomplete=${args.autocomplete}
+        size=${args.size}
+        minlength=${args.minlength}
+        maxlength=${args.maxlength}
+      ></z-input>
+    </div>
   `,
   parameters: {
     controls: {

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -268,7 +268,6 @@ export class ZInput {
       maxlength: this.maxlength,
       class: {
         [`input-${this.status}`]: !!this.status,
-        ellipsis: !this.value,
       },
       autocomplete: this.autocomplete,
       onInput: (e: InputEvent) => this.emitInputChange((e.target as HTMLInputElement).value),
@@ -343,7 +342,7 @@ export class ZInput {
     if (this.icon || type === InputType.PASSWORD) {
       Object.assign(attr.class, {"has-icon": true});
     }
-    if (this.hasclearicon && type != InputType.NUMBER) {
+    if (this.hasclearicon && type != InputType.NUMBER && !!this.value) {
       Object.assign(attr.class, {"has-clear-icon": true});
     }
 

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -268,6 +268,7 @@ export class ZInput {
       maxlength: this.maxlength,
       class: {
         [`input-${this.status}`]: !!this.status,
+        ellipsis: !this.value,
       },
       autocomplete: this.autocomplete,
       onInput: (e: InputEvent) => this.emitInputChange((e.target as HTMLInputElement).value),

--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -12,12 +12,6 @@
   margin: 0;
 }
 
-.text-wrapper > div > input.ellipsis {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 :host([size="small"]) .text-wrapper > div > input {
   height: calc(var(--space-unit) * 4.5);
 }

--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -12,6 +12,12 @@
   margin: 0;
 }
 
+.text-wrapper > div > input.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 :host([size="small"]) .text-wrapper > div > input {
   height: calc(var(--space-unit) * 4.5);
 }

--- a/src/components/z-input/test-text.spec.ts
+++ b/src/components/z-input/test-text.spec.ts
@@ -15,7 +15,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon ellipsis" type="text" />
+              <input id="id" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                 <z-icon class="big" name="multiply"></z-icon>
@@ -36,7 +36,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="small">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon ellipsis" type="text" />
+              <input id="id" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="small" name="multiply"></z-icon>
@@ -57,7 +57,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="x-small">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon ellipsis" type="text" />
+              <input id="id" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="x-small" name="multiply"></z-icon>
@@ -223,7 +223,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big" type="password">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon has-icon ellipsis" type="password" />
+              <input id="id" class="has-icon" type="password" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -249,7 +249,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big" type="password">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon has-icon ellipsis" type="text" />
+              <input id="id" class="has-icon" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -323,7 +323,7 @@ describe("Suite test ZInput - text", () => {
       <z-input htmlid="id" icon="pdf" size="big">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-icon has-clear-icon ellipsis" type="text" />
+              <input id="id" class="has-icon" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -346,7 +346,7 @@ describe("Suite test ZInput - text", () => {
       <z-input htmlid="test" max="10" message="false" min="1" size="big" step="2" type="number">
         <div class="text-wrapper">
           <div>
-            <input id="test" class="ellipsis" max="10" min="1" step="2" type="number">
+            <input id="test" max="10" min="1" step="2" type="number">
             <span class="icons-wrapper">
               <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                 <z-icon class="big" name="multiply"></z-icon>

--- a/src/components/z-input/test-text.spec.ts
+++ b/src/components/z-input/test-text.spec.ts
@@ -15,7 +15,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon" type="text" />
+              <input id="id" class="has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                 <z-icon class="big" name="multiply"></z-icon>
@@ -36,7 +36,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="small">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon" type="text" />
+              <input id="id" class="has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="small" name="multiply"></z-icon>
@@ -57,7 +57,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="x-small">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon" type="text" />
+              <input id="id" class="has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="x-small" name="multiply"></z-icon>
@@ -223,7 +223,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big" type="password">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon has-icon" type="password" />
+              <input id="id" class="has-clear-icon has-icon ellipsis" type="password" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -249,7 +249,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big" type="password">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon has-icon" type="text" />
+              <input id="id" class="has-clear-icon has-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -323,7 +323,7 @@ describe("Suite test ZInput - text", () => {
       <z-input htmlid="id" icon="pdf" size="big">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-icon has-clear-icon" type="text" />
+              <input id="id" class="has-icon has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -346,7 +346,7 @@ describe("Suite test ZInput - text", () => {
       <z-input htmlid="test" max="10" message="false" min="1" size="big" step="2" type="number">
         <div class="text-wrapper">
           <div>
-            <input id="test" max="10" min="1" step="2" type="number">
+            <input id="test" class="ellipsis" max="10" min="1" step="2" type="number">
             <span class="icons-wrapper">
               <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                 <z-icon class="big" name="multiply"></z-icon>


### PR DESCRIPTION
# Feat - z-input - Remove right padding from the placeholder

## Motivation and Context

This PR removes extra right padding from the placeholder when the input value is none.

## Priority

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)


### Screenshots
![Schermata del 2025-04-24 11-06-19](https://github.com/user-attachments/assets/f61e8396-aab6-40fd-9f8f-f86f8271e75f)
