### PR TITLE
fix(z-modal): ensure close button appears first in focus order

### DIFF
--- a/src/components/z-modal/index.tsx
+++ b/src/components/z-modal/index.tsx
@@ -154,17 +154,30 @@ export class ZModal implements ComponentInterface {
     const focusableElements = this.focusableElements;
     const shadowActiveElement = this.host.shadowRoot.activeElement;
     const activeElement = this.host.ownerDocument.activeElement;
-    const firstFocusableElement = focusableElements[0];
-    const lastFocusableElement = focusableElements[focusableElements.length - 1];
-    if (e.shiftKey && (shadowActiveElement == firstFocusableElement || activeElement == firstFocusableElement)) {
-      // shift + tab was pressed and current active element is the first focusable element
+
+    // Find the currently focused element in our ordered list
+    const currentElement = shadowActiveElement || activeElement;
+    const currentIndex = focusableElements.findIndex(el => el === currentElement);
+
+    // If no element is focused or element not found, focus the first element
+    if (currentIndex === -1) {
       e.preventDefault();
-      lastFocusableElement.focus();
-    } else if (!e.shiftKey && (shadowActiveElement == lastFocusableElement || activeElement == lastFocusableElement)) {
-      // shift + tab was pressed and current active element is the first focusable element
-      e.preventDefault();
-      firstFocusableElement.focus();
+      focusableElements[0]?.focus();
+      return;
     }
+
+    // Calculate next index based on direction
+    let nextIndex: number;
+    if (e.shiftKey) {
+      // Shift+Tab: move backward, wrap to last if at first
+      nextIndex = currentIndex === 0 ? focusableElements.length - 1 : currentIndex - 1;
+    } else {
+      // Tab: move forward, wrap to first if at last
+      nextIndex = currentIndex === focusableElements.length - 1 ? 0 : currentIndex + 1;
+    }
+
+    e.preventDefault();
+    focusableElements[nextIndex]?.focus();
   }
 
   private closeButtonSlot(): HTMLElement | void {

--- a/src/components/z-modal/index.tsx
+++ b/src/components/z-modal/index.tsx
@@ -157,12 +157,13 @@ export class ZModal implements ComponentInterface {
 
     // Find the currently focused element in our ordered list
     const currentElement = shadowActiveElement || activeElement;
-    const currentIndex = focusableElements.findIndex(el => el === currentElement);
+    const currentIndex = focusableElements.findIndex((el) => el === currentElement);
 
     // If no element is focused or element not found, focus the first element
     if (currentIndex === -1) {
       e.preventDefault();
       focusableElements[0]?.focus();
+
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.3 (Focus Order)** by ensuring the modal close button receives focus before content buttons, matching the visual order.

**Issue**: The modal close button in shadow DOM appeared last in the keyboard tab sequence (CONTINUA -> INDIETRO -> Close button) despite being visually positioned first in the header. This violated WCAG 2.4.3 because the focus order didn't preserve the meaning conveyed by the visual layout.

**Solution**: Modified the Tab key handler to explicitly manage focus order based on the `focusableElements` array, which correctly places shadow DOM elements (close button) before light DOM elements (content buttons). The focus sequence now matches the visual order: Close button -> CONTINUA -> INDIETRO.

## Test Plan

- [x] Opened modal on registration flow (testmy.zanichelli.it/registrazione/docente)
- [x] Verified close button now receives focus first when pressing Tab
- [x] Verified Tab cycles through: Close button -> CONTINUA -> INDIETRO -> Close button
- [x] Verified Shift+Tab moves backward through the same sequence
- [x] Verified focus wraps correctly at boundaries

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/m6y9nirothb7cs34u544wjzcsk/

---

**WCAG Reference:**
[2.4.3 Focus Order (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)