### PR TITLE
fix(z-input): add aria-pressed to password toggle

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -437,6 +437,7 @@ export class ZInput {
         class="input-icon toggle-password-icon"
         disabled={this.disabled}
         aria-label={this.passwordHidden ? "mostra password" : "nascondi password"}
+        aria-pressed={this.passwordHidden ? "false" : "true"}
         onClick={() => (this.passwordHidden = !this.passwordHidden)}
       >
         <z-icon


### PR DESCRIPTION
## Summary

Fixes **WCAG 4.1.2 (Name, Role, Value)** by adding `aria-pressed` attribute to the password visibility toggle button in the `z-input` component.

**Issue**: The password visibility toggle button has `aria-label` but lacks the required `aria-pressed` attribute to indicate its current state. Screen reader users cannot determine whether the password is currently visible or hidden.

**Solution**: Added `aria-pressed` attribute that dynamically reflects the button's state:
- `aria-pressed="false"` when password is hidden
- `aria-pressed="true"` when password is visible

## Impact

This change affects the `z-input` component used across Zanichelli applications including:
- myZanichelli login (https://my.zanichelli.it/)
- Any other forms using password fields with the `z-input` component

## Test Plan

- [x] Lint checks pass
- [x] Code follows existing patterns in the component
- [x] `aria-pressed` attribute correctly reflects toggle state

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2505/

---

**WCAG Reference:**
[4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)