### PR TITLE
fix(z-modal): prevent focus escape from modal dialog

### DIFF
--- a/src/components/z-modal/index.tsx
+++ b/src/components/z-modal/index.tsx
@@ -157,12 +157,28 @@ export class ZModal {
     const activeElement = this.host.ownerDocument.activeElement;
     const firstFocusableElement = focusableElements[0];
     const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+    // Check if current active element is in the focusable list
+    const isActiveElementInList = focusableElements.some((el) => el === shadowActiveElement || el === activeElement);
+
+    // If focus has escaped the modal's focusable elements, bring it back
+    if (!isActiveElementInList) {
+      e.preventDefault();
+      if (e.shiftKey) {
+        lastFocusableElement.focus();
+      } else {
+        firstFocusableElement.focus();
+      }
+
+      return;
+    }
+
     if (e.shiftKey && (shadowActiveElement == firstFocusableElement || activeElement == firstFocusableElement)) {
       // shift + tab was pressed and current active element is the first focusable element
       e.preventDefault();
       lastFocusableElement.focus();
     } else if (!e.shiftKey && (shadowActiveElement == lastFocusableElement || activeElement == lastFocusableElement)) {
-      // shift + tab was pressed and current active element is the first focusable element
+      // tab was pressed and current active element is the last focusable element
       e.preventDefault();
       firstFocusableElement.focus();
     }


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.3 (Focus Order)** by preventing focus from escaping the modal dialog during keyboard navigation.

**Issue**: When tabbing through modal elements in `<z-modal>`, focus could escape to the parent `<dialog>` container element instead of cycling back to the first focusable element. This created an unpredictable focus order that violated keyboard navigation expectations for modal dialogs.

**Solution**: Added a check in the `handleKeyDown` method to detect when focus moves outside the list of focusable elements within the modal. If focus has escaped (e.g., to the `<dialog>` element or other non-focusable containers), the fix redirects focus back to the appropriate boundary element (first or last) based on the tab direction.

## Test Plan

- [x] Built the component successfully without errors
- [x] Verified focus trap logic handles escaped focus correctly
- [x] Linting and formatting pass
- [x] Focus remains trapped within modal during Tab/Shift+Tab navigation

## Evidence

View full audit details and evidence:
https://app.workback.ai/dashboard/issue/2773/

---

**WCAG Reference:**
[2.4.3 Focus Order (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)