### PR TITLE
fix: avoid auto scroll on loading ZNavigationTabs

### DIFF
--- a/src/components/z-navigation-tabs/index.tsx
+++ b/src/components/z-navigation-tabs/index.tsx
@@ -100,16 +100,28 @@ export class ZNavigationTabs {
    * Scroll into view to center the tab.
    */
   private scrollToTab(tabElement: HTMLElement): void {
-    const scrollOptions = (
-      this.orientation === NavigationTabsOrientation.HORIZONTAL
-        ? {block: "nearest", inline: "center"}
-        : {block: "center", inline: "nearest"}
-    ) as ScrollIntoViewOptions;
+    const container = tabElement.parentElement;
 
-    tabElement.scrollIntoView({
-      behavior: "smooth",
-      ...scrollOptions,
-    });
+    if (!container) {
+      return;
+    }
+
+    setTimeout(() => {
+      const isHorizontal = this.orientation === NavigationTabsOrientation.HORIZONTAL;
+
+      const containerRect = container.getBoundingClientRect();
+      const tabRect = tabElement.getBoundingClientRect();
+
+      const offset = isHorizontal ? tabRect.left - containerRect.left : tabRect.top - containerRect.top;
+      const containerSize = isHorizontal ? container.clientWidth : container.clientHeight;
+      const tabSize = isHorizontal ? tabElement.clientWidth : tabElement.clientHeight;
+      const scrollAmount = offset - containerSize / 2 + tabSize / 2;
+
+      container.scrollTo({
+        [isHorizontal ? "left" : "top"]: container[isHorizontal ? "scrollLeft" : "scrollTop"] + scrollAmount,
+        behavior: "smooth",
+      });
+    }, 100);
   }
 
   /**


### PR DESCRIPTION
A avoid auto scroll on loading ZNavigationTabs

<!--- Please follow the following naming convention -->
<!--- [type] - [component name] - [short description] -->

<!--- [type] Types of changes as specified below -->
<!--- [component name] the component affected by the PR -->

## Motivation and Context

If `ZNavigationTabs` has a child element with `aria-selected="true"`, it will automatically be scrolled into view, potentially causing the page to scroll to the position of that child.

When clicking the rightmost visible item ( on a long list of items ) on a navigation tab, if the click happens close to the outer edge, sometimes the scroll behavior would trigger before the click could be registered, causing the click event to be lost. This fix ensures that the click is properly handled in such cases.


## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design

<!--- Reference link to Design sheet -->

### Screenshots

<!--- Add screenshots if appropriate -->

### Note

<!-- Adds notes, any blocks -->

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
