### PR TITLE
fix(z-input): add visual indicator for required fields

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -376,6 +376,7 @@ export class ZInput {
         htmlFor={this.htmlid}
       >
         {this.label}
+        {this.required && <span class="required-indicator" aria-hidden="true"> *</span>}
       </label>
     );
   }

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -376,7 +376,15 @@ export class ZInput {
         htmlFor={this.htmlid}
       >
         {this.label}
-        {this.required && <span class="required-indicator" aria-hidden="true"> *</span>}
+        {this.required && (
+          <span
+            class="required-indicator"
+            aria-hidden="true"
+          >
+            {" "}
+            *
+          </span>
+        )}
       </label>
     );
   }

--- a/src/components/z-input/styles-general.css
+++ b/src/components/z-input/styles-general.css
@@ -162,3 +162,8 @@ textarea::placeholder {
 :host([disabled]:not([disabled="false"])) label.z-label {
   color: var(--color-disabled03);
 }
+
+/* REQUIRED INDICATOR */
+label.z-label .required-indicator {
+  color: var(--color-form-hover-error);
+}


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.3.2 (Labels or Instructions)** by adding a visual asterisk (*) indicator to required form fields in the z-input component.

**Issue**: Required form fields (such as "Nome" and "Cognome" on the student registration form) lack visual indicators to show users which fields must be completed. While the Continue button remains disabled until fields are filled, there is no visual cue (such as an asterisk) to inform users that these fields are required.

**Solution**: Modified the `renderLabel()` method in the z-input component to append a red asterisk (*) with `aria-hidden="true"` when the `required` prop is set to true. The asterisk provides a universally recognized visual indicator while the `required` attribute on the input element provides programmatic indication for assistive technologies.

## Implementation Details

- Added conditional rendering of asterisk in `renderLabel()` method
- Styled asterisk with error color (`--color-form-hover-error`) for visual prominence
- Used `aria-hidden="true"` on asterisk since the `required` attribute already provides programmatic indication

## Application Usage Requirements

**Important**: Applications using the z-input component must add the `required` attribute to achieve full WCAG 3.3.2 compliance:

```html
<!-- Before -->
<z-input type="text" label="nome" placeholder="Nome" />

<!-- After -->
<z-input type="text" label="nome" placeholder="Nome" required />
```

The following applications should be updated to add `required` attributes:
- Student registration form (`/registrazione/studente/1`) - Nome and Cognome fields

## Test Plan

- [x] Built component successfully with `yarn build.wc`
- [x] Verified asterisk appears in label when `required` prop is true
- [x] Verified asterisk is styled with error color for visibility
- [x] Confirmed `aria-hidden="true"` prevents duplicate announcements

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/5031/

---

**WCAG Reference:**
[3.3.2 Labels or Instructions (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)