### PR TITLE
fix(z-carousel): add status announcements for carousel navigation

### DIFF
--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -69,6 +69,10 @@ export class ZCarousel {
   @State()
   canNavigateNext: boolean;
 
+  /** Status message for screen readers */
+  @State()
+  statusMessage: string = "";
+
   /** Reference for the items container element. */
   protected itemsContainer: HTMLUListElement;
 
@@ -88,6 +92,7 @@ export class ZCarousel {
   @Watch("current")
   onIndexChange(): void {
     this.indexChange.emit({currentItem: this.current});
+    this.updateStatusMessage();
   }
 
   @Watch("single")
@@ -229,6 +234,38 @@ export class ZCarousel {
     });
   }
 
+  /**
+   * Extract text content from an item for screen reader announcement
+   */
+  private getItemText(item: HTMLLIElement): string {
+    const heading = item.querySelector("h1, h2, h3, h4, h5, h6");
+    if (heading) {
+      return heading.textContent?.trim() || "";
+    }
+    return item.textContent?.trim().substring(0, 100) || "";
+  }
+
+  /**
+   * Update status message for screen readers when carousel navigates
+   */
+  private updateStatusMessage(): void {
+    if (!this.items || this.items.length === 0) {
+      return;
+    }
+
+    const currentItem = this.items[this.current];
+    if (!currentItem) {
+      return;
+    }
+
+    const itemText = this.getItemText(currentItem);
+    if (this.single) {
+      this.statusMessage = `Elemento ${this.current + 1} di ${this.items.length}${itemText ? `: ${itemText}` : ""}`;
+    } else {
+      this.statusMessage = itemText || `Elemento ${this.current + 1}`;
+    }
+  }
+
   /** Check if navigation of at least one direction is enabled */
   private get canNavigate(): boolean {
     return this.canNavigatePrev || this.canNavigateNext;
@@ -305,6 +342,14 @@ export class ZCarousel {
               hidden={this.arrowsPosition !== CarouselArrowsPosition.OVER || !this.canNavigate}
               ariaLabel={this.single ? "Mostra l'elemento successivo" : "Mostra gli elementi successivi"}
             />
+          </div>
+          <div
+            class="z-carousel-status"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {this.statusMessage}
           </div>
         </div>
 

--- a/src/components/z-carousel/styles.css
+++ b/src/components/z-carousel/styles.css
@@ -23,6 +23,18 @@
   flex-direction: column;
 }
 
+.z-carousel-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .z-carousel-title {
   margin-bottom: calc(var(--space-unit) * 2);
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 4.1.3 (Status Messages)** by adding screen reader announcements when carousel content changes.

**Issue**: The "Ultime novità" carousel on the Siti laZ page has next/previous navigation buttons, but when users click these buttons to cycle through items, there is no ARIA live region or role=status to announce which item is now visible. Screen reader users clicking the carousel controls receive no feedback about what content is displayed.

**Solution**: Added a visually hidden live region with `role="status"` and `aria-live="polite"` that announces the current carousel item's title and position whenever users navigate. The announcement extracts the heading content from each carousel item (e.g., "Elemento 1 di 8: myZanichelli").

## Changes

- Added `statusMessage` state property to track current item information
- Created `updateStatusMessage()` method to extract item titles from headings and format announcements
- Added `getItemText()` helper to intelligently extract text content from carousel items
- Added status live region element with proper ARIA attributes (`role="status"`, `aria-live="polite"`, `aria-atomic="true"`)
- Applied screen-reader-only CSS to visually hide the status element while keeping it accessible

## Test Plan

- [x] Carousel navigation announces current item title to screen readers
- [x] Status messages include item position (e.g., "Elemento 1 di 8") for single-item carousels
- [x] Status element is visually hidden but accessible to assistive technology
- [x] Works with both single and multi-item carousel modes

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/160/

---

**WCAG Reference:**
[4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)
