### PR TITLE
fix(a11y): add visible focus indicator for all links

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -3,3 +3,9 @@
 @import "./tokens/main.css";
 @import "./tokens/themes/index.css";
 @import "components/z-accordion/z-accordion-globals.css";
+
+/* Ensure all links have visible focus indicators for WCAG 2.4.7 compliance */
+a:focus-visible {
+  outline: 2px solid var(--color-primary-default, #002c63);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.7 (Focus Visible)** by adding visible focus indicators to all link elements.

**Issue**: Links embedded in checkbox labels and other contexts lack visible focus indicators when navigated via keyboard, preventing keyboard users from determining their current focus position.

**Solution**: Added global CSS rule to display a 2px solid outline on all `<a>` elements when focused via keyboard using `:focus-visible` pseudo-class.

## Technical Changes

Added to `/src/global.css`:

```css
a:focus-visible {
  outline: 2px solid var(--color-primary-default, #002c63);
  outline-offset: 2px;
}
```

This ensures all links display a clear, visible focus indicator that meets WCAG Level AA requirements.

## Test Plan

- [x] Focus indicator appears on links when navigating with Tab key
- [x] Focus indicator uses Zanichelli primary blue color (#002c63)
- [x] Outline offset provides clear visual separation
- [x] No focus indicator appears on mouse click (`:focus-visible` only triggers for keyboard)
- [x] Linting passes with Prettier formatting applied

## Impact

This fix applies to all links across Zanichelli applications using the design-system, particularly:
- Links in checkbox/radio labels (registration forms, consent forms)
- Links in dense content areas
- Navigation links without additional styling

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/1829/

---

**WCAG Reference:**
[2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)