### PR TITLE
fix(z-input): increase password toggle button size to meet WCAG 2.5.8

### DIFF
--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -41,12 +41,16 @@
 
 .text-wrapper .icons-wrapper > button.input-icon {
   display: flex;
+  min-width: 24px;
+  min-height: 24px;
   padding: 0;
   border: 0;
   background: none;
   color: inherit;
   font: inherit;
   pointer-events: initial;
+  align-items: center;
+  justify-content: center;
 }
 
 .text-wrapper .icons-wrapper > .input-icon + .input-icon {

--- a/src/components/z-input/styles-text.css
+++ b/src/components/z-input/styles-text.css
@@ -43,14 +43,14 @@
   display: flex;
   min-width: 24px;
   min-height: 24px;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   border: 0;
   background: none;
   color: inherit;
   font: inherit;
   pointer-events: initial;
-  align-items: center;
-  justify-content: center;
 }
 
 .text-wrapper .icons-wrapper > .input-icon + .input-icon {


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.5.8 (Target Size - Minimum)** by increasing the password visibility toggle button size from 18×18px to 24×24px.

**Issue**: Password toggle buttons (eye icons) on password input fields were only 18×18 CSS pixels, failing to meet the minimum 24×24 CSS pixel target size requirement.

**Solution**: Added `min-width: 24px` and `min-height: 24px` to the password toggle button styling in the `z-input` component, along with flexbox centering to maintain icon positioning.

## Test Plan

- [x] Applied fix and verified button size increased to 24×24px
- [x] Tested password toggle functionality - works correctly
- [x] Verified icon remains centered within button
- [x] Tested on registration form password fields

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/5093/

---

**WCAG Reference:**
[2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)