### PR TITLE
fix(z-result-card): improve text display at high zoom levels

### DIFF
--- a/src/components/z-result-card/styles.css
+++ b/src/components/z-result-card/styles.css
@@ -57,9 +57,9 @@ z-book-cover {
 .card-subtitle {
   display: -webkit-box;
   overflow: hidden;
-  color: var(--color-default-text);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  color: var(--color-default-text);
   line-clamp: 2;
   line-height: 1.4;
   word-break: break-word;

--- a/src/components/z-result-card/styles.css
+++ b/src/components/z-result-card/styles.css
@@ -7,7 +7,7 @@
   display: flex;
   overflow: hidden;
   min-width: 0;
-  height: 11.125rem;
+  min-height: 11.125rem;
   padding: var(--space-unit);
   border: var(--border-size-medium) solid var(--color-surface02);
   background-color: var(--color-surface01);
@@ -48,17 +48,21 @@ z-book-cover {
   -webkit-box-orient: vertical;
   font-size: var(--font-size-3);
   font-weight: var(--font-bd);
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
   line-height: 1.5;
   word-break: break-word;
 }
 
 .card-subtitle {
+  display: -webkit-box;
   overflow: hidden;
   color: var(--color-default-text);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .tags-container {
@@ -134,6 +138,12 @@ z-book-cover {
     display: block;
     overflow: hidden;
     line-height: normal;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .card-subtitle {
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.4 (Resize Text)** by allowing result card text to wrap across more lines instead of being truncated at high zoom levels.

**Issue**: When users zoom to 200%, book titles and subtitles in `z-result-card` components are truncated with ellipsis, hiding important product information needed to make purchasing decisions.

**Solution**: 
- Increased title `line-clamp` from 2 to 3 lines
- Changed subtitle from `nowrap` to 2-line clamp with wrapping
- Changed card height from fixed to `min-height` to allow expansion
- Preserved mobile breakpoint behavior with single-line truncation

## Test Plan

- [x] Verify cards display normally at 100% zoom
- [x] Verify text wraps appropriately at 200% zoom without truncation
- [x] Verify mobile view maintains single-line truncation
- [x] Verify tooltips still appear when text is truncated

## Impact

This change affects the `z-result-card` component used across Zanichelli applications for displaying search results and product listings.

## Related Issue

Addresses accessibility issue #22 in myzanichelli_shop repository where search result cards truncate text at 200% zoom.

---

**WCAG Reference:** [1.4.4 Resize Text (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html)