### PR TITLE
fix(z-carousel): add context to navigation button accessible names

### DIFF
--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -285,7 +285,13 @@ export class ZCarousel {
               onClick={this.onPrev.bind(this)}
               disabled={!this.infinite && !this.canNavigatePrev}
               hidden={this.arrowsPosition !== CarouselArrowsPosition.OVER || !this.canNavigate}
-              ariaLabel={this.single ? "Mostra l'elemento precedente" : "Mostra gli elementi precedenti"}
+              ariaLabel={
+                this.label
+                  ? `${this.single ? "Mostra l'elemento precedente" : "Mostra gli elementi precedenti"} di ${this.label}`
+                  : this.single
+                    ? "Mostra l'elemento precedente"
+                    : "Mostra gli elementi precedenti"
+              }
             />
             <ul
               class="z-carousel-items-container"
@@ -303,7 +309,13 @@ export class ZCarousel {
               onClick={this.onNext.bind(this)}
               disabled={!this.infinite && !this.canNavigateNext}
               hidden={this.arrowsPosition !== CarouselArrowsPosition.OVER || !this.canNavigate}
-              ariaLabel={this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"}
+              ariaLabel={
+                this.label
+                  ? `${this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"} di ${this.label}`
+                  : this.single
+                    ? "Mostra l'elemento successivo"
+                    : "Mostra gli elementi successivi"
+              }
             />
           </div>
         </div>
@@ -317,7 +329,13 @@ export class ZCarousel {
                 icon="arrow-left"
                 onClick={this.onPrev.bind(this)}
                 disabled={!this.infinite && !this.canNavigatePrev}
-                ariaLabel={this.single ? "Mostra l'elemento precedente" : "Mostra gli elementi precedenti"}
+                ariaLabel={
+                  this.label
+                    ? `${this.single ? "Mostra l'elemento precedente" : "Mostra gli elementi precedenti"} di ${this.label}`
+                    : this.single
+                      ? "Mostra l'elemento precedente"
+                      : "Mostra gli elementi precedenti"
+                }
               />
             )}
             {this.progressMode === CarouselProgressMode.DOTS && this.single && this.items && (
@@ -348,7 +366,13 @@ export class ZCarousel {
                 icon="arrow-right"
                 onClick={this.onNext.bind(this)}
                 disabled={!this.infinite && !this.canNavigateNext}
-                ariaLabel={this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"}
+                ariaLabel={
+                  this.label
+                    ? `${this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"} di ${this.label}`
+                    : this.single
+                      ? "Mostra l'elemento successivo"
+                      : "Mostra gli elementi successivi"
+                }
               />
             )}
           </div>


### PR DESCRIPTION
## Summary

Fixes **WCAG 4.1.2 (Name, Role, Value)** by enhancing carousel navigation button accessible names to include context about what content is being navigated.

**Issue**: Carousel navigation buttons had generic labels like "Mostra gli elementi precedenti/successivi" without indicating what elements are being navigated.

**Solution**: Modified the `z-carousel` component to append the carousel's label to navigation button aria-labels when a label is provided, giving users context about the content (e.g., "Mostra gli elementi successivi di Ultime novità").

## Changes

- Updated all four navigation button instances in `z-carousel/index.tsx` to conditionally append the carousel label to aria-labels
- Maintains backward compatibility - if no label is provided, buttons use the original generic labels

## Test Plan

- [x] Modified carousel component to use label in aria-labels
- [x] Tested that buttons now have descriptive accessible names when label prop is provided
- [x] Verified backward compatibility with carousels without labels

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/154/

---

**WCAG Reference:**
[4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)