### PR TITLE
fix: remove background from dark theme

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,6 +9,10 @@ Ogni volta che viene implementato un **breaking change** su un componente, la su
 
 Indice delle breaking changes divise per numero di versione in cui sono state introdotte.
 
+- [v19.0.0](#v1900)
+
+  - [Rimosso colore di background per il tema dark](#rimozione-background-dal-tema-dark)
+
 - [v18.0.0](#v1800)
 
   - [Refactor componente `z-book-card`](#refactor-componente-zbookcard-v2)
@@ -117,6 +121,12 @@ Indice delle breaking changes divise per numero di versione in cui sono state in
   - [ZStatusTag (deprecato)](#zstatustag-deprecato)
   - [ZButtonFilter (deprecato)](#zbuttonfilter-deprecato)
   - [ZChip (rifattorizzato)](#zchip-rifattorizzato)
+
+## v19.0.0
+
+### Rimozione background dal tema Dark
+
+È stato rimosso `background: var(--color-background);` dal tema dark, dovrà essere impostato direttamente nell'applicazione che utilizza il ds se lo si vuole personalizzare.
 
 ## v18.0.0
 

--- a/src/tokens/themes/dark-default.css
+++ b/src/tokens/themes/dark-default.css
@@ -81,6 +81,4 @@
   --color-text-link-red-pressed: var(--color-white);
   --color-text-link-red-visited: var(--color-white);
   --color-text-link-red: var(--color-white);
-
-  background: var(--color-background);
 }


### PR DESCRIPTION
# [FIX] Remove background color from dark theme

## Motivation and Context

The default token assigned to background for the dark theme has been removed uniforming it to other themes.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [ ] 3 - Medium
- [ ] 4 - Low
- [X] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [X] Breaking (fix or feature that would cause existing functionality to not work as expected)