### PR TITLE
fix(z-input): add aria-required to required checkboxes

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -545,6 +545,7 @@ export class ZInput implements ComponentInterface {
 
   /* START checkbox */
   private renderCheckbox(): HTMLDivElement {
+    const ariaRequired = this.required ? {"aria-required": "true"} : {};
     return (
       <div class="checkbox-wrapper">
         <input
@@ -557,6 +558,7 @@ export class ZInput implements ComponentInterface {
           required={this.required}
           onChange={this.handleCheck.bind(this)}
           value={this.value}
+          {...ariaRequired}
           {...this.getAriaAttributes()}
           {...this.getFocusBlurAttributes()}
         />

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -546,6 +546,7 @@ export class ZInput implements ComponentInterface {
   /* START checkbox */
   private renderCheckbox(): HTMLDivElement {
     const ariaRequired = this.required ? {"aria-required": "true"} : {};
+
     return (
       <div class="checkbox-wrapper">
         <input

--- a/src/components/z-input/test-checkbox.spec.ts
+++ b/src/components/z-input/test-checkbox.spec.ts
@@ -104,4 +104,22 @@ describe("Suite test ZInput - checkbox", () => {
         </z-input>
       `);
   });
+
+  it("Test render ZInput required with aria-required", async () => {
+    const page = await newSpecPage({
+      components: [ZInput],
+      html: `<z-input htmlid="checkid" type="checkbox" required label="Required checkbox"></z-input>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <z-input htmlid="checkid" type="checkbox" required label="Required checkbox" size="big">
+        <div class="checkbox-wrapper">
+          <input id="checkid" type="checkbox" required aria-required="true" />
+          <label htmlFor="checkid" class="checkbox-label after">
+            <z-icon name="checkbox" class="big"></z-icon>
+            <span>Required checkbox</span>
+          </label>
+        </div>
+      </z-input>
+    `);
+  });
 });

--- a/src/components/z-input/test-checkbox.spec.ts
+++ b/src/components/z-input/test-checkbox.spec.ts
@@ -114,7 +114,7 @@ describe("Suite test ZInput - checkbox", () => {
       <z-input htmlid="checkid" type="checkbox" required label="Required checkbox" size="big">
         <div class="checkbox-wrapper">
           <input id="checkid" type="checkbox" required aria-required="true" />
-          <label htmlFor="checkid" class="checkbox-label after">
+          <label for="checkid" class="checkbox-label after">
             <z-icon name="checkbox" class="big"></z-icon>
             <span>Required checkbox</span>
           </label>


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.3.1 (Info and Relationships)** by ensuring checkbox inputs programmatically indicate their required status through the `aria-required` attribute.

**Issue**: Required checkboxes in the registration form lack programmatic indicators of their required status. Screen reader users cannot determine which checkboxes are mandatory, forcing them to use trial-and-error to discover form requirements.

**Solution**: Modified the `z-input` component to automatically add `aria-required="true"` when the `required` prop is set on checkbox inputs. This ensures both the HTML5 `required` attribute and ARIA `aria-required` attribute are present for maximum accessibility compatibility.

## Changes

- **src/components/z-input/index.tsx**: Added `aria-required="true"` to checkbox inputs when `required` prop is true
- **src/components/z-input/test-checkbox.spec.ts**: Added unit test verifying `aria-required` is applied to required checkboxes

## Test Plan

- [x] Added unit test for `required` checkbox with `aria-required` attribute
- [x] Verified existing checkbox tests still pass
- [x] Manually tested with screen reader (VoiceOver/NVDA) to confirm required status is announced
- [x] Verified visual appearance is unchanged

## Impact

This fix applies to all checkboxes rendered with `<z-input type="checkbox" required>` across all applications using the design system, including:
- Registration forms (student, teacher, professional)
- Consent forms
- Any other forms with required checkbox fields

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/5054/

---

**WCAG Reference:**
[1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)
