### PR TITLE
fix(z-input): associate helper message with input via aria-describedby

### DIFF
--- a/src/components/z-input-message/index.tsx
+++ b/src/components/z-input-message/index.tsx
@@ -7,6 +7,10 @@ import {InputStatus} from "../../beans";
   shadow: true,
 })
 export class ZInputMessage {
+  /** the id of the message element for aria-describedby association */
+  @Prop()
+  htmlid?: string;
+
   /** input helper message */
   @Prop()
   message: string;
@@ -40,7 +44,10 @@ export class ZInputMessage {
 
   render(): HTMLZInputMessageElement {
     return (
-      <Host {...this.statusRole}>
+      <Host
+        {...this.statusRole}
+        id={this.htmlid}
+      >
         {this.statusIcons[this.status] && this.message && <z-icon name={this.statusIcons[this.status]}></z-icon>}
         <span innerHTML={this.message} />
       </Host>

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -314,12 +314,15 @@ export class ZInput {
     const activedescendant = this.htmlAriaActivedescendant
       ? {"aria-activedescendant": this.htmlAriaActivedescendant}
       : {};
+    const describedby =
+      boolean(this.message) !== false ? {"aria-describedby": `${this.htmlid}_message`} : {};
 
     return {
       ...expanded,
       ...controls,
       ...autocomplete,
       ...activedescendant,
+      ...describedby,
     };
   }
 
@@ -454,6 +457,7 @@ export class ZInput {
 
     return (
       <z-input-message
+        htmlid={`${this.htmlid}_message`}
         message={boolean(this.message) === true ? undefined : (this.message as string)}
         status={this.status}
         class={this.size}
@@ -468,6 +472,8 @@ export class ZInput {
 
   private renderTextarea(): HTMLDivElement {
     const attributes = this.getTextAttributes();
+    const ariaDescribedby =
+      boolean(this.message) !== false ? {"aria-describedby": `${this.htmlid}_message`} : {};
 
     return (
       <Fragment>
@@ -487,6 +493,7 @@ export class ZInput {
             }}
             aria-label={this.ariaLabel || undefined}
             {...this.getRoleAttribute()}
+            {...ariaDescribedby}
           ></textarea>
         </div>
         {this.renderMessage()}


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.3.1 (Info and Relationships)** by programmatically associating helper messages with their corresponding input fields via `aria-describedby`.

**Issue**: The `z-input` component displays helper text via `z-input-message`, but this text is not programmatically associated with the input field. Screen reader users do not hear the helper text when they focus on the input, missing important context like "Trovi il codice stampato sul bollino SIAE, nella prima pagina del libro" for the activation code input.

**Solution**: 
- Added `htmlid` prop to `z-input-message` component to set its ID
- Modified `z-input` to generate unique message IDs and pass them to `z-input-message`
- Added `aria-describedby` attributes to text inputs and textareas pointing to their associated message IDs

## Test Plan

- [x] Verify `aria-describedby` is added to text input elements when a message is present
- [x] Verify `aria-describedby` is added to textarea elements when a message is present
- [x] Verify the message element receives the correct ID
- [x] Test with screen reader to confirm helper text is announced on focus

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/1859/

---

**WCAG Reference:**
[1.3.1 Info and Relationships (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
