### PR TITLE
fix(z-button): add opacity to disabled state for WCAG 1.4.1

### DIFF
--- a/src/components/z-button/styles.css
+++ b/src/components/z-button/styles.css
@@ -88,6 +88,7 @@
   border-color: var(--color-disabled01);
   background-color: var(--color-disabled01);
   color: var(--color-disabled03);
+  opacity: 0.6;
 }
 
 :host([variant="secondary"]) .z-button--container {
@@ -115,6 +116,7 @@
   border-color: var(--color-disabled01);
   background-color: var(--color-button-secondary);
   color: var(--color-disabled03);
+  opacity: 0.6;
 }
 
 :host([variant="tertiary"]) .z-button--container {
@@ -148,4 +150,5 @@
   border-color: var(--color-disabled01);
   background-color: var(--color-disabled01);
   color: var(--color-disabled03);
+  opacity: 0.6;
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding opacity to disabled button states across all variants.

**Issue**: Button state changes (enabled/disabled) were indicated solely through color changes (red border → grey border), creating a barrier for users with color vision deficiencies.

**Solution**: Added `opacity: 0.6` to all disabled button variants (primary, secondary, tertiary) in the z-button component. This provides a visual indicator independent of color that clearly distinguishes disabled buttons.

## Impact

This fix applies to all z-button components across Zanichelli applications, including:
- Registration forms
- Checkout flows  
- General UI interactions

Users with color vision deficiencies, low vision, or viewing content in monochrome will now be able to identify disabled buttons without relying on color perception.

## Test Plan

- [x] Added opacity property to primary variant disabled state
- [x] Added opacity property to secondary variant disabled state
- [x] Added opacity property to tertiary variant disabled state
- [x] Verified CSS syntax
- [x] Tested that disabled buttons are now distinguishable through reduced opacity

## Evidence

View before/after comparison and full audit details:
https://app.workback.ai/dashboard/issue/3665/

---

**WCAG Reference:**
[1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)
