### PR TITLE
fix(z-icon): add aria-hidden to SVG for improved accessibility

### DIFF
--- a/src/components/z-icon/index.tsx
+++ b/src/components/z-icon/index.tsx
@@ -88,6 +88,7 @@ export class ZIcon implements ComponentInterface {
         viewBox="0 0 1000 1000"
         width={this.width}
         height={this.height}
+        aria-hidden="true"
       >
         {this.selectPathOrPolygon(ICONS["picker-color"])}
       </svg>
@@ -102,6 +103,7 @@ export class ZIcon implements ComponentInterface {
         viewBox="0 0 1000 1000"
         width={this.width}
         height={this.height}
+        aria-hidden="true"
       >
         {this.selectPathOrPolygon(ICONS[this.getTransparentIndicatorIconIfNeeded()])}
       </svg>


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.1.1 (Non-text Content)** by adding `aria-hidden="true"` to SVG elements inside `z-icon`'s shadow DOM.

**Issue**: Decorative icon images in buttons (such as the modal close button) are exposed to screen readers, even though the parent button has proper accessible text. This creates redundant and confusing information for screen reader users.

**Solution**: Added `aria-hidden="true"` attribute to SVG elements within z-icon's `renderBaseIcon()` and `renderColorIndicator()` methods. This provides defense-in-depth alongside the existing `aria-hidden="true"` on the Host element, ensuring consistent behavior across all assistive technologies.

## Impact

This fix applies to all z-icon instances throughout the design system, ensuring decorative icons are properly hidden from assistive technologies. The button's existing accessible label ("chiudi modale") remains visible to screen readers.

## Test Plan

- [x] Verified modal close button has proper accessible name
- [x] Verified icon is hidden from accessibility tree
- [x] Rebased on latest `master` to resolve merge conflicts after upstream refactor
- [x] Lint checks pass (eslint, prettier)

## Evidence

View full audit details: https://app.workback.ai/issues/qibww8dxqn5prkt7fqymusa54u/

---

**WCAG Reference:** [1.1.1 Non-text Content (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)