### PR TITLE
fix(z-input): ensure checkbox label meets WCAG 2.5.8 target size

### DIFF
--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -28,6 +28,7 @@
   display: inline-flex;
   align-items: center;
   margin: 0;
+  min-height: 24px;
   padding: calc(var(--space-unit) * 0.375) 0;
   color: inherit;
   font-family: inherit;
@@ -35,7 +36,6 @@
   font-weight: inherit;
   line-height: 1;
   text-transform: inherit;
-  min-height: 24px;
 }
 
 .radio-wrapper input:not(:disabled) + .radio-label,

--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -28,12 +28,14 @@
   display: inline-flex;
   align-items: center;
   margin: 0;
+  padding: calc(var(--space-unit) * 0.375) 0;
   color: inherit;
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
   line-height: 1;
   text-transform: inherit;
+  min-height: 24px;
 }
 
 .radio-wrapper input:not(:disabled) + .radio-label,

--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -26,10 +26,10 @@
 .radio-wrapper .radio-label,
 .checkbox-wrapper .checkbox-label {
   display: inline-flex;
-  align-items: center;
-  margin: 0;
   min-height: 24px;
+  align-items: center;
   padding: calc(var(--space-unit) * 0.375) 0;
+  margin: 0;
   color: inherit;
   font-family: inherit;
   font-size: inherit;


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.5.8 (Target Size - Level AA)** by adding vertical padding and minimum height to checkbox and radio button labels.

**Issue**: Checkbox labels had insufficient clickable area (224.89×18px), failing to meet the 24px minimum height requirement. This creates targeting difficulties for users with motor impairments.

**Solution**: Added `padding: calc(var(--space-unit) * 0.375) 0` (approximately 3px vertical padding) and `min-height: 24px` to `.checkbox-label` and `.radio-label` classes, ensuring all checkbox and radio button labels meet the WCAG 2.5.8 minimum target size of 24×24 CSS pixels.

## Changes

- Modified `src/components/z-input/styles-checkbox-radio.css`
  - Added vertical padding to labels: `padding: calc(var(--space-unit) * 0.375) 0`
  - Added minimum height constraint: `min-height: 24px`

## Impact

- **Affected components**: All `z-input` checkbox and radio button implementations across Zanichelli applications
- **Visual impact**: Minimal - adds approximately 3px padding above and below label text
- **Accessibility impact**: Significant improvement for users with motor impairments

## Test Plan

- [x] Verified CSS changes compile without errors
- [x] Confirmed minimum target size of 24px height is achieved
- [x] Tested on teacher registration form at `/registrazione/docente/2`
- [x] Verified no visual regression in spacing or alignment

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2509/

## WCAG Reference

[2.5.8 Target Size (Minimum) - Level AA](https://www.w3.org/WAI/WCAG21/Understanding/target-size-minimum.html)

> The size of the target for pointer inputs is at least 24 by 24 CSS pixels.