### PR TITLE
Feat/ZResultCard

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1768,14 +1768,6 @@ export namespace Components {
           * Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.
          */
         "isInfoCard": boolean;
-        /**
-          * Tags associated with the opera. This is a string array that can be used to display tags in the component.
-         */
-        "operaTags"?: string[];
-        /**
-          * The label for the volumes. This is used to display the number of volumes or a related message.
-         */
-        "volumesLabel"?: string;
     }
     /**
      * @cssprop --z-searchbar-results-height - Max height of the results container (default: 540px)
@@ -5621,14 +5613,6 @@ declare namespace LocalJSX {
           * Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.
          */
         "isInfoCard"?: boolean;
-        /**
-          * Tags associated with the opera. This is a string array that can be used to display tags in the component.
-         */
-        "operaTags"?: string[];
-        /**
-          * The label for the volumes. This is used to display the number of volumes or a related message.
-         */
-        "volumesLabel"?: string;
     }
     /**
      * @cssprop --z-searchbar-results-height - Max height of the results container (default: 540px)

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1749,6 +1749,14 @@ export namespace Components {
          */
         "author"?: string;
         /**
+          * The subtitle of the opera.
+         */
+        "cardSubtitle": string;
+        /**
+          * The title of the opera.
+         */
+        "cardTitle": string;
+        /**
           * The URL of the cover image. This is used to display the cover image of the opera.
          */
         "cover"?: string;
@@ -1761,17 +1769,9 @@ export namespace Components {
          */
         "isInfoPage": boolean;
         /**
-          * The subtitle of the opera.
-         */
-        "operaSubtitle": string;
-        /**
           * Tags associated with the opera. This is a string array that can be used to display tags in the component.
          */
         "operaTags"?: string[];
-        /**
-          * The title of the opera.
-         */
-        "operaTitle": string;
         /**
           * The label for the volumes. This is used to display the number of volumes or a related message.
          */
@@ -5602,6 +5602,14 @@ declare namespace LocalJSX {
          */
         "author"?: string;
         /**
+          * The subtitle of the opera.
+         */
+        "cardSubtitle"?: string;
+        /**
+          * The title of the opera.
+         */
+        "cardTitle"?: string;
+        /**
           * The URL of the cover image. This is used to display the cover image of the opera.
          */
         "cover"?: string;
@@ -5614,17 +5622,9 @@ declare namespace LocalJSX {
          */
         "isInfoPage"?: boolean;
         /**
-          * The subtitle of the opera.
-         */
-        "operaSubtitle"?: string;
-        /**
           * Tags associated with the opera. This is a string array that can be used to display tags in the component.
          */
         "operaTags"?: string[];
-        /**
-          * The title of the opera.
-         */
-        "operaTitle"?: string;
         /**
           * The label for the volumes. This is used to display the number of volumes or a related message.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1749,11 +1749,11 @@ export namespace Components {
          */
         "author"?: string;
         /**
-          * The subtitle of the opera.
+          * The subtitle of the card.
          */
         "cardSubtitle": string;
         /**
-          * The title of the opera.
+          * The title of the card.
          */
         "cardTitle": string;
         /**
@@ -5594,11 +5594,11 @@ declare namespace LocalJSX {
          */
         "author"?: string;
         /**
-          * The subtitle of the opera.
+          * The subtitle of the card.
          */
         "cardSubtitle"?: string;
         /**
-          * The title of the opera.
+          * The title of the card.
          */
         "cardTitle"?: string;
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1743,6 +1743,40 @@ export namespace Components {
          */
         "secondLabel"?: string;
     }
+    interface ZResultCard {
+        /**
+          * The author of the opera.
+         */
+        "author": string;
+        /**
+          * The URL of the cover image. This is used to display the cover image of the opera.
+         */
+        "cover": string;
+        /**
+          * Indicates whether the card has multiple covers. This is used to apply specific styles when there are multiple covers.
+         */
+        "hasMultipleCovers": boolean;
+        /**
+          * Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.
+         */
+        "isInfoPage": boolean;
+        /**
+          * The subtitle of the opera.
+         */
+        "operaSubtitle": string;
+        /**
+          * Tags associated with the opera. This is a string array that can be used to display tags in the component.
+         */
+        "operaTags": string[];
+        /**
+          * The title of the opera.
+         */
+        "operaTitle": string;
+        /**
+          * The label for the volumes. This is used to display the number of volumes or a related message.
+         */
+        "volumesLabel": string;
+    }
     /**
      * @cssprop --z-searchbar-results-height - Max height of the results container (default: 540px)
      * @cssprop --z-searchbar-tag-text-color - Color of tag's text (default --color-primary03);
@@ -3290,6 +3324,12 @@ declare global {
         prototype: HTMLZRangePickerElement;
         new (): HTMLZRangePickerElement;
     };
+    interface HTMLZResultCardElement extends Components.ZResultCard, HTMLStencilElement {
+    }
+    var HTMLZResultCardElement: {
+        prototype: HTMLZResultCardElement;
+        new (): HTMLZResultCardElement;
+    };
     interface HTMLZSearchbarElementEventMap {
         "searchSubmit": string;
         "searchTyping": string;
@@ -3633,6 +3673,7 @@ declare global {
         "z-panel-elem": HTMLZPanelElemElement;
         "z-popover": HTMLZPopoverElement;
         "z-range-picker": HTMLZRangePickerElement;
+        "z-result-card": HTMLZResultCardElement;
         "z-searchbar": HTMLZSearchbarElement;
         "z-section-title": HTMLZSectionTitleElement;
         "z-select": HTMLZSelectElement;
@@ -5555,6 +5596,40 @@ declare namespace LocalJSX {
          */
         "secondLabel"?: string;
     }
+    interface ZResultCard {
+        /**
+          * The author of the opera.
+         */
+        "author"?: string;
+        /**
+          * The URL of the cover image. This is used to display the cover image of the opera.
+         */
+        "cover"?: string;
+        /**
+          * Indicates whether the card has multiple covers. This is used to apply specific styles when there are multiple covers.
+         */
+        "hasMultipleCovers"?: boolean;
+        /**
+          * Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.
+         */
+        "isInfoPage"?: boolean;
+        /**
+          * The subtitle of the opera.
+         */
+        "operaSubtitle"?: string;
+        /**
+          * Tags associated with the opera. This is a string array that can be used to display tags in the component.
+         */
+        "operaTags"?: string[];
+        /**
+          * The title of the opera.
+         */
+        "operaTitle"?: string;
+        /**
+          * The label for the volumes. This is used to display the number of volumes or a related message.
+         */
+        "volumesLabel"?: string;
+    }
     /**
      * @cssprop --z-searchbar-results-height - Max height of the results container (default: 540px)
      * @cssprop --z-searchbar-tag-text-color - Color of tag's text (default --color-primary03);
@@ -6099,6 +6174,7 @@ declare namespace LocalJSX {
         "z-panel-elem": ZPanelElem;
         "z-popover": ZPopover;
         "z-range-picker": ZRangePicker;
+        "z-result-card": ZResultCard;
         "z-searchbar": ZSearchbar;
         "z-section-title": ZSectionTitle;
         "z-select": ZSelect;
@@ -6366,6 +6442,7 @@ declare module "@stencil/core" {
              */
             "z-popover": LocalJSX.ZPopover & JSXBase.HTMLAttributes<HTMLZPopoverElement>;
             "z-range-picker": LocalJSX.ZRangePicker & JSXBase.HTMLAttributes<HTMLZRangePickerElement>;
+            "z-result-card": LocalJSX.ZResultCard & JSXBase.HTMLAttributes<HTMLZResultCardElement>;
             /**
              * @cssprop --z-searchbar-results-height - Max height of the results container (default: 540px)
              * @cssprop --z-searchbar-tag-text-color - Color of tag's text (default --color-primary03);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1745,9 +1745,9 @@ export namespace Components {
     }
     interface ZResultCard {
         /**
-          * The author of the opera.
+          * The authors of the opera.
          */
-        "author"?: string;
+        "authors"?: string;
         /**
           * The subtitle of the card.
          */
@@ -5590,9 +5590,9 @@ declare namespace LocalJSX {
     }
     interface ZResultCard {
         /**
-          * The author of the opera.
+          * The authors of the opera.
          */
-        "author"?: string;
+        "authors"?: string;
         /**
           * The subtitle of the card.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1747,11 +1747,11 @@ export namespace Components {
         /**
           * The author of the opera.
          */
-        "author": string;
+        "author"?: string;
         /**
           * The URL of the cover image. This is used to display the cover image of the opera.
          */
-        "cover": string;
+        "cover"?: string;
         /**
           * Indicates whether the card has multiple covers. This is used to apply specific styles when there are multiple covers.
          */
@@ -1767,7 +1767,7 @@ export namespace Components {
         /**
           * Tags associated with the opera. This is a string array that can be used to display tags in the component.
          */
-        "operaTags": string[];
+        "operaTags"?: string[];
         /**
           * The title of the opera.
          */
@@ -1775,7 +1775,7 @@ export namespace Components {
         /**
           * The label for the volumes. This is used to display the number of volumes or a related message.
          */
-        "volumesLabel": string;
+        "volumesLabel"?: string;
     }
     /**
      * @cssprop --z-searchbar-results-height - Max height of the results container (default: 540px)

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1767,7 +1767,7 @@ export namespace Components {
         /**
           * Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.
          */
-        "isInfoPage": boolean;
+        "isInfoCard": boolean;
         /**
           * Tags associated with the opera. This is a string array that can be used to display tags in the component.
          */
@@ -5620,7 +5620,7 @@ declare namespace LocalJSX {
         /**
           * Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.
          */
-        "isInfoPage"?: boolean;
+        "isInfoCard"?: boolean;
         /**
           * Tags associated with the opera. This is a string array that can be used to display tags in the component.
          */

--- a/src/components/css-components/index.css
+++ b/src/components/css-components/index.css
@@ -2,3 +2,4 @@
 @import "./z-label/styles.css";
 @import "./z-link/styles.css";
 @import "./z-scrollbar/styles.css";
+@import "./z-cover/styles.css";

--- a/src/components/css-components/z-cover/index.stories.css
+++ b/src/components/css-components/z-cover/index.stories.css
@@ -1,0 +1,10 @@
+.z-cover-story {
+  display: flex;
+  width: 220px;
+  height: 220px;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--space-unit) * 2);
+  background-color: #f5f5f5;
+  border-radius: var(--border-size-large);
+}

--- a/src/components/css-components/z-cover/index.stories.css
+++ b/src/components/css-components/z-cover/index.stories.css
@@ -5,6 +5,6 @@
   align-items: center;
   justify-content: center;
   padding: calc(var(--space-unit) * 2);
-  background-color: #f5f5f5;
+  background-color: var(--gray50);
   border-radius: var(--border-size-large);
 }

--- a/src/components/css-components/z-cover/index.stories.ts
+++ b/src/components/css-components/z-cover/index.stories.ts
@@ -1,0 +1,42 @@
+import {html} from "lit-html";
+import "./index.stories.css";
+import "./styles.css";
+
+export default {
+  title: "ZCover",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export const SingleCover = (): ReturnType<typeof html> => html`
+  <div class="z-cover-story">
+    <div class="z-cover-container">
+      <div class="z-cover-stack">
+        <img
+          src="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
+          alt="Book Cover"
+          class="z-cover-img"
+        />
+      </div>
+    </div>
+  </div>
+`;
+
+export const MultipleCover = (): ReturnType<typeof html> => html`
+  <div class="z-cover-story">
+    <div class="z-cover-container has-multiple">
+      <div class="z-cover-stack">
+        <div>
+          <div class="z-cover-shadow z-shadow-2"></div>
+          <div class="z-cover-shadow z-shadow-1"></div>
+        </div>
+        <img
+          src="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
+          alt="Book Cover"
+          class="z-cover-img"
+        />
+      </div>
+    </div>
+  </div>
+`;

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -36,7 +36,7 @@
 .z-cover-shadow {
   position: absolute;
   z-index: 1;
-  background: #e0e0e0;
+  background: var(--gray100);
   border-radius: var(--border-size-large);
 }
 
@@ -44,14 +44,14 @@
   z-index: 1;
   top: var(--space-unit);
   right: var(--space-unit);
-  border: 2px solid var(--gray200);
+  border: var(--border-size-medium) solid var(--gray200);
 }
 
 .z-shadow-2 {
   z-index: 0;
   top: calc(var(--space-unit) * 2);
   right: calc(var(--space-unit) * 2);
-  border: 2px solid var(--gray200);
+  border: var(--border-size-medium) solid var(--gray200);
 }
 
 .z-cover-img {
@@ -59,7 +59,7 @@
   z-index: 2;
   top: 0;
   right: 0;
-  border: 1px solid var(--gray200);
+  border: var(--border-size-small) var(--gray200);
   border-radius: 6px;
   object-fit: cover;
   object-position: left;

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -26,12 +26,12 @@
 /* Scaled sizes for multiple covers */
 .z-cover-container.has-multiple .z-cover-shadow,
 .z-cover-container.has-multiple .z-cover-img {
-  width: 107px;
-  min-width: 107px;
-  max-width: 107px;
-  height: 142px;
-  min-height: 142px;
-  max-height: 142px;
+  width: 105px;
+  min-width: 105px;
+  max-width: 105px;
+  height: 140px;
+  min-height: 140px;
+  max-height: 140px;
 }
 
 .z-cover-shadow {
@@ -65,5 +65,5 @@
 }
 
 .z-cover-container.has-multiple .z-cover-img {
-  left: 10px;
+  left: 12px;
 }

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -66,5 +66,6 @@
 }
 
 .z-cover-container.has-multiple .z-cover-img {
-  right: 0;
+  top: 2px;
+  left: calc(var(--space-unit) * 2);
 }

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -15,12 +15,12 @@
 /* Base sizes for single cover */
 .z-cover-shadow,
 .z-cover-img {
-  width: 119px;
-  min-width: 119px;
-  max-width: 119px;
-  height: 158px;
-  min-height: 158px;
-  max-height: 158px;
+  width: 117px;
+  min-width: 117px;
+  max-width: 117px;
+  height: 156px;
+  min-height: 156px;
+  max-height: 156px;
 }
 
 /* Scaled sizes for multiple covers */

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -4,11 +4,9 @@
   width: 115px;
   height: 175px;
   align-items: center;
-  padding: var(--space-unit);
 }
 
 .z-cover-stack {
-  position: relative;
   width: 100%;
   height: 100%;
 }
@@ -19,9 +17,9 @@
   width: 115px;
   min-width: 115px;
   max-width: 115px;
-  height: 160px;
-  min-height: 160px;
-  max-height: 160px;
+  height: 175px;
+  min-height: 175px;
+  max-height: 175px;
 }
 
 /* Scaled sizes for multiple covers */
@@ -30,9 +28,9 @@
   width: 95px;
   min-width: 95px;
   max-width: 95px;
-  height: 140px;
-  min-height: 140px;
-  max-height: 140px;
+  height: 160px;
+  min-height: 160px;
+  max-height: 160px;
 }
 
 .z-cover-shadow {
@@ -65,6 +63,7 @@
   border-radius: 6px;
   box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
   object-fit: cover;
+  object-position: left;
 }
 
 .z-cover-container.has-multiple .z-cover-img {

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -28,9 +28,9 @@
   width: 95px;
   min-width: 95px;
   max-width: 95px;
-  height: 157px;
-  min-height: 157px;
-  max-height: 157px;
+  height: 155px;
+  min-height: 155px;
+  max-height: 155px;
 }
 
 .z-cover-shadow {
@@ -38,21 +38,20 @@
   z-index: 1;
   background: #e0e0e0;
   border-radius: var(--border-size-large);
-  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
 }
 
 .z-shadow-1 {
   z-index: 1;
   top: var(--space-unit);
   right: var(--space-unit);
-  border: 1px solid var(--gray200);
+  border: 2px solid var(--gray200);
 }
 
 .z-shadow-2 {
   z-index: 0;
   top: calc(var(--space-unit) * 2);
   right: calc(var(--space-unit) * 2);
-  border: 1px solid var(--gray200);
+  border: 2px solid var(--gray200);
 }
 
 .z-cover-img {
@@ -60,8 +59,8 @@
   z-index: 2;
   top: 0;
   right: 0;
+  border: 1px solid var(--gray200);
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
   object-fit: cover;
   object-position: left;
 }

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -1,0 +1,72 @@
+.z-cover-container {
+  position: relative;
+  display: flex;
+  width: 115px;
+  height: 175px;
+  align-items: center;
+  padding: var(--space-unit);
+}
+
+.z-cover-stack {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+/* Base sizes for single cover */
+.z-cover-shadow,
+.z-cover-img {
+  width: 115px;
+  min-width: 115px;
+  max-width: 115px;
+  height: 160px;
+  min-height: 160px;
+  max-height: 160px;
+}
+
+/* Scaled sizes for multiple covers */
+.z-cover-container.has-multiple .z-cover-shadow,
+.z-cover-container.has-multiple .z-cover-img {
+  width: 95px;
+  min-width: 95px;
+  max-width: 95px;
+  height: 140px;
+  min-height: 140px;
+  max-height: 140px;
+}
+
+.z-cover-shadow {
+  position: absolute;
+  z-index: 1;
+  background: #e0e0e0;
+  border-radius: var(--border-size-large);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+}
+
+.z-shadow-1 {
+  z-index: 1;
+  top: var(--space-unit);
+  right: var(--space-unit);
+  border: 1px solid var(--gray200);
+}
+
+.z-shadow-2 {
+  z-index: 0;
+  top: calc(var(--space-unit) * 2);
+  right: calc(var(--space-unit) * 2);
+  border: 1px solid var(--gray200);
+}
+
+.z-cover-img {
+  position: absolute;
+  z-index: 2;
+  top: 0;
+  right: 0;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  object-fit: cover;
+}
+
+.z-cover-container.has-multiple .z-cover-img {
+  right: 0;
+}

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -1,9 +1,10 @@
 .z-cover-container {
   position: relative;
   display: flex;
-  width: 115px;
-  height: 175px;
+  width: 119px;
+  height: 158px;
   align-items: center;
+  justify-items: center;
 }
 
 .z-cover-stack {
@@ -14,44 +15,43 @@
 /* Base sizes for single cover */
 .z-cover-shadow,
 .z-cover-img {
-  width: 115px;
-  min-width: 115px;
-  max-width: 115px;
-  height: 175px;
-  min-height: 175px;
-  max-height: 175px;
+  width: 119px;
+  min-width: 119px;
+  max-width: 119px;
+  height: 158px;
+  min-height: 158px;
+  max-height: 158px;
 }
 
 /* Scaled sizes for multiple covers */
 .z-cover-container.has-multiple .z-cover-shadow,
 .z-cover-container.has-multiple .z-cover-img {
-  width: 95px;
-  min-width: 95px;
-  max-width: 95px;
-  height: 155px;
-  min-height: 155px;
-  max-height: 155px;
+  width: 107px;
+  min-width: 107px;
+  max-width: 107px;
+  height: 142px;
+  min-height: 142px;
+  max-height: 142px;
 }
 
 .z-cover-shadow {
   position: absolute;
   z-index: 1;
-  background: var(--gray100);
-  border-radius: var(--border-size-large);
+  background-color: var(--color-white);
 }
 
 .z-shadow-1 {
   z-index: 1;
   top: var(--space-unit);
-  right: var(--space-unit);
-  border: var(--border-size-medium) solid var(--gray200);
+  right: 6px;
+  border: var(--border-size-small) solid black;
 }
 
 .z-shadow-2 {
   z-index: 0;
   top: calc(var(--space-unit) * 2);
-  right: calc(var(--space-unit) * 2);
-  border: var(--border-size-medium) solid var(--gray200);
+  right: 12px;
+  border: var(--border-size-small) solid black;
 }
 
 .z-cover-img {
@@ -59,13 +59,11 @@
   z-index: 2;
   top: 0;
   right: 0;
-  border: var(--border-size-small) var(--gray200);
-  border-radius: 6px;
+  border: var(--border-size-small) solid black;
   object-fit: cover;
   object-position: left;
 }
 
 .z-cover-container.has-multiple .z-cover-img {
-  top: 2px;
-  left: calc(var(--space-unit) * 2);
+  left: 10px;
 }

--- a/src/components/css-components/z-cover/styles.css
+++ b/src/components/css-components/z-cover/styles.css
@@ -28,9 +28,9 @@
   width: 95px;
   min-width: 95px;
   max-width: 95px;
-  height: 160px;
-  min-height: 160px;
-  max-height: 160px;
+  height: 157px;
+  min-height: 157px;
+  max-height: 157px;
 }
 
 .z-cover-shadow {

--- a/src/components/result-card/z-result-card/index.spec.ts
+++ b/src/components/result-card/z-result-card/index.spec.ts
@@ -77,6 +77,120 @@ describe("Suite test ZResultCard", () => {
         `);
   });
 
+  it("Test render ZResultCard without author", async () => {
+    const page = await newSpecPage({
+      components: [ZResultCard],
+      html: `<z-result-card 
+                card-title="Opera title multiple cover" 
+                card-subtitle="Opera subtitle multiple cover"
+                cover="test-cover.jpg"
+                has-multiple-covers="true"
+            ></z-result-card>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+            <z-result-card card-title="Opera title multiple cover" card-subtitle="Opera subtitle multiple cover" cover="test-cover.jpg" has-multiple-covers="true" tabindex="0">
+                <mock:shadow-root>
+                    <div class="z-cover-container has-multiple">
+                        <div class="z-cover-stack">
+                            <div>
+                                <div class="z-cover-shadow z-shadow-2"></div>
+                                <div class="z-cover-shadow z-shadow-1"></div>
+                            </div>
+                            <img alt="Book Cover" class="z-cover-img" src="test-cover.jpg">
+                        </div>
+                    </div>
+                    <div class="info-container">
+                        <div class="card-title">Opera title multiple cover</div>
+                        <div class="card-subtitle">Opera subtitle multiple cover</div>
+                        <div class="tags-container">
+                            <slot name="tags"></slot>
+                        </div>
+                        <div class="volumes-label">
+                            <slot name="volumes"></slot>
+                        </div>
+                    </div>
+                </mock:shadow-root>
+            </z-result-card>
+        `);
+  });
+
+  it("Test render ZResultCard with tags", async () => {
+    const page = await newSpecPage({
+      components: [ZResultCard],
+      html: `<z-result-card 
+                author="Test author"
+                card-title="Opera with tags" 
+                card-subtitle="Subtitle with tags"
+                cover="test-cover.jpg">
+                <div slot="tags">Tag 1</div>
+                <div slot="tags">Tag 2</div>
+            </z-result-card>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+            <z-result-card author="Test author" card-title="Opera with tags" card-subtitle="Subtitle with tags" cover="test-cover.jpg" tabindex="0">
+                <mock:shadow-root>
+                    <div class="z-cover-container">
+                        <div class="z-cover-stack">
+                            <img alt="Book Cover" class="z-cover-img" src="test-cover.jpg">
+                        </div>
+                    </div>
+                    <div class="info-container">
+                        <div class="author-label">Test author</div>
+                        <div class="card-title">Opera with tags</div>
+                        <div class="card-subtitle">Subtitle with tags</div>
+                        <div class="tags-container">
+                            <slot name="tags"></slot>
+                        </div>
+                        <div class="volumes-label">
+                            <slot name="volumes"></slot>
+                        </div>
+                    </div>
+                </mock:shadow-root>
+                <div slot="tags">Tag 1</div>
+                <div slot="tags">Tag 2</div>
+            </z-result-card>
+        `);
+  });
+
+  it("Test render ZResultCard with volumes", async () => {
+    const page = await newSpecPage({
+      components: [ZResultCard],
+      html: `<z-result-card 
+                author="Test author"
+                card-title="Opera with volumes" 
+                card-subtitle="Subtitle with volumes"
+                cover="test-cover.jpg">
+                <span slot="volumes">Volume 1</span>
+            </z-result-card>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+            <z-result-card author="Test author" card-title="Opera with volumes" card-subtitle="Subtitle with volumes" cover="test-cover.jpg" tabindex="0">
+                <mock:shadow-root>
+                    <div class="z-cover-container">
+                        <div class="z-cover-stack">
+                            <img alt="Book Cover" class="z-cover-img" src="test-cover.jpg">
+                        </div>
+                    </div>
+                    <div class="info-container">
+                        <div class="author-label">Test author</div>
+                        <div class="card-title">Opera with volumes</div>
+                        <div class="card-subtitle">Subtitle with volumes</div>
+                        <div class="tags-container">
+                            <slot name="tags"></slot>
+                        </div>
+                        <div class="volumes-label">
+                            <slot name="volumes"></slot>
+                        </div>
+                    </div>
+                </mock:shadow-root>
+                <span slot="volumes">Volume 1</span>
+            </z-result-card>
+        `);
+  });
+
   it("Test render ZResultCard as info card", async () => {
     const page = await newSpecPage({
       components: [ZResultCard],

--- a/src/components/result-card/z-result-card/index.spec.ts
+++ b/src/components/result-card/z-result-card/index.spec.ts
@@ -22,9 +22,9 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="author-label">Test author</div>
-                        <div class="card-title">Opera title single cover</div>
-                        <div class="card-subtitle">Opera subtitle single cover</div>
+                        <span class="author-label">Test author</span>
+                        <span class="card-title">Opera title single cover</span>
+                        <span class="card-subtitle">Opera subtitle single cover</span>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>
@@ -62,9 +62,9 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="author-label">Test author</div>
-                        <div class="card-title">Opera title multiple cover</div>
-                        <div class="card-subtitle">Opera subtitle multiple cover</div>
+                        <span class="author-label">Test author</span>
+                        <span class="card-title">Opera title multiple cover</span>
+                        <span class="card-subtitle">Opera subtitle multiple cover</span>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>
@@ -101,8 +101,8 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="card-title">Opera title multiple cover</div>
-                        <div class="card-subtitle">Opera subtitle multiple cover</div>
+                        <span class="card-title">Opera title multiple cover</span>
+                        <span class="card-subtitle">Opera subtitle multiple cover</span>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>
@@ -137,9 +137,9 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="author-label">Test author</div>
-                        <div class="card-title">Opera with tags</div>
-                        <div class="card-subtitle">Subtitle with tags</div>
+                        <span class="author-label">Test author</span>
+                        <span class="card-title">Opera with tags</span>
+                        <span class="card-subtitle">Subtitle with tags</span>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>
@@ -175,9 +175,9 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="author-label">Test author</div>
-                        <div class="card-title">Opera with volumes</div>
-                        <div class="card-subtitle">Subtitle with volumes</div>
+                        <span class="author-label">Test author</span>
+                        <span class="card-title">Opera with volumes</span>
+                        <span class="card-subtitle">Subtitle with volumes</span>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>
@@ -210,8 +210,8 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="card-title info-title">Info Title</div>
-                        <div class="card-subtitle info-subtitle">Info Subtitle</div>
+                        <span class="card-title info-title">Info Title</span>
+                        <span class="card-subtitle info-subtitle">Info Subtitle</span>
                     </div>
                 </mock:shadow-root>
             </z-result-card>

--- a/src/components/result-card/z-result-card/index.spec.ts
+++ b/src/components/result-card/z-result-card/index.spec.ts
@@ -2,23 +2,29 @@ import {newSpecPage} from "@stencil/core/testing";
 import {ZResultCard} from "./index";
 
 describe("Suite test ZResultCard", () => {
-  it("Test render ZResultCard empty", async () => {
+  it("Test render ZResultCard with single cover", async () => {
     const page = await newSpecPage({
       components: [ZResultCard],
-      html: `<z-result-card card-title="" card-subtitle=""></z-result-card>`,
+      html: `<z-result-card 
+                  author="Test author"
+                  card-title="Opera title single cover" 
+                  card-subtitle="Opera subtitle single cover"
+                  cover="test-cover.jpg"
+              ></z-result-card>`,
     });
 
     expect(page.root).toEqualHtml(`
-            <z-result-card card-title="" card-subtitle="" tabindex="0">
+            <z-result-card author="Test author" card-title="Opera title single cover" card-subtitle="Opera subtitle single cover" cover="test-cover.jpg" tabindex="0">
                 <mock:shadow-root>
                     <div class="z-cover-container">
                         <div class="z-cover-stack">
-                            <img alt="Book Cover" class="z-cover-img">
+                            <img alt="Book Cover" class="z-cover-img" src="test-cover.jpg">
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="card-title"></div>
-                        <div class="card-subtitle"></div>
+                        <div class="author-label">Test author</div>
+                        <div class="card-title">Opera title single cover</div>
+                        <div class="card-subtitle">Opera subtitle single cover</div>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>
@@ -31,20 +37,20 @@ describe("Suite test ZResultCard", () => {
         `);
   });
 
-  it("Test render ZResultCard with opera props", async () => {
+  it("Test render ZResultCard with multiple covers", async () => {
     const page = await newSpecPage({
       components: [ZResultCard],
       html: `<z-result-card 
-                author="Test Author"
-                card-title="Test Title" 
-                card-subtitle="Test Subtitle"
+                author="Test author"
+                card-title="Opera title multiple cover" 
+                card-subtitle="Opera subtitle multiple cover"
                 cover="test-cover.jpg"
                 has-multiple-covers="true"
             ></z-result-card>`,
     });
 
     expect(page.root).toEqualHtml(`
-            <z-result-card author="Test Author" card-title="Test Title" card-subtitle="Test Subtitle" cover="test-cover.jpg" has-multiple-covers="true" tabindex="0">
+            <z-result-card author="Test author" card-title="Opera title multiple cover" card-subtitle="Opera subtitle multiple cover" cover="test-cover.jpg" has-multiple-covers="true" tabindex="0">
                 <mock:shadow-root>
                     <div class="z-cover-container has-multiple">
                         <div class="z-cover-stack">
@@ -56,9 +62,9 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <div class="author-label">Test Author</div>
-                        <div class="card-title">Test Title</div>
-                        <div class="card-subtitle">Test Subtitle</div>
+                        <div class="author-label">Test author</div>
+                        <div class="card-title">Opera title multiple cover</div>
+                        <div class="card-subtitle">Opera subtitle multiple cover</div>
                         <div class="tags-container">
                             <slot name="tags"></slot>
                         </div>

--- a/src/components/result-card/z-result-card/index.spec.ts
+++ b/src/components/result-card/z-result-card/index.spec.ts
@@ -1,0 +1,100 @@
+import {newSpecPage} from "@stencil/core/testing";
+import {ZResultCard} from "./index";
+
+describe("Suite test ZResultCard", () => {
+  it("Test render ZResultCard empty", async () => {
+    const page = await newSpecPage({
+      components: [ZResultCard],
+      html: `<z-result-card card-title="" card-subtitle=""></z-result-card>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+            <z-result-card card-title="" card-subtitle="" tabindex="0">
+                <mock:shadow-root>
+                    <div class="z-cover-container">
+                        <div class="z-cover-stack">
+                            <img alt="Book Cover" class="z-cover-img">
+                        </div>
+                    </div>
+                    <div class="info-container">
+                        <div class="card-title"></div>
+                        <div class="card-subtitle"></div>
+                        <div class="tags-container">
+                            <slot name="tags"></slot>
+                        </div>
+                        <div class="volumes-label">
+                            <slot name="volumes"></slot>
+                        </div>
+                    </div>
+                </mock:shadow-root>
+            </z-result-card>
+        `);
+  });
+
+  it("Test render ZResultCard with opera props", async () => {
+    const page = await newSpecPage({
+      components: [ZResultCard],
+      html: `<z-result-card 
+                author="Test Author"
+                card-title="Test Title" 
+                card-subtitle="Test Subtitle"
+                cover="test-cover.jpg"
+                has-multiple-covers="true"
+            ></z-result-card>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+            <z-result-card author="Test Author" card-title="Test Title" card-subtitle="Test Subtitle" cover="test-cover.jpg" has-multiple-covers="true" tabindex="0">
+                <mock:shadow-root>
+                    <div class="z-cover-container has-multiple">
+                        <div class="z-cover-stack">
+                            <div>
+                                <div class="z-cover-shadow z-shadow-2"></div>
+                                <div class="z-cover-shadow z-shadow-1"></div>
+                            </div>
+                            <img alt="Book Cover" class="z-cover-img" src="test-cover.jpg">
+                        </div>
+                    </div>
+                    <div class="info-container">
+                        <div class="author-label">Test Author</div>
+                        <div class="card-title">Test Title</div>
+                        <div class="card-subtitle">Test Subtitle</div>
+                        <div class="tags-container">
+                            <slot name="tags"></slot>
+                        </div>
+                        <div class="volumes-label">
+                            <slot name="volumes"></slot>
+                        </div>
+                    </div>
+                </mock:shadow-root>
+            </z-result-card>
+        `);
+  });
+
+  it("Test render ZResultCard as info card", async () => {
+    const page = await newSpecPage({
+      components: [ZResultCard],
+      html: `<z-result-card
+                card-title="Info Title"
+                card-subtitle="Info Subtitle"
+                is-info-card="true"
+            ></z-result-card>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+            <z-result-card card-title="Info Title" card-subtitle="Info Subtitle" is-info-card="true" class="info-card" tabindex="0">
+                <mock:shadow-root>
+                    <div class="info-icon-column">
+                        <div class="info-icon-container">
+                            <z-icon class="info-icon" height="18" name="link" width="18"></z-icon>
+                        </div>
+                    </div>
+                    <div class="info-container">
+                        <div class="card-title info-title">Info Title</div>
+                        <div class="card-subtitle info-subtitle">Info Subtitle</div>
+                    </div>
+                </mock:shadow-root>
+            </z-result-card>
+        `);
+  });
+});

--- a/src/components/result-card/z-result-card/index.spec.ts
+++ b/src/components/result-card/z-result-card/index.spec.ts
@@ -6,7 +6,7 @@ describe("Suite test ZResultCard", () => {
     const page = await newSpecPage({
       components: [ZResultCard],
       html: `<z-result-card 
-                  author="Test author"
+                  authors="Test author"
                   card-title="Opera title single cover" 
                   card-subtitle="Opera subtitle single cover"
                   cover="test-cover.jpg"
@@ -14,7 +14,7 @@ describe("Suite test ZResultCard", () => {
     });
 
     expect(page.root).toEqualHtml(`
-            <z-result-card author="Test author" card-title="Opera title single cover" card-subtitle="Opera subtitle single cover" cover="test-cover.jpg" tabindex="0">
+            <z-result-card authors="Test author" card-title="Opera title single cover" card-subtitle="Opera subtitle single cover" cover="test-cover.jpg" tabindex="0">
                 <mock:shadow-root>
                     <div class="z-cover-container">
                         <div class="z-cover-stack">
@@ -22,7 +22,7 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <span class="author-label">Test author</span>
+                        <span class="authors-label">Test author</span>
                         <span class="card-title">Opera title single cover</span>
                         <span class="card-subtitle">Opera subtitle single cover</span>
                         <div class="tags-container">
@@ -41,7 +41,7 @@ describe("Suite test ZResultCard", () => {
     const page = await newSpecPage({
       components: [ZResultCard],
       html: `<z-result-card 
-                author="Test author"
+                authors="Test author"
                 card-title="Opera title multiple cover" 
                 card-subtitle="Opera subtitle multiple cover"
                 cover="test-cover.jpg"
@@ -50,7 +50,7 @@ describe("Suite test ZResultCard", () => {
     });
 
     expect(page.root).toEqualHtml(`
-            <z-result-card author="Test author" card-title="Opera title multiple cover" card-subtitle="Opera subtitle multiple cover" cover="test-cover.jpg" has-multiple-covers="true" tabindex="0">
+            <z-result-card authors="Test author" card-title="Opera title multiple cover" card-subtitle="Opera subtitle multiple cover" cover="test-cover.jpg" has-multiple-covers="true" tabindex="0">
                 <mock:shadow-root>
                     <div class="z-cover-container has-multiple">
                         <div class="z-cover-stack">
@@ -62,7 +62,7 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <span class="author-label">Test author</span>
+                        <span class="authors-label">Test author</span>
                         <span class="card-title">Opera title multiple cover</span>
                         <span class="card-subtitle">Opera subtitle multiple cover</span>
                         <div class="tags-container">
@@ -77,7 +77,7 @@ describe("Suite test ZResultCard", () => {
         `);
   });
 
-  it("Test render ZResultCard without author", async () => {
+  it("Test render ZResultCard without authors", async () => {
     const page = await newSpecPage({
       components: [ZResultCard],
       html: `<z-result-card 
@@ -119,7 +119,7 @@ describe("Suite test ZResultCard", () => {
     const page = await newSpecPage({
       components: [ZResultCard],
       html: `<z-result-card 
-                author="Test author"
+                authors="Test author"
                 card-title="Opera with tags" 
                 card-subtitle="Subtitle with tags"
                 cover="test-cover.jpg">
@@ -129,7 +129,7 @@ describe("Suite test ZResultCard", () => {
     });
 
     expect(page.root).toEqualHtml(`
-            <z-result-card author="Test author" card-title="Opera with tags" card-subtitle="Subtitle with tags" cover="test-cover.jpg" tabindex="0">
+            <z-result-card authors="Test author" card-title="Opera with tags" card-subtitle="Subtitle with tags" cover="test-cover.jpg" tabindex="0">
                 <mock:shadow-root>
                     <div class="z-cover-container">
                         <div class="z-cover-stack">
@@ -137,7 +137,7 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <span class="author-label">Test author</span>
+                        <span class="authors-label">Test author</span>
                         <span class="card-title">Opera with tags</span>
                         <span class="card-subtitle">Subtitle with tags</span>
                         <div class="tags-container">
@@ -158,7 +158,7 @@ describe("Suite test ZResultCard", () => {
     const page = await newSpecPage({
       components: [ZResultCard],
       html: `<z-result-card 
-                author="Test author"
+                authors="Test author"
                 card-title="Opera with volumes" 
                 card-subtitle="Subtitle with volumes"
                 cover="test-cover.jpg">
@@ -167,7 +167,7 @@ describe("Suite test ZResultCard", () => {
     });
 
     expect(page.root).toEqualHtml(`
-            <z-result-card author="Test author" card-title="Opera with volumes" card-subtitle="Subtitle with volumes" cover="test-cover.jpg" tabindex="0">
+            <z-result-card authors="Test author" card-title="Opera with volumes" card-subtitle="Subtitle with volumes" cover="test-cover.jpg" tabindex="0">
                 <mock:shadow-root>
                     <div class="z-cover-container">
                         <div class="z-cover-stack">
@@ -175,7 +175,7 @@ describe("Suite test ZResultCard", () => {
                         </div>
                     </div>
                     <div class="info-container">
-                        <span class="author-label">Test author</span>
+                        <span class="authors-label">Test author</span>
                         <span class="card-title">Opera with volumes</span>
                         <span class="card-subtitle">Subtitle with volumes</span>
                         <div class="tags-container">

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -18,13 +18,13 @@ export class ZResultCard {
    * The title of the opera.
    */
   @Prop()
-  operaTitle: string;
+  cardTitle: string;
 
   /**
    * The subtitle of the opera.
    */
   @Prop()
-  operaSubtitle: string;
+  cardSubtitle: string;
 
   /**
    * Tags associated with the opera.
@@ -85,8 +85,8 @@ export class ZResultCard {
         </div>
         <div class="info-container">
           <div class="author-label">{this.author}</div>
-          <div class="opera-title">{this.operaTitle}</div>
-          <div class="opera-subtitle">{this.operaSubtitle}</div>
+          <div class="card-title">{this.cardTitle}</div>
+          <div class="card-subtitle">{this.cardSubtitle}</div>
           <div class="tags-container">
             <slot name="tags"></slot>
           </div>

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -53,7 +53,7 @@ export class ZResultCard {
 
   private subtitleRef: HTMLElement;
 
-  private setEllipsisTitle(el: HTMLElement): void {
+  private setTooltipTitle(el: HTMLElement): void {
     if (!el) {
       return;
     }
@@ -83,15 +83,15 @@ export class ZResultCard {
   }
 
   componentDidRender(): void {
-    this.setEllipsisTitle(this.authorRef);
-    this.setEllipsisTitle(this.titleRef);
-    this.setEllipsisTitle(this.subtitleRef);
+    this.setTooltipTitle(this.authorRef);
+    this.setTooltipTitle(this.titleRef);
+    this.setTooltipTitle(this.subtitleRef);
   }
 
   private resizeHandler = (): void => {
-    this.setEllipsisTitle(this.authorRef);
-    this.setEllipsisTitle(this.titleRef);
-    this.setEllipsisTitle(this.subtitleRef);
+    this.setTooltipTitle(this.authorRef);
+    this.setTooltipTitle(this.titleRef);
+    this.setTooltipTitle(this.subtitleRef);
   };
 
   componentDidLoad(): void {

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -47,6 +47,46 @@ export class ZResultCard {
   @Prop()
   isInfoCard = false;
 
+  private authorRef: HTMLElement;
+
+  private titleRef: HTMLElement;
+
+  private subtitleRef: HTMLElement;
+
+  private setEllipsisTitle(el: HTMLElement): void {
+    if (!el) {
+      return;
+    }
+
+    const isTruncated = el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+
+    if (isTruncated) {
+      el.setAttribute("title", el.textContent.trim());
+    } else {
+      el.removeAttribute("title");
+    }
+  }
+
+  componentDidRender(): void {
+    this.setEllipsisTitle(this.authorRef);
+    this.setEllipsisTitle(this.titleRef);
+    this.setEllipsisTitle(this.subtitleRef);
+  }
+
+  private resizeHandler = (): void => {
+    this.setEllipsisTitle(this.authorRef);
+    this.setEllipsisTitle(this.titleRef);
+    this.setEllipsisTitle(this.subtitleRef);
+  };
+
+  componentDidLoad(): void {
+    window.addEventListener("resize", this.resizeHandler);
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener("resize", this.resizeHandler);
+  }
+
   private renderOperaCard = (): HTMLZResultCardElement => {
     return (
       <Host tabIndex={0}>
@@ -66,9 +106,26 @@ export class ZResultCard {
           </div>
         </div>
         <div class="info-container">
-          {this.author && <div class="author-label">{this.author}</div>}
-          <div class="card-title">{this.cardTitle}</div>
-          <div class="card-subtitle">{this.cardSubtitle}</div>
+          {this.author && (
+            <div
+              class="author-label"
+              ref={(el) => (this.authorRef = el as HTMLElement)}
+            >
+              {this.author}
+            </div>
+          )}
+          <div
+            class="card-title"
+            ref={(el) => (this.titleRef = el as HTMLElement)}
+          >
+            {this.cardTitle}
+          </div>
+          <div
+            class="card-subtitle"
+            ref={(el) => (this.subtitleRef = el as HTMLElement)}
+          >
+            {this.cardSubtitle}
+          </div>
           <div class="tags-container">
             <slot name="tags"></slot>
           </div>
@@ -97,18 +154,24 @@ export class ZResultCard {
           </div>
         </div>
         <div class="info-container">
-          <div class="card-title info-title">{this.cardTitle}</div>
-          <div class="card-subtitle info-subtitle">{this.cardSubtitle}</div>
+          <div
+            class="card-title info-title"
+            ref={(el) => (this.titleRef = el as HTMLElement)}
+          >
+            {this.cardTitle}
+          </div>
+          <div
+            class="card-subtitle info-subtitle"
+            ref={(el) => (this.subtitleRef = el as HTMLElement)}
+          >
+            {this.cardSubtitle}
+          </div>
         </div>
       </Host>
     );
   };
 
   render(): HTMLZResultCardElement {
-    if (this.isInfoCard) {
-      return this.renderInfoCard();
-    }
-
-    return this.renderOperaCard();
+    return this.isInfoCard ? this.renderInfoCard() : this.renderOperaCard();
   }
 }

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -122,25 +122,25 @@ export class ZResultCard {
         </div>
         <div class="info-container">
           {this.author && (
-            <div
+            <span
               class="author-label"
               ref={(el) => (this.authorRef = el as HTMLElement)}
             >
               {this.author}
-            </div>
+            </span>
           )}
-          <div
+          <span
             class="card-title"
             ref={(el) => (this.titleRef = el as HTMLElement)}
           >
             {this.cardTitle}
-          </div>
-          <div
+          </span>
+          <span
             class="card-subtitle"
             ref={(el) => (this.subtitleRef = el as HTMLElement)}
           >
             {this.cardSubtitle}
-          </div>
+          </span>
           <div class="tags-container">
             <slot name="tags"></slot>
           </div>
@@ -169,18 +169,18 @@ export class ZResultCard {
           </div>
         </div>
         <div class="info-container">
-          <div
+          <span
             class="card-title info-title"
             ref={(el) => (this.titleRef = el as HTMLElement)}
           >
             {this.cardTitle}
-          </div>
-          <div
+          </span>
+          <span
             class="card-subtitle info-subtitle"
             ref={(el) => (this.subtitleRef = el as HTMLElement)}
           >
             {this.cardSubtitle}
-          </div>
+          </span>
         </div>
       </Host>
     );

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -1,4 +1,4 @@
-import {Component, Element, h, Host, Prop} from "@stencil/core";
+import {Component, Element, Host, Prop, h} from "@stencil/core";
 
 @Component({
   tag: "z-result-card",
@@ -59,15 +59,11 @@ export class ZResultCard {
    * This can be used to apply specific styles or behaviors for info pages.
    */
   @Prop()
-  isInfoPage = false;
+  isInfoCard = false;
 
   private renderOperaCard = (): HTMLZResultCardElement => {
     return (
-      <Host
-        onClick={() => {
-          console.log("Card clicked");
-        }}
-      >
+      <Host tabIndex={0}>
         <div class={`z-cover-container ${this.hasMultipleCovers ? "has-multiple" : ""}`}>
           <div class="z-cover-stack">
             {this.hasMultipleCovers && (
@@ -101,10 +97,8 @@ export class ZResultCard {
   private renderInfoCard = (): HTMLZResultCardElement => {
     return (
       <Host
+        tabIndex={0}
         class="info-card"
-        onClick={() => {
-          console.log("Card clicked");
-        }}
       >
         <div class="info-icon-column">
           <div class="info-icon-container">
@@ -125,7 +119,7 @@ export class ZResultCard {
   };
 
   render(): HTMLZResultCardElement {
-    if (this.isInfoPage) {
+    if (this.isInfoCard) {
       return this.renderInfoCard();
     }
 

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -72,8 +72,8 @@ export class ZResultCard {
           <div class="z-cover-stack">
             {this.hasMultipleCovers && (
               <div>
-                <div class="z-cover-shadow z-shadow-2"></div>
-                <div class="z-cover-shadow z-shadow-1"></div>
+                <div class="z-cover-shadow z-shadow-2" />
+                <div class="z-cover-shadow z-shadow-1" />
               </div>
             )}
             <img
@@ -84,7 +84,7 @@ export class ZResultCard {
           </div>
         </div>
         <div class="info-container">
-          <div class="author-label">{this.author}</div>
+          {this.author && <div class="author-label">{this.author}</div>}
           <div class="card-title">{this.cardTitle}</div>
           <div class="card-subtitle">{this.cardSubtitle}</div>
           <div class="tags-container">
@@ -101,11 +101,25 @@ export class ZResultCard {
   private renderInfoCard = (): HTMLZResultCardElement => {
     return (
       <Host
+        class="info-card"
         onClick={() => {
           console.log("Card clicked");
         }}
       >
-        <div>Info Card</div>
+        <div class="info-icon-column">
+          <div class="info-icon-container">
+            <z-icon
+              class="info-icon"
+              name="link"
+              width={18}
+              height={18}
+            />
+          </div>
+        </div>
+        <div class="info-container">
+          <div class="card-title info-title">{this.cardTitle}</div>
+          <div class="card-subtitle info-subtitle">{this.cardSubtitle}</div>
+        </div>
       </Host>
     );
   };

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -86,7 +86,9 @@ export class ZResultCard {
           <div class="tags-container">
             <slot name="tags"></slot>
           </div>
-          <span class="volumes-label">{this.volumesLabel}</span>
+          <div class="volumes-label">
+            <slot name="volumes"></slot>
+          </div>
         </div>
       </Host>
     );

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -12,7 +12,7 @@ export class ZResultCard {
    * The author of the opera.
    */
   @Prop()
-  author: string;
+  author?: string;
 
   /**
    * The title of the opera.
@@ -31,21 +31,21 @@ export class ZResultCard {
    * This is a string array that can be used to display tags in the component.
    */
   @Prop()
-  operaTags: string[];
+  operaTags?: string[];
 
   /**
    * The label for the volumes.
    * This is used to display the number of volumes or a related message.
    */
   @Prop()
-  volumesLabel: string;
+  volumesLabel?: string;
 
   /**
    * The URL of the cover image.
    * This is used to display the cover image of the opera.
    */
   @Prop()
-  cover: string;
+  cover?: string;
 
   /**
    * Indicates whether the card has multiple covers.
@@ -61,7 +61,7 @@ export class ZResultCard {
   @Prop()
   isInfoPage = false;
 
-  render(): HTMLZResultCardElement {
+  private renderOperaCard = (): HTMLZResultCardElement => {
     return (
       <Host
         onClick={() => {
@@ -96,5 +96,25 @@ export class ZResultCard {
         </div>
       </Host>
     );
+  };
+
+  private renderInfoCard = (): HTMLZResultCardElement => {
+    return (
+      <Host
+        onClick={() => {
+          console.log("Card clicked");
+        }}
+      >
+        <div>Info Card</div>
+      </Host>
+    );
+  };
+
+  render(): HTMLZResultCardElement {
+    if (this.isInfoPage) {
+      return this.renderInfoCard();
+    }
+
+    return this.renderOperaCard();
   }
 }

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -21,10 +21,10 @@ export class ZResultCard {
   cardSubtitle: string;
 
   /**
-   * The author of the opera.
+   * The authors of the opera.
    */
   @Prop()
-  author?: string;
+  authors?: string;
 
   /**
    * The URL of the cover image.
@@ -47,7 +47,7 @@ export class ZResultCard {
   @Prop()
   isInfoCard = false;
 
-  private authorRef: HTMLElement;
+  private authorsRef: HTMLElement;
 
   private titleRef: HTMLElement;
 
@@ -83,13 +83,13 @@ export class ZResultCard {
   }
 
   componentDidRender(): void {
-    this.setTooltipTitle(this.authorRef);
+    this.setTooltipTitle(this.authorsRef);
     this.setTooltipTitle(this.titleRef);
     this.setTooltipTitle(this.subtitleRef);
   }
 
   private resizeHandler = (): void => {
-    this.setTooltipTitle(this.authorRef);
+    this.setTooltipTitle(this.authorsRef);
     this.setTooltipTitle(this.titleRef);
     this.setTooltipTitle(this.subtitleRef);
   };
@@ -121,12 +121,12 @@ export class ZResultCard {
           </div>
         </div>
         <div class="info-container">
-          {this.author && (
+          {this.authors && (
             <span
-              class="author-label"
-              ref={(el) => (this.authorRef = el as HTMLElement)}
+              class="authors-label"
+              ref={(el) => (this.authorsRef = el as HTMLElement)}
             >
-              {this.author}
+              {this.authors}
             </span>
           )}
           <span

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -58,7 +58,22 @@ export class ZResultCard {
       return;
     }
 
-    const isTruncated = el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+    // Check if element uses line-clamp
+    const style = window.getComputedStyle(el);
+    const hasLineClamp = style.getPropertyValue("-webkit-line-clamp") !== "none";
+
+    let isTruncated;
+    if (hasLineClamp) {
+      // For elements with line-clamp, check if content height exceeds line-clamp height
+      const lineHeight = parseInt(style.lineHeight);
+      const maxLines = parseInt(style.getPropertyValue("-webkit-line-clamp"));
+      const maxHeight = lineHeight * maxLines;
+
+      isTruncated = el.scrollHeight > maxHeight;
+    } else {
+      // Original check for elements without line-clamp
+      isTruncated = el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+    }
 
     if (isTruncated) {
       el.setAttribute("title", el.textContent.trim());

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -1,0 +1,94 @@
+import {Component, Element, h, Host, Prop} from "@stencil/core";
+
+@Component({
+  tag: "z-result-card",
+  styleUrls: ["styles.css", "../../css-components/z-cover/styles.css"],
+  shadow: true,
+})
+export class ZResultCard {
+  @Element() hostElement: HTMLZResultCardElement;
+
+  /**
+   * The author of the opera.
+   */
+  @Prop()
+  author: string;
+
+  /**
+   * The title of the opera.
+   */
+  @Prop()
+  operaTitle: string;
+
+  /**
+   * The subtitle of the opera.
+   */
+  @Prop()
+  operaSubtitle: string;
+
+  /**
+   * Tags associated with the opera.
+   * This is a string array that can be used to display tags in the component.
+   */
+  @Prop()
+  operaTags: string[];
+
+  /**
+   * The label for the volumes.
+   * This is used to display the number of volumes or a related message.
+   */
+  @Prop()
+  volumesLabel: string;
+
+  /**
+   * The URL of the cover image.
+   * This is used to display the cover image of the opera.
+   */
+  @Prop()
+  cover: string;
+
+  /**
+   * Indicates whether the card has multiple covers.
+   * This is used to apply specific styles when there are multiple covers.
+   */
+  @Prop()
+  hasMultipleCovers = false;
+
+  /**
+   * Indicates whether the card is an info page.
+   * This can be used to apply specific styles or behaviors for info pages.
+   */
+  @Prop()
+  isInfoPage = false;
+
+  render(): HTMLZResultCardElement {
+    return (
+      <Host>
+        <div class={`z-cover-container ${this.hasMultipleCovers ? "has-multiple" : ""}`}>
+          <div class="z-cover-stack">
+            {this.hasMultipleCovers && (
+              <div>
+                <div class="z-cover-shadow z-shadow-2"></div>
+                <div class="z-cover-shadow z-shadow-1"></div>
+              </div>
+            )}
+            <img
+              src={this.cover}
+              alt="Book Cover"
+              class="z-cover-img"
+            />
+          </div>
+        </div>
+        <div class="info-container">
+          <div class="author-label">{this.author}</div>
+          <div class="opera-title">{this.operaTitle}</div>
+          <div class="opera-subtitle">{this.operaSubtitle}</div>
+          <div class="tags-container">
+            <slot name="tags"></slot>
+          </div>
+          <span class="volumes-label">{this.volumesLabel}</span>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -63,7 +63,11 @@ export class ZResultCard {
 
   render(): HTMLZResultCardElement {
     return (
-      <Host>
+      <Host
+        onClick={() => {
+          console.log("Card clicked");
+        }}
+      >
         <div class={`z-cover-container ${this.hasMultipleCovers ? "has-multiple" : ""}`}>
           <div class="z-cover-stack">
             {this.hasMultipleCovers && (

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -9,22 +9,22 @@ export class ZResultCard {
   @Element() hostElement: HTMLZResultCardElement;
 
   /**
-   * The author of the opera.
-   */
-  @Prop()
-  author?: string;
-
-  /**
-   * The title of the opera.
+   * The title of the card.
    */
   @Prop()
   cardTitle: string;
 
   /**
-   * The subtitle of the opera.
+   * The subtitle of the card.
    */
   @Prop()
   cardSubtitle: string;
+
+  /**
+   * The author of the opera.
+   */
+  @Prop()
+  author?: string;
 
   /**
    * The URL of the cover image.

--- a/src/components/result-card/z-result-card/index.tsx
+++ b/src/components/result-card/z-result-card/index.tsx
@@ -27,20 +27,6 @@ export class ZResultCard {
   cardSubtitle: string;
 
   /**
-   * Tags associated with the opera.
-   * This is a string array that can be used to display tags in the component.
-   */
-  @Prop()
-  operaTags?: string[];
-
-  /**
-   * The label for the volumes.
-   * This is used to display the number of volumes or a related message.
-   */
-  @Prop()
-  volumesLabel?: string;
-
-  /**
    * The URL of the cover image.
    * This is used to display the cover image of the opera.
    */

--- a/src/components/result-card/z-result-card/readme.md
+++ b/src/components/result-card/z-result-card/readme.md
@@ -1,0 +1,23 @@
+# z-result-card
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property        | Attribute        | Description | Type       | Default     |
+| --------------- | ---------------- | ----------- | ---------- | ----------- |
+| `author`        | `author`         |             | `string`   | `undefined` |
+| `cover`         | `cover`          |             | `string`   | `undefined` |
+| `isInfoPage`    | `is-info-page`   |             | `boolean`  | `false`     |
+| `operaSubtitle` | `opera-subtitle` |             | `string`   | `undefined` |
+| `operaTags`     | --               |             | `string[]` | `undefined` |
+| `operaTitle`    | `opera-title`    |             | `string`   | `undefined` |
+| `volumesLabel`  | `volumes-label`  |             | `string`   | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/result-card/z-result-card/readme.md
+++ b/src/components/result-card/z-result-card/readme.md
@@ -7,16 +7,28 @@
 
 ## Properties
 
-| Property        | Attribute        | Description | Type       | Default     |
-| --------------- | ---------------- | ----------- | ---------- | ----------- |
-| `author`        | `author`         |             | `string`   | `undefined` |
-| `cover`         | `cover`          |             | `string`   | `undefined` |
-| `isInfoPage`    | `is-info-page`   |             | `boolean`  | `false`     |
-| `operaSubtitle` | `opera-subtitle` |             | `string`   | `undefined` |
-| `operaTags`     | --               |             | `string[]` | `undefined` |
-| `operaTitle`    | `opera-title`    |             | `string`   | `undefined` |
-| `volumesLabel`  | `volumes-label`  |             | `string`   | `undefined` |
+| Property            | Attribute             | Description                                                                                                           | Type      | Default     |
+| ------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `authors`           | `authors`             | The authors of the opera.                                                                                             | `string`  | `undefined` |
+| `cardSubtitle`      | `card-subtitle`       | The subtitle of the card.                                                                                             | `string`  | `undefined` |
+| `cardTitle`         | `card-title`          | The title of the card.                                                                                                | `string`  | `undefined` |
+| `cover`             | `cover`               | The URL of the cover image. This is used to display the cover image of the opera.                                     | `string`  | `undefined` |
+| `hasMultipleCovers` | `has-multiple-covers` | Indicates whether the card has multiple covers. This is used to apply specific styles when there are multiple covers. | `boolean` | `false`     |
+| `isInfoCard`        | `is-info-card`        | Indicates whether the card is an info page. This can be used to apply specific styles or behaviors for info pages.    | `boolean` | `false`     |
 
+
+## Dependencies
+
+### Depends on
+
+- [z-icon](../../z-icon)
+
+### Graph
+```mermaid
+graph TD;
+  z-result-card --> z-icon
+  style z-result-card fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -48,7 +48,6 @@
   min-width: 0;
   max-width: 100%;
   max-height: 2.4em;
-  margin-top: var(--space-unit);
   margin-bottom: 4px;
   -webkit-box-orient: vertical;
   font-size: var(--font-size-3);
@@ -70,7 +69,7 @@
   display: flex;
   max-width: 100%;
   flex-wrap: wrap;
-  margin-top: var(--space-unit);
+  margin-top: calc(var(--space-unit) * 2);
   gap: var(--space-unit);
 }
 
@@ -87,6 +86,10 @@
   display: flex;
   width: 100%;
   height: 75px;
+}
+
+:host(.info-card) .info-container {
+  justify-content: space-between;
 }
 
 .info-icon-column {

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -68,6 +68,66 @@
   font-size: var(--font-size-1);
 }
 
+:host(.info-card) {
+  display: flex;
+  width: 100%;
+  max-width: 500px;
+  height: 75px;
+}
+
+.info-icon-column {
+  display: flex;
+  width: 50px;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.info-icon-container {
+  display: flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: calc(var(--space-unit) * 3);
+  background-color: var(--gray50);
+  border-radius: var(--border-size-large);
+}
+
+.card-title.info-title {
+  display: -webkit-box;
+  overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
+  max-height: 2.4em;
+  margin-top: 0;
+  margin-bottom: 4px;
+  -webkit-box-orient: vertical;
+  font-size: var(--font-size-3);
+  font-weight: var(--font-bd);
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.card-subtitle.info-subtitle {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  line-height: 1.2;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.info-icon {
+  width: 18px; /* modificato per match con le props nel tsx */
+  height: 18px; /* modificato per match con le props nel tsx */
+  color: var(--color-default-text);
+}
+
 @media (max-width: 768px) {
   .card-title {
     display: block;
@@ -78,5 +138,13 @@
     line-height: normal;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .card-title.info-title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+    white-space: normal;
   }
 }

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -6,7 +6,7 @@
   height: 175px;
   max-height: 175px;
   padding: var(--space-unit);
-  border: 2px solid var(--color-surface02);
+  border: var(--border-size-medium) solid var(--color-surface02);
   border-radius: var(--border-size-large);
   cursor: pointer;
   font-family: var(--font-family-sans);
@@ -33,7 +33,7 @@
   padding-left: calc(var(--space-unit) * 2);
 }
 
-.author-label {
+.authors-label {
   overflow: hidden;
   color: var(--color-default-text);
   font-size: var(--font-size-2);

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -3,8 +3,8 @@
   overflow: hidden;
   width: 100%;
   min-width: 0;
-  height: calc(175px - var(--space-unit) * 2);
-  max-height: calc(175px - var(--space-unit) * 2);
+  height: calc(174px - var(--space-unit) * 2);
+  max-height: calc(174px - var(--space-unit) * 2);
   padding: var(--space-unit);
   border: var(--border-size-medium) solid var(--color-surface02);
   border-radius: var(--border-size-large);

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -5,10 +5,24 @@
   min-width: 0;
   max-width: 500px;
   height: 175px;
+  max-height: 175px;
+  padding: var(--space-unit);
   border: 2px solid var(--color-surface02);
   border-radius: var(--border-size-large);
   cursor: pointer;
   font-family: var(--font-family-sans);
+}
+
+:host(:focus:focus-visible) {
+  z-index: 1;
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
+}
+
+:host(.info-card:focus:focus-visible) {
+  z-index: 1;
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
 }
 
 .info-container {
@@ -17,7 +31,7 @@
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  padding: var(--space-unit);
+  padding-left: calc(var(--space-unit) * 2);
 }
 
 .author-label {
@@ -89,7 +103,7 @@
   height: 34px;
   align-items: center;
   justify-content: center;
-  margin-bottom: calc(var(--space-unit) * 3);
+  margin-bottom: calc(var(--space-unit) * 4.5);
   background-color: var(--gray50);
   border-radius: var(--border-size-large);
 }
@@ -123,8 +137,8 @@
 }
 
 .info-icon {
-  width: 18px; /* modificato per match con le props nel tsx */
-  height: 18px; /* modificato per match con le props nel tsx */
+  width: 18px;
+  height: 18px;
   color: var(--color-default-text);
 }
 

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -4,7 +4,7 @@
   min-width: 0;
   max-width: 500px;
   height: 175px;
-  border: 1px solid var(--color-surface02);
+  border: 2px solid var(--color-surface02);
   border-radius: var(--border-size-large);
   font-family: var(--font-family-sans);
 }

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -3,7 +3,6 @@
   overflow: hidden;
   width: 100%;
   min-width: 0;
-  max-width: 500px;
   height: 175px;
   max-height: 175px;
   padding: var(--space-unit);
@@ -69,6 +68,8 @@
 
 .tags-container {
   display: flex;
+  max-width: 100%;
+  flex-wrap: wrap;
   margin-top: var(--space-unit);
   gap: var(--space-unit);
 }
@@ -85,7 +86,6 @@
 :host(.info-card) {
   display: flex;
   width: 100%;
-  max-width: 500px;
   height: 75px;
 }
 

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -50,7 +50,7 @@
   font-weight: var(--font-bd);
   -webkit-line-clamp: 2;
   line-clamp: 2;
-  line-height: 1.2;
+  line-height: 1.5;
   word-break: break-word;
 }
 

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -45,10 +45,6 @@
 .card-title {
   display: -webkit-box;
   overflow: hidden;
-  min-width: 0;
-  max-width: 100%;
-  max-height: 2.4em;
-  margin-bottom: 4px;
   -webkit-box-orient: vertical;
   font-size: var(--font-size-3);
   font-weight: var(--font-bd);
@@ -63,6 +59,17 @@
   color: var(--color-default-text);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.card-subtitle.info-subtitle {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  line-height: 1.2;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .tags-container {
@@ -125,17 +132,6 @@
   word-break: break-word;
 }
 
-.card-subtitle.info-subtitle {
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  line-height: 1.2;
-  white-space: normal;
-  word-break: break-word;
-}
-
 .info-icon {
   width: 18px;
   height: 18px;
@@ -146,19 +142,8 @@
   .card-title {
     display: block;
     overflow: hidden;
-    max-height: unset;
-    -webkit-line-clamp: unset;
-    line-clamp: unset;
     line-height: normal;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .card-title.info-title {
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 1;
-    line-clamp: 1;
-    white-space: normal;
   }
 }

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -29,7 +29,7 @@
   white-space: nowrap;
 }
 
-.opera-title {
+.card-title {
   display: -webkit-box;
   overflow: hidden;
   min-width: 0;
@@ -46,7 +46,7 @@
   word-break: break-word;
 }
 
-.opera-subtitle {
+.card-subtitle {
   overflow: hidden;
   color: var(--color-default-text);
   text-overflow: ellipsis;
@@ -69,7 +69,7 @@
 }
 
 @media (max-width: 768px) {
-  .opera-title {
+  .card-title {
     display: block;
     overflow: hidden;
     max-height: unset;

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -1,7 +1,6 @@
 :host {
   display: flex;
   overflow: hidden;
-  width: 100%;
   min-width: 0;
   height: calc(174px - var(--space-unit) * 2);
   max-height: calc(174px - var(--space-unit) * 2);
@@ -91,7 +90,6 @@
 
 :host(.info-card) {
   display: flex;
-  width: 100%;
   height: calc(76px - var(--space-unit) * 2);
   max-height: calc(76px - var(--space-unit) * 2);
 }

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -3,8 +3,8 @@
   overflow: hidden;
   width: 100%;
   min-width: 0;
-  height: 175px;
-  max-height: 175px;
+  height: calc(175px - var(--space-unit) * 2);
+  max-height: calc(175px - var(--space-unit) * 2);
   padding: var(--space-unit);
   border: var(--border-size-medium) solid var(--color-surface02);
   border-radius: var(--border-size-large);

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -92,8 +92,8 @@
 :host(.info-card) {
   display: flex;
   width: 100%;
-  height: calc(75px - var(--space-unit) * 2);
-  max-height: calc(75px - var(--space-unit) * 2);
+  height: calc(76px - var(--space-unit) * 2);
+  max-height: calc(76px - var(--space-unit) * 2);
 }
 
 .info-icon-column {

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -1,0 +1,63 @@
+:host {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  max-width: 500px;
+  height: 175px;
+  border: 1px solid var(--color-surface02);
+  border-radius: var(--border-size-large);
+  font-family: var(--font-family-sans);
+}
+
+.info-container {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: var(--space-unit);
+}
+
+.author-label {
+  overflow: hidden;
+  color: var(--color-default-text);
+  font-size: var(--font-size-2);
+  font-weight: var(--font-rg);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.opera-title {
+  display: -webkit-box;
+  overflow: hidden;
+  min-width: 0;
+  max-width: 100%;
+  margin-top: var(--space-unit);
+  margin-bottom: 4px;
+  -webkit-box-orient: vertical;
+  font-size: var(--font-size-3);
+  font-weight: var(--font-bd);
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  text-overflow: ellipsis;
+}
+
+.tags-container {
+  display: flex;
+  margin-top: var(--space-unit);
+  gap: var(--space-unit);
+}
+
+.volumes-label {
+  display: flex;
+  height: auto;
+  flex-direction: column;
+  margin-top: auto;
+}
+
+@media (max-width: var(--breakpoint-sm)) {
+  .opera-title {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -85,11 +85,8 @@
 :host(.info-card) {
   display: flex;
   width: 100%;
-  height: 75px;
-}
-
-:host(.info-card) .info-container {
-  justify-content: space-between;
+  height: calc(75px - var(--space-unit) * 2);
+  max-height: calc(75px - var(--space-unit) * 2);
 }
 
 .info-icon-column {
@@ -106,7 +103,7 @@
   height: 34px;
   align-items: center;
   justify-content: center;
-  margin-bottom: calc(var(--space-unit) * 4.5);
+  margin-bottom: calc(var(--space-unit) * 3);
   background-color: var(--gray50);
   border-radius: var(--border-size-large);
 }

--- a/src/components/result-card/z-result-card/styles.css
+++ b/src/components/result-card/z-result-card/styles.css
@@ -1,17 +1,21 @@
 :host {
   display: flex;
+  overflow: hidden;
   width: 100%;
   min-width: 0;
   max-width: 500px;
   height: 175px;
   border: 2px solid var(--color-surface02);
   border-radius: var(--border-size-large);
+  cursor: pointer;
   font-family: var(--font-family-sans);
 }
 
 .info-container {
   display: flex;
+  overflow: hidden;
   min-width: 0;
+  flex: 1;
   flex-direction: column;
   padding: var(--space-unit);
 }
@@ -30,6 +34,7 @@
   overflow: hidden;
   min-width: 0;
   max-width: 100%;
+  max-height: 2.4em;
   margin-top: var(--space-unit);
   margin-bottom: 4px;
   -webkit-box-orient: vertical;
@@ -37,7 +42,15 @@
   font-weight: var(--font-bd);
   -webkit-line-clamp: 2;
   line-clamp: 2;
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.opera-subtitle {
+  overflow: hidden;
+  color: var(--color-default-text);
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tags-container {
@@ -51,12 +64,18 @@
   height: auto;
   flex-direction: column;
   margin-top: auto;
+  color: var(--color-default-text);
+  font-size: var(--font-size-1);
 }
 
-@media (max-width: var(--breakpoint-sm)) {
+@media (max-width: 768px) {
   .opera-title {
     display: block;
     overflow: hidden;
+    max-height: unset;
+    -webkit-line-clamp: unset;
+    line-clamp: unset;
+    line-height: normal;
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/src/components/result-card/z-result-card/z-result-card.stories.ts
+++ b/src/components/result-card/z-result-card/z-result-card.stories.ts
@@ -1,0 +1,131 @@
+import {Meta, StoryObj} from "@storybook/web-components";
+import {html} from "lit";
+import "./index";
+
+const StoryMeta: Meta = {
+  title: "ZResultCard",
+  component: "z-result-card",
+  argTypes: {
+    cardTitle: {control: "text"},
+    cardSubtitle: {control: "text"},
+    author: {control: "text"},
+    cover: {control: "text"},
+    hasMultipleCovers: {control: "boolean"},
+    isInfoCard: {control: "boolean"},
+  },
+};
+
+export default StoryMeta;
+
+type Story = StoryObj;
+
+const args = {
+  cardTitle: "Title",
+  cardSubtitle: "Subtitle",
+  author: "John Doe",
+  cover: "https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG",
+  hasMultipleCovers: false,
+  isInfoCard: false,
+};
+
+export const SingleCover: Story = {
+  args: {
+    ...args,
+  },
+
+  render: (args) => html`
+    <z-result-card
+      .cardTitle=${args.cardTitle}
+      .cardSubtitle=${args.cardSubtitle}
+      .author=${args.author}
+      .cover=${args.cover}
+      .hasMultipleCovers=${args.hasMultipleCovers}
+      .isInfoCard=${args.isInfoCard}
+    >
+      <span slot="tags">Example tag</span>
+      <span slot="volumes">2 volumes</span>
+    </z-result-card>
+  `,
+};
+
+export const MultipleCovers: Story = {
+  args: {
+    ...args,
+    hasMultipleCovers: true,
+  },
+  render: (args) => html`
+    <z-result-card
+      .cardTitle=${args.cardTitle}
+      .cardSubtitle=${args.cardSubtitle}
+      .author=${args.author}
+      .cover=${args.cover}
+      .hasMultipleCovers=${args.hasMultipleCovers}
+      .isInfoCard=${args.isInfoCard}
+    >
+      <span slot="tags">Example tag</span>
+      <span slot="volumes">2 volumes</span>
+    </z-result-card>
+  `,
+};
+
+export const InfoCard: Story = {
+  args: {
+    ...args,
+    cardTitle: "Info Card Title",
+    cardSubtitle:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tincidunt maximus tellus, eget dapibus nulla blandit sed. Nullam augue ipsum, mattis sit amet diam ut, finibus posuere libero. Fusce nec erat eu risus fermentum mattis.",
+    isInfoCard: true,
+  },
+  render: (args) => html`
+    <z-result-card
+      .cardTitle=${args.cardTitle}
+      .cardSubtitle=${args.cardSubtitle}
+      .author=${args.author}
+      .cover=${args.cover}
+      .hasMultipleCovers=${args.hasMultipleCovers}
+      .isInfoCard=${args.isInfoCard}
+    />
+  `,
+};
+
+export const LongTitleAndSubtitle: Story = {
+  args: {
+    ...args,
+    cardTitle:
+      "This is a very long title that should wrap to the next line if it exceeds the width of the card, it goes on two rows for desktop devices and one row for mobile",
+    cardSubtitle:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tincidunt maximus tellus, eget dapibus nulla blandit sed. Nullam augue ipsum, mattis sit amet diam ut, finibus posuere libero. Fusce nec erat eu risus fermentum mattis. Nunc volutpat viverra felis, eu iaculis ipsum tempus mattis. Phasellus euismod quam eget nisl pellentesque.",
+    hasMultipleCovers: true,
+  },
+  render: (args) => html`
+    <z-result-card
+      .cardTitle=${args.cardTitle}
+      .cardSubtitle=${args.cardSubtitle}
+      .author=${args.author}
+      .cover=${args.cover}
+      .hasMultipleCovers=${args.hasMultipleCovers}
+      .isInfoCard=${args.isInfoCard}
+    >
+      <span slot="tags">Example tag</span>
+      <span slot="volumes">2 volumes</span>
+    </z-result-card>
+  `,
+};
+
+export const NoAuthorTagsAndVolumes: Story = {
+  args: {
+    ...args,
+    author: undefined,
+  },
+
+  render: (args) => html`
+    <z-result-card
+      .cardTitle=${args.cardTitle}
+      .cardSubtitle=${args.cardSubtitle}
+      .author=${args.author}
+      .cover=${args.cover}
+      .hasMultipleCovers=${args.hasMultipleCovers}
+      .isInfoCard=${args.isInfoCard}
+    />
+  `,
+};

--- a/src/components/result-card/z-result-card/z-result-card.stories.ts
+++ b/src/components/result-card/z-result-card/z-result-card.stories.ts
@@ -8,7 +8,7 @@ const StoryMeta: Meta = {
   argTypes: {
     cardTitle: {control: "text"},
     cardSubtitle: {control: "text"},
-    author: {control: "text"},
+    authors: {control: "text"},
     cover: {control: "text"},
     hasMultipleCovers: {control: "boolean"},
     isInfoCard: {control: "boolean"},
@@ -22,7 +22,7 @@ type Story = StoryObj;
 const args = {
   cardTitle: "Title",
   cardSubtitle: "Subtitle",
-  author: "John Doe",
+  authors: "John Doe",
   cover: "https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG",
   hasMultipleCovers: false,
   isInfoCard: false,
@@ -37,7 +37,7 @@ export const SingleCover: Story = {
     <z-result-card
       .cardTitle=${args.cardTitle}
       .cardSubtitle=${args.cardSubtitle}
-      .author=${args.author}
+      .authors=${args.authors}
       .cover=${args.cover}
       .hasMultipleCovers=${args.hasMultipleCovers}
       .isInfoCard=${args.isInfoCard}
@@ -57,11 +57,12 @@ export const MultipleCovers: Story = {
     <z-result-card
       .cardTitle=${args.cardTitle}
       .cardSubtitle=${args.cardSubtitle}
-      .author=${args.author}
+      .authors=${args.authors}
       .cover=${args.cover}
       .hasMultipleCovers=${args.hasMultipleCovers}
       .isInfoCard=${args.isInfoCard}
     >
+      <span slot="tags">Example tag</span>
       <span slot="tags">Example tag</span>
       <span slot="volumes">2 volumes</span>
     </z-result-card>
@@ -81,7 +82,7 @@ export const LongTitleAndSubtitle: Story = {
     <z-result-card
       .cardTitle=${args.cardTitle}
       .cardSubtitle=${args.cardSubtitle}
-      .author=${args.author}
+      .authors=${args.authors}
       .cover=${args.cover}
       .hasMultipleCovers=${args.hasMultipleCovers}
       .isInfoCard=${args.isInfoCard}
@@ -102,7 +103,7 @@ export const OnlyTitleAndSubtitle: Story = {
     <z-result-card
       .cardTitle=${args.cardTitle}
       .cardSubtitle=${args.cardSubtitle}
-      .author=${args.author}
+      .authors=${args.authors}
       .cover=${args.cover}
       .hasMultipleCovers=${args.hasMultipleCovers}
       .isInfoCard=${args.isInfoCard}
@@ -122,7 +123,7 @@ export const InfoCard: Story = {
     <z-result-card
       .cardTitle=${args.cardTitle}
       .cardSubtitle=${args.cardSubtitle}
-      .author=${args.author}
+      .authors=${args.authors}
       .cover=${args.cover}
       .hasMultipleCovers=${args.hasMultipleCovers}
       .isInfoCard=${args.isInfoCard}

--- a/src/components/result-card/z-result-card/z-result-card.stories.ts
+++ b/src/components/result-card/z-result-card/z-result-card.stories.ts
@@ -68,26 +68,6 @@ export const MultipleCovers: Story = {
   `,
 };
 
-export const InfoCard: Story = {
-  args: {
-    ...args,
-    cardTitle: "Info Card Title",
-    cardSubtitle:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tincidunt maximus tellus, eget dapibus nulla blandit sed. Nullam augue ipsum, mattis sit amet diam ut, finibus posuere libero. Fusce nec erat eu risus fermentum mattis.",
-    isInfoCard: true,
-  },
-  render: (args) => html`
-    <z-result-card
-      .cardTitle=${args.cardTitle}
-      .cardSubtitle=${args.cardSubtitle}
-      .author=${args.author}
-      .cover=${args.cover}
-      .hasMultipleCovers=${args.hasMultipleCovers}
-      .isInfoCard=${args.isInfoCard}
-    />
-  `,
-};
-
 export const LongTitleAndSubtitle: Story = {
   args: {
     ...args,
@@ -112,12 +92,32 @@ export const LongTitleAndSubtitle: Story = {
   `,
 };
 
-export const NoAuthorTagsAndVolumes: Story = {
+export const OnlyTitleAndSubtitle: Story = {
   args: {
     ...args,
     author: undefined,
   },
 
+  render: (args) => html`
+    <z-result-card
+      .cardTitle=${args.cardTitle}
+      .cardSubtitle=${args.cardSubtitle}
+      .author=${args.author}
+      .cover=${args.cover}
+      .hasMultipleCovers=${args.hasMultipleCovers}
+      .isInfoCard=${args.isInfoCard}
+    />
+  `,
+};
+
+export const InfoCard: Story = {
+  args: {
+    ...args,
+    cardTitle: "Info Card Title",
+    cardSubtitle:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tincidunt maximus tellus, eget dapibus nulla blandit sed. Nullam augue ipsum, mattis sit amet diam ut, finibus posuere libero. Fusce nec erat eu risus fermentum mattis.",
+    isInfoCard: true,
+  },
   render: (args) => html`
     <z-result-card
       .cardTitle=${args.cardTitle}

--- a/src/components/result-card/z-result-card/z-result-card.stories.ts
+++ b/src/components/result-card/z-result-card/z-result-card.stories.ts
@@ -103,7 +103,6 @@ export const OnlyTitleAndSubtitle: Story = {
     <z-result-card
       .cardTitle=${args.cardTitle}
       .cardSubtitle=${args.cardSubtitle}
-      .authors=${args.authors}
       .cover=${args.cover}
       .hasMultipleCovers=${args.hasMultipleCovers}
       .isInfoCard=${args.isInfoCard}

--- a/src/components/z-icon/readme.md
+++ b/src/components/z-icon/readme.md
@@ -63,6 +63,7 @@
  - [z-notification](../z-notification)
  - [z-pagination](../z-pagination)
  - [z-panel-elem](../z-panel-elem)
+ - [z-result-card](../result-card/z-result-card)
  - [z-searchbar](../z-searchbar)
  - [z-select](../z-select)
  - [z-slideshow](../../snowflakes/myz/z-slideshow)
@@ -107,6 +108,7 @@ graph TD;
   z-notification --> z-icon
   z-pagination --> z-icon
   z-panel-elem --> z-icon
+  z-result-card --> z-icon
   z-searchbar --> z-icon
   z-select --> z-icon
   z-slideshow --> z-icon

--- a/src/index.html
+++ b/src/index.html
@@ -30,47 +30,6 @@
         <h1 slot="title">Albe test app</h1>
       </z-app-header>
     </header>
-    <main>
-      <div style="margin: 16px; display: flex">
-        <z-result-card
-          author="Massimo Bergamini, Graziella Barozzi"
-          card-title="Opera Title"
-          card-subtitle="App e software per una didattica attiva"
-          cover="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
-        >
-          <span slot="tags">Tags</span>
-          <span slot="tags">Tags</span>
-          <span slot="tags">Tags</span>
-          <span slot="volumes">Volume unico</span>
-        </z-result-card>
-        <z-result-card
-          style="margin-left: 16px"
-          author="Massimo Bergamini, Graziella Barozzi"
-          card-title="Opera Title prova molto molto lungo su max due righe a desktop, una a mobile con ellipsis per il troncamento"
-          card-subtitle="2022"
-          has-multiple-covers="true"
-          cover="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
-        >
-          <span slot="tags">Tags</span>
-          <span slot="volumes">4 Volumi</span>
-        </z-result-card>
-      </div>
-      <div style="margin: 16px; display: flex">
-        <z-result-card
-          author="Massimo Bergamini, Graziella Barozzi"
-          card-title="LaZ Tutor di matematica"
-          card-subtitle="Che cos'è? laZ Tutor di matematica è il sito Zanichelli  che ti aiuta a imparare nel modo che preferisci: parti dagli esercizi e scopri che cosa ti serve ripassare, oppure guarda un video di teoria e poi mettiti alla prova."
-          is-info-card="true"
-          has-multiple-covers="true"
-          cover="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
-        />
-      </div>
-    </main>
-
-    <style>
-      body {
-        margin: 0;
-      }
-    </style>
+    <main></main>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -32,4 +32,9 @@
     </header>
     <main></main>
   </body>
+  <style>
+    body {
+      margin: 0;
+    }
+  </style>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -30,11 +30,47 @@
         <h1 slot="title">Albe test app</h1>
       </z-app-header>
     </header>
-    <main></main>
+    <main>
+      <div style="margin: 16px; display: flex">
+        <z-result-card
+          author="Massimo Bergamini, Graziella Barozzi"
+          card-title="Opera Title"
+          card-subtitle="App e software per una didattica attiva"
+          cover="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
+        >
+          <span slot="tags">Tags</span>
+          <span slot="tags">Tags</span>
+          <span slot="tags">Tags</span>
+          <span slot="volumes">Volume unico</span>
+        </z-result-card>
+        <z-result-card
+          style="margin-left: 16px"
+          author="Massimo Bergamini, Graziella Barozzi"
+          card-title="Opera Title prova molto molto lungo su max due righe a desktop, una a mobile con ellipsis per il troncamento"
+          card-subtitle="2022"
+          has-multiple-covers="true"
+          cover="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
+        >
+          <span slot="tags">Tags</span>
+          <span slot="volumes">4 Volumi</span>
+        </z-result-card>
+      </div>
+      <div style="margin: 16px; display: flex">
+        <z-result-card
+          author="Massimo Bergamini, Graziella Barozzi"
+          card-title="LaZ Tutor di matematica"
+          card-subtitle="Che cos'è? laZ Tutor di matematica è il sito Zanichelli  che ti aiuta a imparare nel modo che preferisci: parti dagli esercizi e scopri che cosa ti serve ripassare, oppure guarda un video di teoria e poi mettiti alla prova."
+          is-info-card="true"
+          has-multiple-covers="true"
+          cover="https://place.abh.ai/s3fs-public/placeholder/DSC_0199_400x400.JPG"
+        />
+      </div>
+    </main>
+
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
   </body>
-  <style>
-    body {
-      margin: 0;
-    }
-  </style>
 </html>


### PR DESCRIPTION
# Title
Feat - ZResultCard

## Motivation and Context

This PR introduces the new ZResultCard component, designed to represent a search result in digital editorial contexts. It also add the css-component ZCover, who can be used "out of the box", but is also necessary for the major component (ZResultCard).

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [X] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)

## Design
(VECCHIE SPECIFICHE)
https://www.figma.com/design/w51ZwDwLNEt0yamar2sRRQ/branch/JNKf12ky0Rr3JbrzsTjtUa/Nuovi-Componenti-e-Pattern?node-id=15790-4755&p=f&t=e3GXLMjKj7xB9t4l-0

(NUOVE SPECIFICHE 18-06-25)
https://www.figma.com/design/w51ZwDwLNEt0yamar2sRRQ/Nuovi-Componenti-e-Pattern?node-id=16543-8977&t=QmpCcRZjSjP1MBUt-0

### Screenshots

![image](https://github.com/user-attachments/assets/b70d9b63-c164-4164-97dd-58bf90041bb1)

### Note

The tags and volume indication sections have been slotted to accommodate the flexibility that the component's use cases require.

<!-- ## Component and Fix approval flow to Master branch
A Pull Request to be merged must have two approvals, one from a member of the product team who developed it and another one from a member of the dst dev team other than the team representative. -->
