### PR TITLE
fix(z-input): add aria-invalid and aria-describedby for error states

### DIFF
--- a/src/components/z-input-message/index.tsx
+++ b/src/components/z-input-message/index.tsx
@@ -7,6 +7,10 @@ import {InputStatus} from "../../beans";
   shadow: true,
 })
 export class ZInputMessage {
+  /** the id of the message element */
+  @Prop()
+  htmlid?: string;
+
   /** input helper message */
   @Prop()
   message: string;
@@ -39,8 +43,10 @@ export class ZInputMessage {
   }
 
   render(): HTMLZInputMessageElement {
+    const idAttr = this.htmlid ? {id: this.htmlid} : {};
+
     return (
-      <Host {...this.statusRole}>
+      <Host {...idAttr} {...this.statusRole}>
         {this.statusIcons[this.status] && this.message && <z-icon name={this.statusIcons[this.status]}></z-icon>}
         <span innerHTML={this.message} />
       </Host>

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -255,6 +255,10 @@ export class ZInput {
   /* START text/password/email/number */
 
   private getTextAttributes(): JSXBase.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
+    const messageId = `${this.htmlid}_message`;
+    const ariaInvalid = this.status === InputStatus.ERROR ? {"aria-invalid": "true"} : {};
+    const ariaDescribedby = this.status && boolean(this.message) !== false ? {"aria-describedby": messageId} : {};
+
     return {
       id: this.htmlid,
       name: this.name,
@@ -271,6 +275,8 @@ export class ZInput {
       },
       autocomplete: this.autocomplete,
       onInput: (e: InputEvent) => this.emitInputChange((e.target as HTMLInputElement).value),
+      ...ariaInvalid,
+      ...ariaDescribedby,
     };
   }
 
@@ -454,6 +460,7 @@ export class ZInput {
 
     return (
       <z-input-message
+        htmlid={`${this.htmlid}_message`}
         message={boolean(this.message) === true ? undefined : (this.message as string)}
         status={this.status}
         class={this.size}
@@ -468,6 +475,7 @@ export class ZInput {
 
   private renderTextarea(): HTMLDivElement {
     const attributes = this.getTextAttributes();
+    const ariaLabel = this.ariaLabel ? {"aria-label": this.ariaLabel} : {};
 
     return (
       <Fragment>
@@ -485,7 +493,7 @@ export class ZInput {
               ...(attributes.class as {[className: string]: boolean}),
               "z-scrollbar": true,
             }}
-            aria-label={this.ariaLabel || undefined}
+            {...ariaLabel}
             {...this.getRoleAttribute()}
           ></textarea>
         </div>


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.3.1 (Error Identification)** by adding programmatic association between input fields and their error messages in the `z-input` component.

**Issue**: When password validation fails, the error message "La password deve avere almeno 8 caratteri" appears visually but is not programmatically associated with the password input field. Screen reader users cannot determine which field has the error or what the error message is.

**Solution**: 
- Add `aria-invalid="true"` to input elements when `status="error"`
- Add `aria-describedby` attribute linking the input to its error message
- Assign unique IDs to error message elements so they can be referenced

## Changes

### `src/components/z-input/index.tsx`
- Modified `getTextAttributes()` to add `aria-invalid` and `aria-describedby` attributes when error status is present
- Updated `renderMessage()` to pass unique `htmlid` to the message component
- Updated `renderTextarea()` to properly handle aria-label attribute

### `src/components/z-input-message/index.tsx`
- Added `htmlid` prop to accept a unique identifier
- Modified `render()` to apply the ID to the Host element

## Test Plan

- [x] Navigate to teacher registration form at https://testmy.zanichelli.it/
- [x] Enter password with less than 8 characters
- [x] Verify error message appears
- [x] Inspect with browser DevTools to confirm `aria-invalid="true"` and `aria-describedby` are present
- [x] Test with screen reader (NVDA/JAWS) to confirm error is announced

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2441/

---

**WCAG Reference:**
[3.3.1 Error Identification](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)
