### PR TITLE
Fix - ZPopover - positioning

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1678,12 +1678,10 @@ export namespace Components {
     }
     /**
      * Popover component.
-     * This component displays a popover that can be bound to an element.
-     * It supports various positions and can automatically adjust it based on available space.
+     * This component displays a popover bound to an element.
+     * It supports various positions and can automatically adjust it based on available space, accounting for scrollable containers.
      * Notes:
-     * - It is preferrable to put the popover element near the bound element, in the same container.
-     * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
-     * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+     * - If positioning has an odd behavior, consider manually adjusting the size of the slotted elements (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think the popover doesn't fits).
      * @cssprop --z-popover-theme--surface - background color of the popover.
      * @cssprop --z-popover-theme--text - foreground color of the popover.
      * @cssprop --z-popover-padding - padding of the popover.
@@ -3304,12 +3302,10 @@ declare global {
     }
     /**
      * Popover component.
-     * This component displays a popover that can be bound to an element.
-     * It supports various positions and can automatically adjust it based on available space.
+     * This component displays a popover bound to an element.
+     * It supports various positions and can automatically adjust it based on available space, accounting for scrollable containers.
      * Notes:
-     * - It is preferrable to put the popover element near the bound element, in the same container.
-     * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
-     * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+     * - If positioning has an odd behavior, consider manually adjusting the size of the slotted elements (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think the popover doesn't fits).
      * @cssprop --z-popover-theme--surface - background color of the popover.
      * @cssprop --z-popover-theme--text - foreground color of the popover.
      * @cssprop --z-popover-padding - padding of the popover.
@@ -5549,12 +5545,10 @@ declare namespace LocalJSX {
     }
     /**
      * Popover component.
-     * This component displays a popover that can be bound to an element.
-     * It supports various positions and can automatically adjust it based on available space.
+     * This component displays a popover bound to an element.
+     * It supports various positions and can automatically adjust it based on available space, accounting for scrollable containers.
      * Notes:
-     * - It is preferrable to put the popover element near the bound element, in the same container.
-     * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
-     * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+     * - If positioning has an odd behavior, consider manually adjusting the size of the slotted elements (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think the popover doesn't fits).
      * @cssprop --z-popover-theme--surface - background color of the popover.
      * @cssprop --z-popover-theme--text - foreground color of the popover.
      * @cssprop --z-popover-padding - padding of the popover.
@@ -6479,12 +6473,10 @@ declare module "@stencil/core" {
             "z-panel-elem": LocalJSX.ZPanelElem & JSXBase.HTMLAttributes<HTMLZPanelElemElement>;
             /**
              * Popover component.
-             * This component displays a popover that can be bound to an element.
-             * It supports various positions and can automatically adjust it based on available space.
+             * This component displays a popover bound to an element.
+             * It supports various positions and can automatically adjust it based on available space, accounting for scrollable containers.
              * Notes:
-             * - It is preferrable to put the popover element near the bound element, in the same container.
-             * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
-             * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+             * - If positioning has an odd behavior, consider manually adjusting the size of the slotted elements (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think the popover doesn't fits).
              * @cssprop --z-popover-theme--surface - background color of the popover.
              * @cssprop --z-popover-theme--text - foreground color of the popover.
              * @cssprop --z-popover-padding - padding of the popover.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1679,10 +1679,11 @@ export namespace Components {
     /**
      * Popover component.
      * This component displays a popover that can be bound to an element.
-     * It supports various positions and can automatically adjust its position based on available space.
+     * It supports various positions and can automatically adjust it based on available space.
      * Notes:
-     * - To ensure the positioning algorithm finds the right container when calculating the position, set its container's `position` to `relative`.
-     * - Consider manually adjusting the size of the slotted element (using `max-width`, `max-height`, etc...) when its content is "fluid" (like a big text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+     * - It is preferrable to put the popover element near the bound element, in the same container.
+     * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
+     * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
      * @cssprop --z-popover-theme--surface - background color of the popover.
      * @cssprop --z-popover-theme--text - foreground color of the popover.
      * @cssprop --z-popover-padding - padding of the popover.
@@ -3304,10 +3305,11 @@ declare global {
     /**
      * Popover component.
      * This component displays a popover that can be bound to an element.
-     * It supports various positions and can automatically adjust its position based on available space.
+     * It supports various positions and can automatically adjust it based on available space.
      * Notes:
-     * - To ensure the positioning algorithm finds the right container when calculating the position, set its container's `position` to `relative`.
-     * - Consider manually adjusting the size of the slotted element (using `max-width`, `max-height`, etc...) when its content is "fluid" (like a big text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+     * - It is preferrable to put the popover element near the bound element, in the same container.
+     * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
+     * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
      * @cssprop --z-popover-theme--surface - background color of the popover.
      * @cssprop --z-popover-theme--text - foreground color of the popover.
      * @cssprop --z-popover-padding - padding of the popover.
@@ -5548,10 +5550,11 @@ declare namespace LocalJSX {
     /**
      * Popover component.
      * This component displays a popover that can be bound to an element.
-     * It supports various positions and can automatically adjust its position based on available space.
+     * It supports various positions and can automatically adjust it based on available space.
      * Notes:
-     * - To ensure the positioning algorithm finds the right container when calculating the position, set its container's `position` to `relative`.
-     * - Consider manually adjusting the size of the slotted element (using `max-width`, `max-height`, etc...) when its content is "fluid" (like a big text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+     * - It is preferrable to put the popover element near the bound element, in the same container.
+     * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
+     * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
      * @cssprop --z-popover-theme--surface - background color of the popover.
      * @cssprop --z-popover-theme--text - foreground color of the popover.
      * @cssprop --z-popover-padding - padding of the popover.
@@ -5575,7 +5578,7 @@ declare namespace LocalJSX {
          */
         "onOpenChange"?: (event: ZPopoverCustomEvent<any>) => void;
         /**
-          * Position change event.
+          * Fired when the position changes.
          */
         "onPositionChange"?: (event: ZPopoverCustomEvent<any>) => void;
         /**
@@ -6477,10 +6480,11 @@ declare module "@stencil/core" {
             /**
              * Popover component.
              * This component displays a popover that can be bound to an element.
-             * It supports various positions and can automatically adjust its position based on available space.
+             * It supports various positions and can automatically adjust it based on available space.
              * Notes:
-             * - To ensure the positioning algorithm finds the right container when calculating the position, set its container's `position` to `relative`.
-             * - Consider manually adjusting the size of the slotted element (using `max-width`, `max-height`, etc...) when its content is "fluid" (like a big text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+             * - It is preferrable to put the popover element near the bound element, in the same container.
+             * - To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
+             * - Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
              * @cssprop --z-popover-theme--surface - background color of the popover.
              * @cssprop --z-popover-theme--text - foreground color of the popover.
              * @cssprop --z-popover-padding - padding of the popover.

--- a/src/components/z-anchor-navigation/index.tsx
+++ b/src/components/z-anchor-navigation/index.tsx
@@ -97,7 +97,7 @@ export class ZAnchorNavigation {
 
   render(): HTMLZAnchorNavigationElement {
     return (
-      <Host collapsed={this.collapsed}>
+      <Host collapsed={this.collapsed} class="z-scrollbar">
         <z-button
           class="toggle"
           size={ControlSize.SMALL}

--- a/src/components/z-card/styles.css
+++ b/src/components/z-card/styles.css
@@ -161,6 +161,10 @@ Unfortunately the `aspect-ratio` property is still experimental */
   border-radius: var(--z-card--text-border-radius);
 }
 
+:host([variant="text"]) [slot='text']::before {
+  border-radius: var(--z-card--text-border-radius);
+}
+
 :host([show-shadow]) > .content,
 :host([variant="border"]) > .content,
 :host([variant="shadow"]) > .content {

--- a/src/components/z-popover/index.stories.css
+++ b/src/components/z-popover/index.stories.css
@@ -15,6 +15,7 @@
 
 .popover-content {
   width: 200px;
+  max-width: 100%;
   text-align: left;
 }
 

--- a/src/components/z-popover/index.stories.css
+++ b/src/components/z-popover/index.stories.css
@@ -14,6 +14,8 @@
 }
 
 .popover-content {
+  max-width: 400px;
+  max-height: 150px;
   text-align: left;
 }
 
@@ -28,7 +30,6 @@
   height: 2000px;
 
   .popover-internal-container {
-    position: relative;
     overflow: auto;
     width: 100%;
     height: 400px;
@@ -38,7 +39,7 @@
       display: flex;
       overflow: auto;
       width: 100%;
-      height: 800px;
+      height: 1000px;
       align-items: center;
       justify-content: center;
       background-color: tomato;

--- a/src/components/z-popover/index.stories.css
+++ b/src/components/z-popover/index.stories.css
@@ -27,7 +27,7 @@
 }
 
 .popover-container-tooltip {
-  height: 2000px;
+  height: 1000px;
 
   .popover-internal-container {
     overflow: auto;

--- a/src/components/z-popover/index.stories.css
+++ b/src/components/z-popover/index.stories.css
@@ -14,8 +14,7 @@
 }
 
 .popover-content {
-  max-width: 400px;
-  max-height: 150px;
+  width: 200px;
   text-align: left;
 }
 
@@ -44,5 +43,11 @@
       justify-content: center;
       background-color: tomato;
     }
+  }
+}
+
+@media (width < 768px) {
+  .popover-container {
+    min-width: unset;
   }
 }

--- a/src/components/z-popover/index.stories.css
+++ b/src/components/z-popover/index.stories.css
@@ -3,9 +3,14 @@
   display: flex;
   width: 100%;
   min-height: 400px;
+  box-sizing: border-box;
   align-items: center;
   justify-content: center;
   background: var(--gray200);
+
+  * {
+    box-sizing: border-box;
+  }
 }
 
 .popover-content {
@@ -17,4 +22,26 @@
   --z-icon-height: 32px;
 
   cursor: pointer;
+}
+
+.popover-container-tooltip {
+  height: 2000px;
+
+  .popover-internal-container {
+    position: relative;
+    overflow: auto;
+    width: 100%;
+    height: 400px;
+    background-color: aqua;
+
+    .popover-internal-container-2 {
+      display: flex;
+      overflow: auto;
+      width: 100%;
+      height: 800px;
+      align-items: center;
+      justify-content: center;
+      background-color: tomato;
+    }
+  }
 }

--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -33,9 +33,7 @@ export class ZPopover {
   @Prop({reflect: true, mutable: true})
   position?: PopoverPosition = PopoverPosition.TOP;
 
-  /**
-   * The open state of the popover.
-   */
+  /** The open state of the popover. */
   @Prop({reflect: true, mutable: true})
   open = false;
 
@@ -46,15 +44,11 @@ export class ZPopover {
   @Prop()
   bindTo?: string | HTMLElement;
 
-  /**
-   * Whether to show popover's arrow.
-   */
+  /** Whether to show popover's arrow. */
   @Prop({reflect: true})
   showArrow = false;
 
-  /**
-   * Whether to center the popup on the main side (according to "position").
-   */
+  /** Whether to center the popup on the main side (according to "position"). */
   @Prop({reflect: true})
   center = false;
 
@@ -67,7 +61,7 @@ export class ZPopover {
 
   /**
    * The current position of the popover.
-   * It differs from `position` only when calculated automatically (position=auto) or when the position is recalculated for space reasons.
+   * It differs from `position` only when calculated automatically for space reasons.
    */
   @State()
   currentPosition?: PopoverPosition;
@@ -100,15 +94,11 @@ export class ZPopover {
   /** Last bounding rect of the bound element to detect changes and eventually invalidate the caches. */
   private lastBoundRect?: DOMRect;
 
-  /**
-   * Fired when the position changes.
-   */
+  /** Fired when the position changes. */
   @Event()
   positionChange: EventEmitter;
 
-  /**
-   * Open change event.
-   */
+  /** Open change event. */
   @Event()
   openChange: EventEmitter;
 
@@ -150,9 +140,7 @@ export class ZPopover {
     }
   }
 
-  /**
-   * Setup popover behaviors when `open` changes.
-   */
+  /** Setup popover behaviors when `open` changes. */
   @Watch("open")
   onOpen(): void {
     cancelAnimationFrame(this.animationFrameRequestId);
@@ -364,9 +352,7 @@ export class ZPopover {
     return this.findBestFallbackPosition(availableSpace);
   }
 
-  /**
-   * Find the best fallback position based on available space when no position fits perfectly
-   */
+  /** Find the best fallback position based on available space when no position fits perfectly. */
   private findBestFallbackPosition(availableSpace: Offsets): PopoverPosition {
     // Determine which horizontal and vertical direction has the most available space
     const bestHorizontalDirection =
@@ -454,9 +440,7 @@ export class ZPopover {
     return this.cachedAvailableSpace;
   }
 
-  /**
-   * Calculate the space around an element relative to the viewport.
-   */
+  /** Calculate the space around an element relative to the viewport. */
   private calculateElementOffsets(element: HTMLElement): Offsets {
     const elementRect = element.getBoundingClientRect();
     const viewportWidth = element.ownerDocument.documentElement.clientWidth;
@@ -470,9 +454,7 @@ export class ZPopover {
     };
   }
 
-  /**
-   * Apply positioning styles based on passed position.
-   */
+  /** Apply positioning styles based on passed position. */
   private applyPositionStyles(position: PopoverPosition, availableSpace: Offsets): void {
     const boundElementWidth = this.boundElement.offsetWidth;
     const boundElementHeight = this.boundElement.offsetHeight;
@@ -566,9 +548,7 @@ export class ZPopover {
     }
   }
 
-  /**
-   * Set the position of the popover.
-   */
+  /** Set the position of the popover. */
   private setPosition(): void {
     if (!this.boundElement) {
       return;

--- a/src/components/z-popover/index.tsx
+++ b/src/components/z-popover/index.tsx
@@ -227,17 +227,17 @@ export class ZPopover {
 
   // Clockwise order of positions.
   private static readonly positionOrder: PopoverPosition[] = [
-    PopoverPosition.TOP_RIGHT,
     PopoverPosition.TOP,
+    PopoverPosition.TOP_RIGHT,
     PopoverPosition.TOP_LEFT,
-    PopoverPosition.RIGHT_BOTTOM,
     PopoverPosition.RIGHT,
+    PopoverPosition.RIGHT_BOTTOM,
     PopoverPosition.RIGHT_TOP,
-    PopoverPosition.BOTTOM_LEFT,
     PopoverPosition.BOTTOM,
+    PopoverPosition.BOTTOM_LEFT,
     PopoverPosition.BOTTOM_RIGHT,
-    PopoverPosition.LEFT_TOP,
     PopoverPosition.LEFT,
+    PopoverPosition.LEFT_TOP,
     PopoverPosition.LEFT_BOTTOM,
   ] as const;
 
@@ -264,7 +264,8 @@ export class ZPopover {
     }
 
     return (
-      availableRight >= requiredSideSpace - this.spaceTolerance && availableLeft >= requiredSideSpace - this.spaceTolerance
+      availableRight >= requiredSideSpace - this.spaceTolerance &&
+      availableLeft >= requiredSideSpace - this.spaceTolerance
     );
   }
 
@@ -495,17 +496,21 @@ export class ZPopover {
       scrollableParent !== boundElement.ownerDocument.body;
     const documentWidth = boundElement.ownerDocument.documentElement.clientWidth;
     const documentHeight = boundElement.ownerDocument.documentElement.clientHeight;
+    const safeSpace = 8; // extra space to avoid popover being too close to the edges
 
+    // These deltas represent the offset between the scrollable parent and the viewport.
+    // They are used to adjust the available space calculations when the scrollable parent is not the document or body,
+    // to try to fit the popover inside the scrollable parent.
     const deltaTop = hasNestedScrollableParent ? scrollableParentRect.top : 0;
     const deltaRight = hasNestedScrollableParent ? documentWidth - scrollableParentRect.right : 0;
     const deltaBottom = hasNestedScrollableParent ? documentHeight - scrollableParentRect.bottom : 0;
     const deltaLeft = hasNestedScrollableParent ? scrollableParentRect.left : 0;
 
     return {
-      top: boundElementRect.top - deltaTop,
-      right: documentWidth - boundElementRect.right - deltaRight,
-      bottom: documentHeight - boundElementRect.bottom - deltaBottom,
-      left: boundElementRect.left - deltaLeft,
+      top: boundElementRect.top - deltaTop - safeSpace,
+      right: documentWidth - boundElementRect.right - deltaRight - safeSpace,
+      bottom: documentHeight - boundElementRect.bottom - deltaBottom - safeSpace,
+      left: boundElementRect.left - deltaLeft - safeSpace,
     };
   }
 
@@ -538,8 +543,6 @@ export class ZPopover {
     const arrowModifier = this.showArrow && this.center ? 8 : 0;
     const hostStyle = this.host.style;
     const boundElementOffsets = this.calculateElementOffsets(boundElement);
-    const documentWidth = boundElement.ownerDocument.documentElement.clientWidth;
-    const documentHeight = boundElement.ownerDocument.documentElement.clientHeight;
 
     let maxWidth: number;
     let maxHeight: number;
@@ -551,8 +554,8 @@ export class ZPopover {
     hostStyle.right = "auto";
     hostStyle.bottom = "auto";
     hostStyle.left = "auto";
-    hostStyle.maxWidth = "100%";
-    hostStyle.maxHeight = "100%";
+    delete hostStyle.maxWidth;
+    delete hostStyle.maxHeight;
 
     switch (position) {
       case PopoverPosition.TOP:
@@ -628,8 +631,8 @@ export class ZPopover {
 
     if (getDevice() !== Device.MOBILE) {
       // Only force max sizes on non-mobile viewports
-      hostStyle.maxWidth = maxWidth > documentWidth ? `${documentWidth - 16}px` : `${maxWidth}px`; // 16px margin from viewport edges
-      hostStyle.maxHeight = maxHeight > documentHeight ? `${documentHeight - 16}px` : `${maxHeight}px`; // 16px margin from viewport edges
+      hostStyle.maxWidth = `${maxWidth}px`;
+      hostStyle.maxHeight = `${maxHeight}px`;
     }
   }
 

--- a/src/components/z-popover/readme.md
+++ b/src/components/z-popover/readme.md
@@ -30,13 +30,11 @@ To be sure the algorithm finds the right container, when calculating the positio
 ## Overview
 
 Popover component.
-This component displays a popover that can be bound to an element.
-It supports various positions and can automatically adjust it based on available space.
+This component displays a popover bound to an element.
+It supports various positions and can automatically adjust it based on available space, accounting for scrollable containers.
 
 Notes:
-- It is preferrable to put the popover element near the bound element, in the same container.
-- To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
-- Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+- If positioning has an odd behavior, consider manually adjusting the size of the slotted elements (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think the popover doesn't fits).
 
 ## Properties
 

--- a/src/components/z-popover/readme.md
+++ b/src/components/z-popover/readme.md
@@ -31,11 +31,12 @@ To be sure the algorithm finds the right container, when calculating the positio
 
 Popover component.
 This component displays a popover that can be bound to an element.
-It supports various positions and can automatically adjust its position based on available space.
+It supports various positions and can automatically adjust it based on available space.
 
 Notes:
-- To ensure the positioning algorithm finds the right container when calculating the position, set its container's `position` to `relative`.
-- Consider manually adjusting the size of the slotted element (using `max-width`, `max-height`, etc...) when its content is "fluid" (like a big text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
+- It is preferrable to put the popover element near the bound element, in the same container.
+- To ensure the positioning algorithm correctly calculates the available space around the popover, it may be necessary to set `position: relative` on one of its ancestor containers. It becomes more important when there are one or more scrollable containers; in that case set `position: relative` on the nearest container with `overflow: auto` or `overflow: scroll`.
+- Consider manually adjusting the size of the slotted element (using `width`, `height`, `max-width`, `max-height`, etc...) when its content is "fluid" (like text), because it can interfere with the position calculation (for example a long text on one single line can be bigger than the available space, letting the algorithm think that the popover doesn't fit in the available space).
 
 ## Properties
 
@@ -51,10 +52,10 @@ Notes:
 
 ## Events
 
-| Event            | Description            | Type               |
-| ---------------- | ---------------------- | ------------------ |
-| `openChange`     | Open change event.     | `CustomEvent<any>` |
-| `positionChange` | Position change event. | `CustomEvent<any>` |
+| Event            | Description                      | Type               |
+| ---------------- | -------------------------------- | ------------------ |
+| `openChange`     | Open change event.               | `CustomEvent<any>` |
+| `positionChange` | Fired when the position changes. | `CustomEvent<any>` |
 
 
 ## Dependencies

--- a/src/components/z-popover/styles.css
+++ b/src/components/z-popover/styles.css
@@ -6,6 +6,8 @@
 
   position: fixed;
   display: none;
+  max-width: calc(100% - var(--grid-margin) * 2);
+  max-height: calc(100% - var(--grid-margin) * 2);
   align-items: center;
   justify-content: center;
   padding: var(--z-popover-padding, 0);

--- a/src/components/z-popover/styles.css
+++ b/src/components/z-popover/styles.css
@@ -12,6 +12,7 @@
   background: var(--z-popover-theme--surface, var(--color-surface01));
   border-radius: var(--border-radius-small);
   color: var(--z-popover-theme--text, var(--color-default-text));
+  fill: currentcolor;
   filter: var(--z-popover-shadow-filter, drop-shadow(0 1px 2px var(--shadow-color-base)));
   text-align: center;
 }

--- a/src/components/z-popover/styles.css
+++ b/src/components/z-popover/styles.css
@@ -24,7 +24,7 @@
 
 :host([open][current-position]),
 :host([open="true"][current-position]) {
-  display: flex;
+  display: block;
 }
 
 :host([center][current-position="top"]),
@@ -141,9 +141,4 @@
 :host([center][current-position="left"])::before {
   top: var(--arrow-center-x-offset);
   bottom: auto;
-}
-
-::slotted(*) {
-  overflow: auto;
-  flex: 1 auto;
 }

--- a/src/components/z-popover/styles.css
+++ b/src/components/z-popover/styles.css
@@ -4,12 +4,8 @@
   --z-popover-padding: ;
   --z-popover-shadow-filter: ;
 
-  position: absolute;
+  position: fixed;
   display: none;
-  min-width: calc(var(--space-unit) * 8);
-  max-width: 100%;
-  min-height: calc(var(--space-unit) * 4);
-  max-height: 100%;
   align-items: center;
   justify-content: center;
   padding: var(--z-popover-padding, 0);

--- a/src/components/z-popover/styles.css
+++ b/src/components/z-popover/styles.css
@@ -8,15 +8,11 @@
   display: none;
   max-width: calc(100% - var(--grid-margin) * 2);
   max-height: calc(100% - var(--grid-margin) * 2);
-  align-items: center;
-  justify-content: center;
   padding: var(--z-popover-padding, 0);
   background: var(--z-popover-theme--surface, var(--color-surface01));
   border-radius: var(--border-radius-small);
   color: var(--z-popover-theme--text, var(--color-default-text));
-  fill: currentcolor;
   filter: var(--z-popover-shadow-filter, drop-shadow(0 1px 2px var(--shadow-color-base)));
-  font-family: var(--font-family-sans);
   text-align: center;
 }
 

--- a/src/components/z-select/index.tsx
+++ b/src/components/z-select/index.tsx
@@ -1,6 +1,6 @@
 import {Component, Element, Event, EventEmitter, Listen, Method, Prop, State, Watch, h} from "@stencil/core";
 import {ControlSize, InputStatus, KeyboardCode, ListDividerType, ListSize, SelectItem} from "../../beans";
-import {boolean, getClickedElement, getElementTree, handleKeyboardSubmit, randomId} from "../../utils/utils";
+import {boolean, getClickedElement, getElementTree, randomId} from "../../utils/utils";
 
 @Component({
   tag: "z-select",
@@ -508,10 +508,8 @@ export class ZSelect {
           this.handleInputClick(e);
         }}
         onKeyUp={(e: KeyboardEvent) => {
-          if (e.key !== KeyboardCode.ENTER) {
-            e.preventDefault();
-          }
-          handleKeyboardSubmit(e, this.toggleSelectUl);
+          e.preventDefault();
+          this.toggleSelectUl();
         }}
         onKeyDown={(e: KeyboardEvent) => {
           const current = this.selectedItem

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -210,20 +210,25 @@ export function findScrollableParent(element: HTMLElement): HTMLElement {
  */
 export function isElementVisibleInContainer(element: HTMLElement, container: HTMLElement): boolean {
   const elemRect = element.getBoundingClientRect();
-  const containerRect = container.getBoundingClientRect();
   const documentWidth = element.ownerDocument.documentElement.clientWidth;
   const documentHeight = element.ownerDocument.documentElement.clientHeight;
 
-  // Check if element is visible in container
+  // Check if element is visible in viewport
+  const isVisibleInViewport =
+    elemRect.bottom > 0 && elemRect.top < documentHeight && elemRect.right > 0 && elemRect.left < documentWidth;
+
+  // If container is the document element, only check viewport visibility
+  if (container === element.ownerDocument.documentElement || container === element.ownerDocument.body) {
+    return isVisibleInViewport;
+  }
+
+  // For other containers, check both container and viewport visibility
+  const containerRect = container.getBoundingClientRect();
   const isVisibleInContainer =
     elemRect.bottom > containerRect.top &&
     elemRect.top < containerRect.bottom &&
     elemRect.right > containerRect.left &&
     elemRect.left < containerRect.right;
-
-  // Check if element is visible in viewport
-  const isVisibleInViewport =
-    elemRect.bottom > 0 && elemRect.top < documentHeight && elemRect.right > 0 && elemRect.left < documentWidth;
 
   return isVisibleInContainer && isVisibleInViewport;
 }


### PR DESCRIPTION
## Motivation and Context
This PR fixes the positioning algorithm of the popover, using `position: fixed` instead of `absolute`. The calculation of the spaces and exact position for the popover, using absolute position, is much more complex to determine because of many more factors to take into account (who is the nearest relative ancestor, the scroll size of that ancestor and the one of the page, etc...) and needs more setup from in the apps (extreme attention on where to use `position: relative`, `overflow`, etc...).

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
