### PR TITLE
fix(z-modal): add visible focus indicator to close button

### DIFF
--- a/src/components/z-modal/styles.css
+++ b/src/components/z-modal/styles.css
@@ -68,10 +68,14 @@
   cursor: pointer;
 }
 
-.modal-container > header button:focus-visible {
+.modal-container > header button:focus {
   border-radius: 50%;
   box-shadow: var(--shadow-focus-primary);
   outline: none !important;
+}
+
+.modal-container > header button:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .modal-container > header button::after {


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.7 (Focus Visible)** by ensuring the close button in the z-modal component displays a visible focus indicator when navigated to via keyboard.

**Issue**: When keyboard users navigate to the modal close button using Tab, the button receives focus but displays no visible indicator, making it impossible to determine which element is focused.

**Solution**: Updated CSS to apply focus styles using `:focus` with a progressive enhancement that removes the indicator for mouse clicks in modern browsers (`:focus:not(:focus-visible)`).

## Test Plan

- [x] Navigate to a page with z-modal component (e.g., login modal on my.zanichelli.it)
- [x] Press Tab to navigate through the modal
- [x] Verify close button shows visible focus indicator (blue shadow)
- [x] Click close button with mouse to verify no focus indicator appears (modern browsers)

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2511/

---

**WCAG Reference:**
[2.4.7 Focus Visible (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)