### PR TITLE
fix(z-file-upload): add aria-labelledby to file input for WCAG 4.1.2

### DIFF
--- a/src/components/file-upload/z-file-upload/index.tsx
+++ b/src/components/file-upload/z-file-upload/index.tsx
@@ -274,6 +274,7 @@ export class ZFileUpload implements ComponentInterface {
         multiple
         onChange={(e) => this.onFilesChange(e)}
         accept={this.acceptedFormat}
+        aria-labelledby={this.description ? "description" : undefined}
         ref={(val) => (this.input = val)}
       />
     );


### PR DESCRIPTION
## Summary

Fixes **WCAG 4.1.2 (Name, Role, Value)** by adding `aria-labelledby` attribute to the file upload input element in the z-file-upload component.

**Issue**: The file upload input had no accessible name. It lacked an associated label element, `aria-label`, and `aria-labelledby` attributes. Screen reader users could not identify or interact with the file upload control.

**Solution**: Added `aria-labelledby` attribute to the `<input type="file">` element that references the existing description span (id="description") when a description prop is provided. This allows assistive technologies to announce the purpose of the file input using the descriptive text.

## Test Plan

- [x] Added `aria-labelledby={this.description ? "description" : undefined}` to input element
- [x] Built component successfully with `yarn build`
- [x] Verified linting passes with `yarn lint`
- [x] Tested accessibility tree shows input now has accessible name
- [x] Confirmed screen readers can announce the input purpose

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/smoky86rh2mqvfuefu98tgnjdc/

---

**WCAG Reference:**
[4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) - Level A

**User Impact:** Screen reader users can now understand what the file upload input is for and interact with it successfully.
