### PR TITLE
fix(z-logo): add visible focus indicator for keyboard navigation

### DIFF
--- a/src/components/z-logo/styles.css
+++ b/src/components/z-logo/styles.css
@@ -17,6 +17,12 @@ a {
   display: block;
   width: 100%;
   height: 100%;
+  border-radius: 4px;
+}
+
+a:focus-visible {
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
 }
 
 :host(.mobile) {


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.1.1 (Keyboard)** by adding a visible focus indicator to the z-logo component's anchor element.

**Issue**: The z-logo component in the site header receives keyboard focus but provides no visible feedback, making it impossible for keyboard users to know when focus is on the logo link.

**Solution**: Added focus-visible styles to the anchor element within the z-logo shadow DOM, using the design system's standard focus token (`--shadow-focus-primary`) for consistency with other focusable components (z-link, z-book-card, z-fab, etc.).

## Test Plan

- [x] Identified z-logo component in design-system repository
- [x] Reproduced focus issue on https://www.zanichelli.it/
- [x] Added focus-visible styles using `--shadow-focus-primary` token
- [x] Verified focus ring renders correctly via Playwright injection test
- [x] Confirmed computed styles match expected box-shadow values
- [x] Checked consistency with z-link and z-book-card focus patterns

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/jxw2gqqw5bvpmuzyn47ow4u58t/

**Before**: Logo receives focus with no visible indicator (only browser default 1px outline)
**After**: Logo shows clear blue focus ring matching design system standard

## Technical Details

The fix adds focus styles to the anchor element within the z-logo shadow DOM:
- Uses `var(--shadow-focus-primary)` token (resolves to white inner ring + blue outer ring)
- `outline: none` removes browser default to avoid double indicators
- `border-radius: 4px` for smooth appearance
- Only triggers on `:focus-visible` (keyboard focus, not mouse clicks)

This matches the established pattern used by z-link, z-book-card, z-fab, and other focusable components in the design system.

---

**WCAG Reference:**
[2.1.1 Keyboard (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)