### PR TITLE
fix(z-icon): prevent focus on decorative icon element

### DIFF
--- a/src/components/z-icon/index.tsx
+++ b/src/components/z-icon/index.tsx
@@ -110,7 +110,10 @@ export class ZIcon implements ComponentInterface {
 
   render(): HTMLZIconElement {
     return (
-      <Host aria-hidden="true">
+      <Host
+        aria-hidden="true"
+        tabindex="-1"
+      >
         {this.hasColorIndicator && !this.needsTransparentIndicator ? (
           <div class="icon-wrapper">
             {this.renderColorIndicator()}


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.3 (Focus Order)** by preventing the z-icon component from being focusable.

**Issue**: The z-icon custom element appears in the keyboard tab order but has no accessible name and `aria-hidden="true"`, creating a confusing experience for keyboard users who tab to an element that screen readers won't announce.

**Solution**: Added `tabindex="-1"` to the z-icon Host element to ensure it can never receive keyboard focus. Elements with `aria-hidden="true"` should never be focusable as this violates WCAG 2.4.3 Focus Order requirements.

## Test Plan

- [x] Added `tabindex="-1"` to z-icon component
- [x] Verified linting passes
- [x] Confirmed fix prevents focus on decorative icons

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/ss59e8axeod9s6t3m7dhxjh4jc/

---

**WCAG Reference:**
[2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)