### PR TITLE
fix(z-input): add visual indicator for radio button selection state

### DIFF
--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -105,7 +105,7 @@
 
 /* checked state - add visual indicator beyond color */
 .radio-wrapper > input:checked + .radio-label > z-icon {
-  outline: 2px solid currentColor;
+  outline: 2px solid currentcolor;
   outline-offset: 2px;
 }
 

--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -103,6 +103,12 @@
   margin-right: calc(var(--space-unit) * 0.5);
 }
 
+/* checked state - add visual indicator beyond color */
+.radio-wrapper > input:checked + .radio-label > z-icon {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
 /* focus */
 .radio-wrapper > input:focus:focus-visible + .radio-label > z-icon {
   border-radius: 50%;
@@ -127,4 +133,9 @@
 .checkbox-wrapper > input:disabled + .checkbox-label > z-icon {
   cursor: default;
   fill: var(--color-disabled01);
+}
+
+/* disabled and checked - outline should still be visible */
+.radio-wrapper > input:disabled:checked + .radio-label > z-icon {
+  outline-color: var(--color-disabled03);
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.3.3 (Sensory Characteristics)** by adding a visual outline indicator to selected radio buttons that does not rely on color alone.

**Issue**: Radio buttons use custom styling where the selected state is indicated primarily through color change (blue fill vs. outline only). Users with color blindness may not be able to distinguish between selected and unselected radio buttons.

**Solution**: Added a 2px outline with 2px offset to selected radio buttons using `currentColor`, providing a visual indicator that works independently of color perception. The outline adapts to disabled states appropriately.

## Test Plan

- [x] Selected radio buttons now display a visible outline around the icon
- [x] Outline is visible in both normal and disabled states
- [x] Outline uses currentColor to maintain contrast with the background
- [x] Focus indicator remains distinct from selection indicator

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/5105/

---

**WCAG Reference:**
[1.3.3 Sensory Characteristics](https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html)