### PR TITLE
fix(z-input): remove clear and toggle password buttons from tab order

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -417,6 +417,7 @@ export class ZInput {
         type="button"
         class={{"reset-icon": true, "input-icon": true, hidden}}
         aria-label="cancella il contenuto dell'input"
+        tabindex="-1"
         onClick={() => {
           this.inputRef.value = "";
           this.emitInputChange("");
@@ -437,6 +438,7 @@ export class ZInput {
         class="input-icon toggle-password-icon"
         disabled={this.disabled}
         aria-label={this.passwordHidden ? "mostra password" : "nascondi password"}
+        tabindex="-1"
         onClick={() => (this.passwordHidden = !this.passwordHidden)}
       >
         <z-icon


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.1.1 (Keyboard)** by removing the clear icon and show/hide password buttons from the keyboard tab order in `z-input` component.

**Issue**: The clear (×) button and show/hide password (eye icon) button were in the natural tab order, interrupting the flow between form fields and forcing keyboard users to tab through secondary actions.

**Solution**: Added `tabindex="-1"` to both buttons, removing them from keyboard tab sequence while keeping them accessible via mouse/touch and screen reader browse mode.

## Test Plan

- [x] Clear button and show/hide password button removed from tab order
- [x] Buttons remain clickable via mouse/touch
- [x] Buttons remain accessible to screen readers via browse mode
- [x] Form field tab order flows naturally: field 1 → field 2 → submit button

## Evidence

Part of the fix for: https://app.workback.ai/dashboard/issue/78/

---

**WCAG Reference:**
[2.1.1 Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)