### PR TITLE
fix(z-input): add WCAG 3.3.1 form error identification

### DIFF
--- a/src/components/z-input-message/index.tsx
+++ b/src/components/z-input-message/index.tsx
@@ -7,6 +7,10 @@ import {InputStatus} from "../../beans";
   shadow: true,
 })
 export class ZInputMessage {
+  /** the id of the message element */
+  @Prop()
+  htmlid?: string;
+
   /** input helper message */
   @Prop()
   message: string;
@@ -39,8 +43,14 @@ export class ZInputMessage {
   }
 
   render(): HTMLZInputMessageElement {
+    const hostAttributes = {
+      ...this.statusRole,
+      ...(this.htmlid ? {id: this.htmlid} : {}),
+      ...(this.status === InputStatus.ERROR && this.message ? {"aria-live": "polite"} : {}),
+    };
+
     return (
-      <Host {...this.statusRole}>
+      <Host {...hostAttributes}>
         {this.statusIcons[this.status] && this.message && <z-icon name={this.statusIcons[this.status]}></z-icon>}
         <span innerHTML={this.message} />
       </Host>

--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -314,12 +314,19 @@ export class ZInput {
     const activedescendant = this.htmlAriaActivedescendant
       ? {"aria-activedescendant": this.htmlAriaActivedescendant}
       : {};
+    const invalid = this.status === InputStatus.ERROR ? {"aria-invalid": "true"} : {};
+    const describedby =
+      this.status === InputStatus.ERROR && boolean(this.message) !== false
+        ? {"aria-describedby": `${this.htmlid}_message`}
+        : {};
 
     return {
       ...expanded,
       ...controls,
       ...autocomplete,
       ...activedescendant,
+      ...invalid,
+      ...describedby,
     };
   }
 
@@ -454,6 +461,7 @@ export class ZInput {
 
     return (
       <z-input-message
+        htmlid={`${this.htmlid}_message`}
         message={boolean(this.message) === true ? undefined : (this.message as string)}
         status={this.status}
         class={this.size}


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.3.1 (Error Identification)** by adding proper ARIA attributes and live region announcements to form validation errors in the z-input component.

**Issue**: When forms are submitted with invalid data, error messages appear visually but are not announced to screen readers. Fields with errors lack `aria-invalid` attributes, and there's no `aria-live` region to notify assistive technology users of validation failures. This blocks screen reader users from successfully completing forms.

**Solution**: Enhanced the `z-input` and `z-input-message` components to:
- Add `aria-invalid="true"` to input elements when status is "error"
- Add `aria-describedby` to link inputs to their error messages
- Add `aria-live="polite"` to error messages for automatic screen reader announcement
- Add ID support to `z-input-message` for proper ARIA associations

## Test Plan

- [x] Added `aria-invalid` attribute when input has error status
- [x] Added `aria-describedby` to link input to error message
- [x] Added `aria-live="polite"` to error messages for screen reader announcement
- [x] Error messages now have IDs for proper ARIA associations

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/dashboard/issue/5206/

---

**WCAG Reference:**
[3.3.1 Error Identification (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)