### PR TITLE
fix(accessibility): add z-input-group component for WCAG 1.3.1 compliance

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1112,6 +1112,17 @@ export namespace Components {
          */
         "value"?: string;
     }
+    interface ZInputGroup {
+        /**
+          * [optional] Whether to visually hide the legend while keeping it accessible to screen readers.
+          * @default false
+         */
+        "hideLegend"?: boolean;
+        /**
+          * The legend text that describes the group of inputs. Required for accessibility.
+         */
+        "legend": string;
+    }
     interface ZInputMessage {
         /**
           * input disabled status (optional)
@@ -3153,6 +3164,12 @@ declare global {
         prototype: HTMLZInputElement;
         new (): HTMLZInputElement;
     };
+    interface HTMLZInputGroupElement extends Components.ZInputGroup, HTMLStencilElement {
+    }
+    var HTMLZInputGroupElement: {
+        prototype: HTMLZInputGroupElement;
+        new (): HTMLZInputGroupElement;
+    };
     interface HTMLZInputMessageElement extends Components.ZInputMessage, HTMLStencilElement {
     }
     var HTMLZInputMessageElement: {
@@ -3915,6 +3932,7 @@ declare global {
         "z-info-box": HTMLZInfoBoxElement;
         "z-info-reveal": HTMLZInfoRevealElement;
         "z-input": HTMLZInputElement;
+        "z-input-group": HTMLZInputGroupElement;
         "z-input-message": HTMLZInputMessageElement;
         "z-list": HTMLZListElement;
         "z-list-element": HTMLZListElementElement;
@@ -5159,6 +5177,17 @@ declare namespace LocalJSX {
           * the input value
          */
         "value"?: string;
+    }
+    interface ZInputGroup {
+        /**
+          * [optional] Whether to visually hide the legend while keeping it accessible to screen readers.
+          * @default false
+         */
+        "hideLegend"?: boolean;
+        /**
+          * The legend text that describes the group of inputs. Required for accessibility.
+         */
+        "legend": string;
     }
     interface ZInputMessage {
         /**
@@ -6980,6 +7009,10 @@ declare namespace LocalJSX {
         "pattern": string;
         "size": ControlSize;
     }
+    interface ZInputGroupAttributes {
+        "legend": string;
+        "hideLegend": boolean;
+    }
     interface ZInputMessageAttributes {
         "message": string;
         "htmlId": string;
@@ -7377,6 +7410,7 @@ declare namespace LocalJSX {
         "z-info-box": Omit<ZInfoBox, keyof ZInfoBoxAttributes> & { [K in keyof ZInfoBox & keyof ZInfoBoxAttributes]?: ZInfoBox[K] } & { [K in keyof ZInfoBox & keyof ZInfoBoxAttributes as `attr:${K}`]?: ZInfoBoxAttributes[K] } & { [K in keyof ZInfoBox & keyof ZInfoBoxAttributes as `prop:${K}`]?: ZInfoBox[K] };
         "z-info-reveal": Omit<ZInfoReveal, keyof ZInfoRevealAttributes> & { [K in keyof ZInfoReveal & keyof ZInfoRevealAttributes]?: ZInfoReveal[K] } & { [K in keyof ZInfoReveal & keyof ZInfoRevealAttributes as `attr:${K}`]?: ZInfoRevealAttributes[K] } & { [K in keyof ZInfoReveal & keyof ZInfoRevealAttributes as `prop:${K}`]?: ZInfoReveal[K] };
         "z-input": Omit<ZInput, keyof ZInputAttributes> & { [K in keyof ZInput & keyof ZInputAttributes]?: ZInput[K] } & { [K in keyof ZInput & keyof ZInputAttributes as `attr:${K}`]?: ZInputAttributes[K] } & { [K in keyof ZInput & keyof ZInputAttributes as `prop:${K}`]?: ZInput[K] };
+        "z-input-group": Omit<ZInputGroup, keyof ZInputGroupAttributes> & { [K in keyof ZInputGroup & keyof ZInputGroupAttributes]?: ZInputGroup[K] } & { [K in keyof ZInputGroup & keyof ZInputGroupAttributes as `attr:${K}`]?: ZInputGroupAttributes[K] } & { [K in keyof ZInputGroup & keyof ZInputGroupAttributes as `prop:${K}`]?: ZInputGroup[K] } & OneOf<"legend", ZInputGroup["legend"], ZInputGroupAttributes["legend"]>;
         "z-input-message": Omit<ZInputMessage, keyof ZInputMessageAttributes> & { [K in keyof ZInputMessage & keyof ZInputMessageAttributes]?: ZInputMessage[K] } & { [K in keyof ZInputMessage & keyof ZInputMessageAttributes as `attr:${K}`]?: ZInputMessageAttributes[K] } & { [K in keyof ZInputMessage & keyof ZInputMessageAttributes as `prop:${K}`]?: ZInputMessage[K] };
         "z-list": Omit<ZList, keyof ZListAttributes> & { [K in keyof ZList & keyof ZListAttributes]?: ZList[K] } & { [K in keyof ZList & keyof ZListAttributes as `attr:${K}`]?: ZListAttributes[K] } & { [K in keyof ZList & keyof ZListAttributes as `prop:${K}`]?: ZList[K] };
         "z-list-element": Omit<ZListElement, keyof ZListElementAttributes> & { [K in keyof ZListElement & keyof ZListElementAttributes]?: ZListElement[K] } & { [K in keyof ZListElement & keyof ZListElementAttributes as `attr:${K}`]?: ZListElementAttributes[K] } & { [K in keyof ZListElement & keyof ZListElementAttributes as `prop:${K}`]?: ZListElement[K] };
@@ -7516,6 +7550,7 @@ declare module "@stencil/core" {
              */
             "z-info-reveal": LocalJSX.IntrinsicElements["z-info-reveal"] & JSXBase.HTMLAttributes<HTMLZInfoRevealElement>;
             "z-input": LocalJSX.IntrinsicElements["z-input"] & JSXBase.HTMLAttributes<HTMLZInputElement>;
+            "z-input-group": LocalJSX.IntrinsicElements["z-input-group"] & JSXBase.HTMLAttributes<HTMLZInputGroupElement>;
             "z-input-message": LocalJSX.IntrinsicElements["z-input-message"] & JSXBase.HTMLAttributes<HTMLZInputMessageElement>;
             "z-list": LocalJSX.IntrinsicElements["z-list"] & JSXBase.HTMLAttributes<HTMLZListElement>;
             "z-list-element": LocalJSX.IntrinsicElements["z-list-element"] & JSXBase.HTMLAttributes<HTMLZListElementElement>;

--- a/src/components/z-input-group/index.stories.tsx
+++ b/src/components/z-input-group/index.stories.tsx
@@ -1,0 +1,125 @@
+import {h} from "@stencil/core";
+import type {Meta, StoryObj} from "@stencil/storybook-plugin";
+import "../z-input";
+import {ZInputGroup} from "./index";
+
+const StoryMeta = {
+  title: "ZInputGroup",
+  component: ZInputGroup,
+  argTypes: {
+    legend: {
+      control: {
+        type: "text",
+      },
+    },
+    hideLegend: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+  args: {
+    legend: "Frequenti",
+    hideLegend: false,
+  },
+  render: (args) => (
+    <z-input-group
+      legend={args.legend}
+      hide-legend={args.hideLegend}
+    >
+      <z-input
+        type="radio"
+        name="studentType"
+        value="underGdpr"
+        label="la scuola e hai meno di 14 anni"
+        size="big"
+      ></z-input>
+      <z-input
+        type="radio"
+        name="studentType"
+        value="overGdpr"
+        label="la scuola e hai più di 14 anni"
+        size="big"
+        checked
+      ></z-input>
+      <z-input
+        type="radio"
+        name="studentType"
+        value="university"
+        label="l'università"
+        size="big"
+      ></z-input>
+    </z-input-group>
+  ),
+} satisfies Meta<ZInputGroup>;
+
+export default StoryMeta;
+
+type Story = StoryObj<ZInputGroup>;
+
+export const RadioGroup = {} satisfies Story;
+
+export const CheckboxGroup = {
+  args: {
+    legend: "Select your preferences",
+  },
+  render: (args) => (
+    <z-input-group
+      legend={args.legend}
+      hide-legend={args.hideLegend}
+    >
+      <z-input
+        type="checkbox"
+        name="preferences"
+        value="newsletter"
+        label="Receive newsletter"
+        size="big"
+      ></z-input>
+      <z-input
+        type="checkbox"
+        name="preferences"
+        value="updates"
+        label="Product updates"
+        size="big"
+        checked
+      ></z-input>
+    </z-input-group>
+  ),
+} satisfies Story;
+
+export const HiddenLegend = {
+  args: {
+    hideLegend: true,
+  },
+  render: (args) => (
+    <div>
+      <h2 class="heading-4-lt">Frequenti</h2>
+      <z-input-group
+        legend={args.legend}
+        hide-legend={args.hideLegend}
+      >
+        <z-input
+          type="radio"
+          name="studentType2"
+          value="underGdpr"
+          label="la scuola e hai meno di 14 anni"
+          size="big"
+        ></z-input>
+        <z-input
+          type="radio"
+          name="studentType2"
+          value="overGdpr"
+          label="la scuola e hai più di 14 anni"
+          size="big"
+        ></z-input>
+        <z-input
+          type="radio"
+          name="studentType2"
+          value="university"
+          label="l'università"
+          size="big"
+        ></z-input>
+      </z-input-group>
+    </div>
+  ),
+} satisfies Story;

--- a/src/components/z-input-group/index.tsx
+++ b/src/components/z-input-group/index.tsx
@@ -1,0 +1,31 @@
+import {Component, ComponentInterface, Host, Prop, h} from "@stencil/core";
+
+/**
+ * @slot - Content containing form inputs (typically radio buttons or checkboxes)
+ */
+@Component({
+  tag: "z-input-group",
+  styleUrl: "styles.css",
+  shadow: false,
+  scoped: true,
+})
+export class ZInputGroup implements ComponentInterface {
+  /** The legend text that describes the group of inputs. Required for accessibility. */
+  @Prop()
+  legend!: string;
+
+  /** [optional] Whether to visually hide the legend while keeping it accessible to screen readers. */
+  @Prop()
+  hideLegend?: boolean = false;
+
+  render() {
+    return (
+      <Host>
+        <fieldset>
+          <legend class={{hidden: this.hideLegend}}>{this.legend}</legend>
+          <slot />
+        </fieldset>
+      </Host>
+    );
+  }
+}

--- a/src/components/z-input-group/readme.md
+++ b/src/components/z-input-group/readme.md
@@ -1,0 +1,40 @@
+# z-input-group
+
+Provides semantic grouping for related form inputs using `<fieldset>` and `<legend>` elements, ensuring WCAG 1.3.1 compliance.
+
+## Usage
+
+Use `z-input-group` to wrap groups of related radio buttons or checkboxes. The `legend` prop provides a descriptive label for the group.
+
+```html
+<z-input-group legend="Select your age group">
+  <z-input type="radio" name="age" value="under14" label="Under 14 years old" />
+  <z-input type="radio" name="age" value="over14" label="14 years or older" />
+</z-input-group>
+```
+
+## WCAG Compliance
+
+This component satisfies WCAG 2.1 Success Criterion 1.3.1 (Info and Relationships) by programmatically associating the legend with the grouped inputs through the `<fieldset>` element.
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property              | Attribute     | Description                                                                                   | Type      | Default     |
+| --------------------- | ------------- | --------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `hideLegend`          | `hide-legend` | [optional] Whether to visually hide the legend while keeping it accessible to screen readers. | `boolean` | `false`     |
+| `legend` _(required)_ | `legend`      | The legend text that describes the group of inputs. Required for accessibility.               | `string`  | `undefined` |
+
+
+## Slots
+
+| Slot | Description                                                            |
+| ---- | ---------------------------------------------------------------------- |
+|      | Content containing form inputs (typically radio buttons or checkboxes) |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/z-input-group/styles.css
+++ b/src/components/z-input-group/styles.css
@@ -1,0 +1,27 @@
+:host {
+  display: block;
+}
+
+fieldset {
+  min-width: 0;
+  padding: 0;
+  border: none;
+  margin: 0;
+}
+
+legend {
+  padding: 0;
+  margin: 0;
+}
+
+legend.hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border-width: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.3.1 (Info and Relationships)** by introducing a new `z-input-group` web component that provides semantic grouping for related form inputs.

**Issue**: Radio button groups in the registration form lack programmatic association between the visible heading ("Frequenti") and the input controls. WCAG 1.3.1 requires that information, structure, and relationships conveyed through presentation be programmatically determinable.

**Solution**: Created `z-input-group` component that wraps inputs with `<fieldset>` and `<legend>` elements, establishing the required programmatic relationship.

## Implementation

### New Component: `z-input-group`

**Features:**
- Wraps form controls with semantic `<fieldset>` and `<legend>` HTML elements
- `legend` prop (required): Provides accessible label for the group
- `hide-legend` prop (optional): Visually hides legend while maintaining accessibility
- Zero visual impact when `hide-legend` is used
- Supports radio buttons, checkboxes, and other grouped inputs

**Usage:**
```html
<z-input-group legend="Frequenti" hide-legend>
  <z-input type="radio" name="studentType" value="underGdpr" label="la scuola e hai meno di 14 anni" size="big"></z-input>
  <z-input type="radio" name="studentType" value="overGdpr" label="la scuola e hai più di 14 anni" size="big"></z-input>
  <z-input type="radio" name="studentType" value="university" label="l'università" size="big"></z-input>
</z-input-group>
```

## Test Plan

- [x] Component builds successfully
- [x] Storybook stories demonstrate usage
- [x] Fieldset/legend structure is correctly rendered
- [x] `hide-legend` prop visually hides legend without removing it from DOM
- [ ] Test with screen readers (NVDA, JAWS, VoiceOver) to verify legend is announced
- [ ] Integration testing in registration form

## Next Steps

After this PR is merged and the component library is published:
1. Update registration form to use `z-input-group`
2. Wrap existing radio button group with the new component
3. Verify fix in production

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/1818/

---

**WCAG Reference:**
[1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)