### PR TITLE
feat: add ellipsis styling for input when empty and update tests

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -268,6 +268,7 @@ export class ZInput {
       maxlength: this.maxlength,
       class: {
         [`input-${this.status}`]: !!this.status,
+        ellipsis: !this.value,
       },
       autocomplete: this.autocomplete,
       onInput: (e: InputEvent) => this.emitInputChange((e.target as HTMLInputElement).value),

--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -12,6 +12,12 @@
   margin: 0;
 }
 
+.text-wrapper > div > input.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 :host([size="small"]) .text-wrapper > div > input {
   height: calc(var(--space-unit) * 4.5);
 }

--- a/src/components/z-input/test-text.spec.ts
+++ b/src/components/z-input/test-text.spec.ts
@@ -15,7 +15,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon" type="text" />
+              <input id="id" class="has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                 <z-icon class="big" name="multiply"></z-icon>
@@ -36,7 +36,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="small">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon" type="text" />
+              <input id="id" class="has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="small" name="multiply"></z-icon>
@@ -57,7 +57,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="x-small">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon" type="text" />
+              <input id="id" class="has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="x-small" name="multiply"></z-icon>
@@ -223,7 +223,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big" type="password">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon has-icon" type="password" />
+              <input id="id" class="has-clear-icon has-icon ellipsis" type="password" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -249,7 +249,7 @@ describe("Suite test ZInput - text", () => {
       <z-input message="false" htmlid="id" size="big" type="password">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-clear-icon has-icon" type="text" />
+              <input id="id" class="has-clear-icon has-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -323,7 +323,7 @@ describe("Suite test ZInput - text", () => {
       <z-input htmlid="id" icon="pdf" size="big">
           <div class="text-wrapper">
             <div>
-              <input id="id" class="has-icon has-clear-icon" type="text" />
+              <input id="id" class="has-icon has-clear-icon ellipsis" type="text" />
               <span class="icons-wrapper">
                 <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                   <z-icon class="big" name="multiply"></z-icon>
@@ -346,7 +346,7 @@ describe("Suite test ZInput - text", () => {
       <z-input htmlid="test" max="10" message="false" min="1" size="big" step="2" type="number">
         <div class="text-wrapper">
           <div>
-            <input id="test" max="10" min="1" step="2" type="number">
+            <input id="test" class="ellipsis" max="10" min="1" step="2" type="number">
             <span class="icons-wrapper">
               <button aria-label="cancella il contenuto dell'input" class="hidden input-icon reset-icon" type="button">
                 <z-icon class="big" name="multiply"></z-icon>


### PR DESCRIPTION
# Feat - z-input - add ellipsis styling

## Motivation and Context
This PR add ellipsis styling for input when empty.

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [x] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
