### PR TITLE
fix(z-input): increase password toggle button size to meet WCAG 2.5.8

### DIFF
--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -62,6 +62,11 @@
   cursor: pointer;
 }
 
+.text-wrapper .icons-wrapper > button.toggle-password-icon {
+  --z-icon-width: 24px;
+  --z-icon-height: 24px;
+}
+
 .text-wrapper .icons-wrapper > .input-icon {
   --z-icon-width: 18px;
   --z-icon-height: 18px;


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.5.8 (Target Size - Level AA)** by increasing the password visibility toggle button from 18×18px to 24×24px.

**Issue**: The password visibility toggle button (eye icon) was only 18×18 CSS pixels, falling 6px short in both width and height of the WCAG 2.5.8 minimum target size requirement of 24×24px. This made it difficult for users with motor disabilities to reliably toggle password visibility in login forms.

**Solution**: Increased the button size to 24×24px by adding specific CSS custom properties (`--z-icon-width` and `--z-icon-height`) to the `.toggle-password-icon` selector in `styles-text.css`.

## Test Plan

- [x] Verified button dimensions are now 24×24px (previously 18×18px)
- [x] Tested keyboard navigation with Tab key - button receives focus correctly
- [x] Tested keyboard activation with Enter key - button toggles password visibility
- [x] Verified aria-label is present ("mostra password" / "nascondi password")
- [x] Confirmed visual appearance is consistent with design system
- [x] Ran stylelint - no linting errors
- [x] Built component library successfully

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2849/

---

**WCAG Reference:**
[2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)