### PR TITLE
fix(z-input): add visible focus indicator to checkboxes and radio buttons

### DIFF
--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -117,6 +117,19 @@
   box-shadow: var(--shadow-focus-primary);
 }
 
+/* Fallback focus styles using :focus (without :focus-visible) for better browser compatibility */
+.radio-wrapper > input:focus + .radio-label > z-icon {
+  outline: 2px solid var(--color-form-active-primary);
+  outline-offset: 2px;
+  border-radius: 50%;
+}
+
+.checkbox-wrapper > input:focus + .checkbox-label > z-icon {
+  outline: 2px solid var(--color-form-active-primary);
+  outline-offset: 2px;
+  border-radius: var(--border-radius-small);
+}
+
 /* disabled */
 .radio-wrapper > input:disabled + .radio-label,
 .checkbox-wrapper > input:disabled + .checkbox-label {

--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -119,15 +119,15 @@
 
 /* Fallback focus styles using :focus (without :focus-visible) for better browser compatibility */
 .radio-wrapper > input:focus + .radio-label > z-icon {
+  border-radius: 50%;
   outline: 2px solid var(--color-form-active-primary);
   outline-offset: 2px;
-  border-radius: 50%;
 }
 
 .checkbox-wrapper > input:focus + .checkbox-label > z-icon {
+  border-radius: var(--border-radius-small);
   outline: 2px solid var(--color-form-active-primary);
   outline-offset: 2px;
-  border-radius: var(--border-radius-small);
 }
 
 /* disabled */


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.7 (Focus Visible)** by adding visible focus indicators to checkboxes and radio buttons in the z-input component.

**Issue**: Checkboxes and radio buttons had no visible focus indicator when navigating with keyboard. The existing `:focus:focus-visible` styles were not consistently displaying across browsers, making it impossible for keyboard users to identify which checkbox is currently focused.

**Solution**: Added fallback `:focus` styles that apply a 2px solid outline with 2px offset around the checkbox/radio icon when it receives keyboard focus. This ensures a clear, visible focus indicator in all browsers.

## Test Plan

- [x] Focused checkboxes using Tab key navigation
- [x] Verified visible blue outline appears around focused checkbox icon
- [x] Tested with multiple checkboxes to confirm focus indicator moves correctly
- [x] Captured before/after screenshots showing the fix

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2490/

**Before**: Checkboxes showed no visual change when focused
**After**: Focused checkboxes display a clear 2px blue outline around the icon

---

**WCAG Reference:**
[2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)