### PR TITLE
fix(z-modal): prevent host element from receiving focus

### DIFF
--- a/src/components/z-modal/index.tsx
+++ b/src/components/z-modal/index.tsx
@@ -88,6 +88,9 @@ export class ZModal implements ComponentInterface {
   }
 
   componentDidLoad(): void {
+    // Ensure host element is not focusable to prevent keyboard trap (WCAG 2.4.3)
+    this.host.setAttribute("tabindex", "-1");
+
     if (typeof window.HTMLDialogElement !== "function") {
       /* workaround to fix `registerDialog` in test environment:
       stencil converts html elements to MockHTMLElement but this element is missing the `localName` property,


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.3 (Focus Order)** by explicitly setting `tabindex="-1"` on the z-modal host element.

**Issue**: The z-modal custom element container could receive keyboard focus depending on browser behavior, disrupting the expected focus order within the modal. While current browsers may delegate focus to the shadow DOM close button, the host element lacks an explicit `tabindex` attribute, making focus behavior inconsistent across browsers and assistive technologies.

**Solution**: Explicitly set `tabindex="-1"` on the host element in `componentDidLoad()` to ensure it is never included in the tab sequence, providing consistent cross-browser keyboard navigation.

## Test Plan

- [x] Build completes successfully (`yarn build`)
- [x] Verified keyboard navigation cycles correctly through all modal elements
- [x] Focus reaches all interactive elements including the close button ("chiudi modale")
- [x] Rebased on latest `master` (May 2026)

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/exraijukmqkrqdvodomsvo5baw/

---

**WCAG Reference:**
[2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)