### PR TITLE
fix(z-stepper-item): add aria-label support for WCAG 2.4.6

### DIFF
--- a/src/components/z-stepper-item/index.tsx
+++ b/src/components/z-stepper-item/index.tsx
@@ -36,18 +36,26 @@ export class ZStepperItem implements ComponentInterface {
   @Prop({reflect: true})
   disabled: boolean;
 
+  /**
+   * The aria-label for the button.
+   */
+  @Prop({reflect: true, attribute: "aria-label"})
+  ariaLabel: string;
+
   private getAttributes(): Record<string, unknown> {
     const href =
       this.href && !this.pressed && !this.disabled ? {onClick: () => (location.href = this.href)} : undefined;
     const role = href ? {role: "link"} : undefined;
     const current = this.pressed && !this.disabled ? {"aria-current": "step"} : undefined;
     const tabindex = this.pressed || this.href === "" ? {tabIndex: -1} : undefined;
+    const ariaLabel = this.ariaLabel ? {"aria-label": this.ariaLabel} : undefined;
 
     return {
       ...href,
       ...role,
       ...current,
       ...tabindex,
+      ...ariaLabel,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.6 (Headings and Labels)** by adding `aria-label` support to the `z-stepper-item` component.

**Issue**: The cart checkout stepper displays buttons labeled simply "2" and "3" without descriptive context. Screen readers announce "button 2", "button 3, disabled" without explaining these are checkout step indicators or what each step contains.

**Solution**: Added `ariaLabel` prop to `z-stepper-item` component that passes through to the button element, allowing parent components to provide descriptive labels like "Passo 2 di 3: I tuoi dati" (Step 2 of 3: Your data).

## Changes

- Added `ariaLabel` prop with `@Prop({reflect: true, attribute: "aria-label"})` decorator
- Updated `getAttributes()` method to include aria-label in button attributes
- Maintains backward compatibility - aria-label is optional

## Impact

Users with screen readers and cognitive disabilities will now understand:
- The purpose of each numbered button
- The current position in the checkout flow
- What each step contains

## Test Plan

- [x] Code change implements aria-label forwarding
- [x] Existing cart checkout flow already uses aria-label in template (no changes needed there)
- [x] Verified button element receives aria-label attribute

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/1864/

---

**WCAG Reference:**
[2.4.6 Headings and Labels (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)
