### PR TITLE
fix(z-link): add underline to links for WCAG 1.4.1 compliance

### DIFF
--- a/src/components/css-components/z-link/styles.css
+++ b/src/components/css-components/z-link/styles.css
@@ -11,7 +11,7 @@ button.z-link {
   cursor: pointer;
   font-family: var(--font-family-sans);
   line-height: inherit;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 a.z-link.z-link-icon,


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding underlines to all `z-link` elements by default.

**Issue**: Links using the `z-link` component class relied solely on color (blue) to distinguish them from surrounding text, with no underline or other non-color visual indicator. This makes links invisible to users with color vision deficiencies.

**Solution**: Changed the default `text-decoration` property from `none` to `underline` in the base `.z-link` styles. Links now have both color and underline, ensuring they are identifiable by all users regardless of color perception.

## Test Plan

- [x] Verified links display with underline by default
- [x] Confirmed keyboard focus states work correctly
- [x] Tested on Centro Assistenza link in contact form
- [x] Stylelint passes

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/2921/

---

**WCAG Reference:**
[1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)