### PR TITLE
fix(z-stepper-item): add ARIA attributes for pressed and disabled states

### DIFF
--- a/src/components/z-stepper-item/index.tsx
+++ b/src/components/z-stepper-item/index.tsx
@@ -42,12 +42,16 @@ export class ZStepperItem {
     const role = href ? {role: "link"} : undefined;
     const current = this.pressed && !this.disabled ? {ariaCurrent: "step"} : undefined;
     const tabindex = this.pressed || this.href === "" ? {tabindex: -1} : undefined;
+    const ariaPressed = this.pressed !== undefined ? {"aria-pressed": String(this.pressed)} : undefined;
+    const ariaDisabled = this.disabled !== undefined ? {"aria-disabled": String(this.disabled)} : undefined;
 
     return {
       ...href,
       ...role,
       ...current,
       ...tabindex,
+      ...ariaPressed,
+      ...ariaDisabled,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 4.1.2 (Name, Role, Value)** by adding proper ARIA attributes to the z-stepper-item component.

**Issue**: The stepper component uses non-standard HTML attributes (`pressed="true"`, `disabled="true"`) that are not recognized by assistive technologies. Buttons inside stepper items lack `aria-pressed` and `aria-disabled` attributes, preventing screen readers from announcing the correct state.

**Solution**: Added `aria-pressed` and `aria-disabled` attributes to the button element within z-stepper-item, ensuring assistive technologies can correctly identify and announce button states.

## Changes

- Modified `src/components/z-stepper-item/index.tsx`
- Added `aria-pressed` attribute when `pressed` prop is set
- Added `aria-disabled` attribute when `disabled` prop is set
- Attributes are applied to the internal button element

## Test Plan

- [x] Built component successfully with `yarn build.wc`
- [x] Linting passes with `yarn lint`
- [x] Verified button elements receive correct ARIA attributes
- [x] Tested on registration flow at `/registrazione/studente/1`

## Impact

**Before**: Screen readers could not announce whether stepper steps were pressed or disabled, making navigation confusing for users with visual impairments.

**After**: Screen readers will correctly announce:
- "button, pressed, current step" for the active step
- "button, disabled" for unavailable steps

## Evidence

View detailed accessibility audit and verification evidence:
https://app.workback.ai/dashboard/issue/1791/

---

**WCAG Reference:**
[4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
