### PR TITLE
fix(z-input): implement keyboard navigation for radio buttons

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -582,6 +582,69 @@ export class ZInput implements ComponentInterface {
   /* END checkbox */
 
   /* START radio */
+  private handleRadioKeyDown(ev: KeyboardEvent): void {
+    if (!this.name || this.disabled || this.readonly) {
+      return;
+    }
+
+    const key = ev.key;
+    if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(key)) {
+      return;
+    }
+
+    ev.preventDefault();
+
+    const radioGroup = Array.from(
+      document.querySelectorAll<HTMLZInputElement>(`z-input[type="radio"][name="${this.name}"]`)
+    ).filter((radio) => !radio.disabled && !radio.readonly);
+
+    if (radioGroup.length === 0) {
+      return;
+    }
+
+    const currentIndex = radioGroup.findIndex((radio) => radio.htmlid === this.htmlid);
+    if (currentIndex === -1) {
+      return;
+    }
+
+    let nextIndex: number;
+    if (key === "ArrowDown" || key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % radioGroup.length;
+    } else {
+      nextIndex = (currentIndex - 1 + radioGroup.length) % radioGroup.length;
+    }
+
+    const nextRadio = radioGroup[nextIndex];
+    const nextInput = nextRadio.querySelector("input[type='radio']") as HTMLInputElement;
+    if (nextInput) {
+      nextInput.focus();
+      nextInput.checked = true;
+      const changeEvent = document.createEvent("Event");
+      changeEvent.initEvent("change", true, true);
+      nextInput.dispatchEvent(changeEvent);
+    }
+  }
+
+  private getRadioTabIndex(): number {
+    if (!this.name) {
+      return 0;
+    }
+
+    const radioGroup = Array.from(
+      document.querySelectorAll<HTMLZInputElement>(`z-input[type="radio"][name="${this.name}"]`)
+    ).filter((radio) => !radio.disabled && !radio.readonly);
+
+    const hasCheckedRadio = radioGroup.some((radio) => radio.checked);
+
+    if (hasCheckedRadio) {
+      return this.checked ? 0 : -1;
+    }
+
+    const isFirstRadio = radioGroup[0]?.htmlid === this.htmlid;
+
+    return isFirstRadio ? 0 : -1;
+  }
+
   private renderRadio(): HTMLDivElement {
     return (
       <div class="radio-wrapper">
@@ -593,7 +656,9 @@ export class ZInput implements ComponentInterface {
           disabled={this.disabled}
           readonly={this.readonly}
           onChange={this.handleCheck.bind(this)}
+          onKeyDown={this.handleRadioKeyDown.bind(this)}
           value={this.value}
+          tabindex={this.getRadioTabIndex()}
           {...this.getAriaAttributes()}
           {...this.getFocusBlurAttributes()}
         />


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.1.1 (Keyboard)** by implementing arrow key navigation and roving tabindex pattern for radio button groups in the `z-input` component.

**Issue**: Radio button groups failed to implement standard keyboard interaction patterns. Only the first radio button received Tab focus, and arrow keys had no effect, leaving other options unreachable via keyboard.

**Solution**: 
- Added `handleRadioKeyDown` method to handle ArrowUp, ArrowDown, ArrowLeft, and ArrowRight keys
- Implemented `getRadioTabIndex` method to apply roving tabindex pattern (only one radio in group has `tabindex="0"`)
- Arrow keys now cycle through radio options and automatically check the focused option
- Follows ARIA authoring practices for radio groups

## Test Plan

- [x] Build completes successfully
- [ ] Tab key focuses only one radio button in the group (first unchecked, or the checked one)
- [ ] Arrow Down/Right moves focus to next radio option and checks it
- [ ] Arrow Up/Left moves focus to previous radio option and checks it
- [ ] Arrow keys wrap around (last → first, first → last)
- [ ] Disabled radio buttons are skipped
- [ ] Change events fire correctly when arrow keys select options

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/5095/

---

**WCAG Reference:**
[2.1.1 Keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)