### PR TITLE
fix(z-stepper-item): add non-color visual indicator for active step

### DIFF
--- a/src/components/z-stepper-item/styles.css
+++ b/src/components/z-stepper-item/styles.css
@@ -82,6 +82,7 @@
 
 :host([pressed]:not([disabled])) .indicator {
   border-color: var(--color-hover-primary);
+  border-width: calc(var(--border-size-medium) * 2);
   background: var(--color-hover-primary);
   color: var(--color-text-inverse);
 }

--- a/src/components/z-stepper-item/styles.css
+++ b/src/components/z-stepper-item/styles.css
@@ -81,8 +81,8 @@
 }
 
 :host([pressed]:not([disabled])) .indicator {
-  border-color: var(--color-hover-primary);
   border-width: calc(var(--border-size-medium) * 2);
+  border-color: var(--color-hover-primary);
   background: var(--color-hover-primary);
   color: var(--color-text-inverse);
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding a thicker border to the active step indicator in the stepper component.

**Issue**: The progress stepper uses color alone (dark blue vs gray) to distinguish the active step from inactive steps. Users with color vision deficiencies cannot reliably identify which step is currently active.

**Solution**: Added a 2x thicker border to the pressed/active step indicator, providing a visual distinction that doesn't rely on color perception.

## Test Plan

- [x] Identified the z-stepper-item component in design-system
- [x] Modified CSS to add `border-width: calc(var(--border-size-medium) * 2)` to pressed state
- [x] Verified the change follows existing CSS patterns and conventions
- [x] Change is minimal and focused on the specific WCAG criterion

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/1782/

## Technical Details

The change affects only the visual presentation of the active step:
- **Before**: Active step distinguished only by color (dark blue background)
- **After**: Active step has both color AND a thicker border (2x normal width)

This ensures WCAG 1.4.1 Level A compliance by providing a non-color visual indicator.

---

**WCAG Reference:**
[1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)