### PR TITLE
fix(z-link): add underlines to all links for WCAG 1.4.1 compliance

### DIFF
--- a/src/components/css-components/z-link/styles.css
+++ b/src/components/css-components/z-link/styles.css
@@ -11,7 +11,9 @@ button.z-link {
   cursor: pointer;
   font-family: var(--font-family-sans);
   line-height: inherit;
-  text-decoration: none;
+  /* WCAG 1.4.1: Links must have visual indicators beyond color */
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 a.z-link.z-link-icon,
@@ -40,6 +42,7 @@ button.z-link:focus-visible,
 a.z-link:active,
 button.z-link:active {
   text-decoration: underline;
+  text-decoration-thickness: 0.125em;
 }
 
 a.z-link:focus-visible,


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding text-decoration underlines to all text links in their default state.

**Issue**: Hyperlinks throughout Zanichelli applications (login modal, footer, etc.) are distinguished from regular text primarily by color. Users with color vision deficiencies cannot reliably identify these as clickable links.

**Solution**: Modified the z-link CSS component to always display underlines on links, with thicker underlines on hover/focus states for better visual feedback.

## Changes

- Added  to default link state
- Added  for better readability  
- Added  for hover/focus/active states

## Test Plan

- [x] Links now have visible underlines in default state
- [x] Underlines become thicker on hover/focus for additional feedback
- [x] Disabled links correctly have no underline

## Related Issues

This fix addresses Zanichelli accessibility issue #3663.

---

**WCAG Reference:**
[1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)