### PR TITLE
fix(z-tag): allow text expansion with increased line spacing

### DIFF
--- a/src/components/z-tag/styles.css
+++ b/src/components/z-tag/styles.css
@@ -17,7 +17,7 @@
   font-size: var(--font-size-1);
   font-weight: var(--font-sb);
   letter-spacing: 0.32px;
-  line-height: 14px;
+  line-height: 1.5;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.12 (Text Spacing)** by changing the `z-tag` component's `line-height` from a fixed `14px` value to a relative `1.5` value.

**Issue**: Year badge elements (showing "2024", "2025", etc.) had fixed line-height causing text clipping when WCAG 1.4.12 text spacing requirements are applied (line-height: 1.5, letter-spacing: 0.12em, word-spacing: 0.16em). The fixed 14px line-height prevented text from expanding vertically, causing approximately 4px of text to be clipped.

**Solution**: Changed `line-height` from `14px` to `1.5` in the `z-tag` component styles to allow text to expand naturally when increased text spacing is applied by users.

## Test Plan

- [x] Tested with WCAG 1.4.12 text spacing requirements (line-height: 1.5, letter-spacing: 0.12em, word-spacing: 0.16em)
- [x] Verified year badges render without clipping in catalog listings
- [x] Confirmed text remains fully visible with increased spacing

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/172/

---

**WCAG Reference:**
[1.4.12 Text Spacing (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html)