### PR TITLE
fix: add visible focus indicator to z-button component

### DIFF
--- a/src/components/z-button/styles.css
+++ b/src/components/z-button/styles.css
@@ -35,7 +35,18 @@
   white-space: nowrap;
 }
 
-:host .z-button--container:focus:focus-visible {
+:host .z-button--container:focus {
+  outline: 2px solid var(--color-primary01);
+  outline-offset: 2px;
+}
+
+:host .z-button--container:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:host .z-button--container:focus-visible {
+  outline: 2px solid var(--color-primary01);
+  outline-offset: 2px;
   box-shadow: var(--shadow-focus-primary);
 }
 

--- a/src/components/z-button/styles.css
+++ b/src/components/z-button/styles.css
@@ -45,9 +45,9 @@
 }
 
 :host .z-button--container:focus-visible {
+  box-shadow: var(--shadow-focus-primary);
   outline: 2px solid var(--color-primary01);
   outline-offset: 2px;
-  box-shadow: var(--shadow-focus-primary);
 }
 
 :host .z-button--container.z-button--has-text {


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.7 (Focus Visible)** by adding a visible focus indicator to the z-button component used throughout the Zanichelli platform, including the teacher registration flow.

**Issue**: The Continue button ("Continua"/"Concludi la registrazione") on Step 3 of the teacher registration flow has no visible focus indicator. Keyboard users cannot see which button has focus, creating an accessibility barrier that prevents them from completing registration.

**Solution**: Added a 2px solid outline with 2px offset to focused buttons, while maintaining optimal UX by removing the outline for mouse interactions using `:focus:not(:focus-visible)`.

## Test Plan

- [x] Focused button shows visible 2px outline with offset
- [x] Keyboard navigation (Tab) displays focus indicator
- [x] Mouse clicks do not show unnecessary focus rings
- [x] Focus indicator has sufficient contrast against all button variants

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2474/

## Technical Details

**Files Changed:**
- `src/components/z-button/styles.css` - Enhanced focus styles for z-button component

**WCAG Success Criterion:**
[2.4.7 Focus Visible (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)

## Impact

This fix resolves the focus visibility issue across all instances of the z-button component used throughout the platform, improving accessibility for keyboard users site-wide.
