### PR TITLE
fix(a11y): increase z-input clear button target size to meet WCAG 2.5.8

### DIFF
--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -59,12 +59,12 @@
 
 .text-wrapper .icons-wrapper > button.reset-icon,
 .text-wrapper .icons-wrapper > button.toggle-password-icon {
-  min-width: 24px;
-  min-height: 24px;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 24px;
+  min-height: 24px;
+  cursor: pointer;
 }
 
 .text-wrapper .icons-wrapper > .input-icon {

--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -59,7 +59,12 @@
 
 .text-wrapper .icons-wrapper > button.reset-icon,
 .text-wrapper .icons-wrapper > button.toggle-password-icon {
+  min-width: 24px;
+  min-height: 24px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .text-wrapper .icons-wrapper > .input-icon {

--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -60,10 +60,10 @@
 .text-wrapper .icons-wrapper > button.reset-icon,
 .text-wrapper .icons-wrapper > button.toggle-password-icon {
   display: flex;
-  align-items: center;
-  justify-content: center;
   min-width: 24px;
   min-height: 24px;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.5.8 (Target Size Minimum)** by increasing the clear button target size in the z-input component from 18×18px to 24×24px.

**Issues**: Clear buttons (X icons) in text input fields and autocomplete dropdown fields are only 18×18px, failing to meet WCAG 2.5.8's minimum target size requirement of 24×24px. Users with motor impairments struggle to accurately click these small targets to reset their selections.

**Solution**: Added `min-width: 24px` and `min-height: 24px` to the clear button and password toggle button CSS, along with flexbox centering to ensure the icon remains centered within the expanded clickable area.

## Changes

Modified `src/components/z-input/styles-text.css`:
- Added `min-width: 24px` to `.reset-icon` and `.toggle-password-icon` buttons
- Added `min-height: 24px` to ensure minimum target dimensions
- Added `display: flex`, `align-items: center`, `justify-content: center` to maintain icon centering

## Impact

- Improves accessibility for users with motor impairments
- Applies to all text input fields and autocomplete dropdowns using the z-input component across Zanichelli products
- No visual regression - icons remain 18×18px centered within a 24×24px clickable area
- Functionality verified - clear buttons continue to work correctly

## Test Plan

- [x] Verified clear button dimensions increased to 24×24px
- [x] Confirmed icon remains centered within button area
- [x] Tested clear button functionality (successfully clears input value)
- [x] Verified no layout issues or visual regressions
- [x] Tested on registration form autocomplete dropdowns

## Evidence

View before/after screenshots and full audit details:
- Input fields: https://app.workback.ai/dashboard/issue/2491/
- Dropdown fields: https://app.workback.ai/dashboard/issue/2523/

---

**WCAG Reference:**
[2.5.8 Target Size (Minimum) (Level AA)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
