### PR TITLE
fix(z-navigation-tabs): update aria-labels for pagination consistency

### DIFF
--- a/src/components/z-navigation-tabs/index.tsx
+++ b/src/components/z-navigation-tabs/index.tsx
@@ -330,7 +330,7 @@ export class ZNavigationTabs {
           onClick={this.navigateBackwards.bind(this)}
           tabIndex={-1}
           disabled={!this.canNavigatePrev}
-          aria-label="Mostra elementi precedenti"
+          aria-label="Vai alla pagina precedente"
           hidden={!this.canNavigate}
         >
           <z-icon
@@ -355,7 +355,7 @@ export class ZNavigationTabs {
           onClick={this.navigateForward.bind(this)}
           tabIndex={-1}
           disabled={!this.canNavigateNext}
-          aria-label="Mostra elementi successivi"
+          aria-label="Vai alla prossima pagina"
           hidden={!this.canNavigate}
         >
           <z-icon


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.2.4 (Consistent Identification)** by updating navigation button aria-labels in the z-navigation-tabs component to use consistent, page-specific terminology.

**Issue**: Navigation buttons had inconsistent accessible names. The buttons used generic "Show previous/next elements" labels ("Mostra elementi precedenti/successivi"), which don't match user expectations for pagination controls that should say "Go to previous/next page" ("Vai alla pagina precedente/prossima").

**Solution**: Updated aria-label attributes to use "Vai alla pagina precedente" and "Vai alla prossima pagina" for better consistency and clarity.

## Changes

- `src/components/z-navigation-tabs/index.tsx`:
  - Previous button: `aria-label="Mostra elementi precedenti"` → `aria-label="Vai alla pagina precedente"`
  - Next button: `aria-label="Mostra elementi successivi"` → `aria-label="Vai alla prossima pagina"`

## Test Plan

- [x] Verified lint checks pass
- [x] Tested with screen reader to confirm new labels are clear and consistent
- [x] Confirmed buttons function correctly with updated labels

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/206/

---

**WCAG Reference:**
[3.2.4 Consistent Identification](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html)
