### PR TITLE
fix(z-link): add underline to z-link-blue for WCAG 1.4.1 compliance

### DIFF
--- a/src/components/css-components/z-link/styles.css
+++ b/src/components/css-components/z-link/styles.css
@@ -89,6 +89,7 @@ a.z-link.z-link-blue.z-link-active,
 button.z-link.z-link-blue.z-link-active {
   color: var(--color-text-link-blue);
   fill: var(--color-text-link-blue);
+  text-decoration: underline;
 }
 
 a.z-link.z-link-red,


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding underline decoration to `z-link-blue` buttons and links.

**Issue**: Blue links and buttons (using the `.z-link-blue` class) relied only on color to distinguish them from surrounding text, with no underline or other non-color visual indicator. Users with color vision deficiencies could not identify these interactive elements.

**Solution**: Added `text-decoration: underline` to the `.z-link-blue` CSS rule, ensuring links are visually distinguishable through both color and underline.

## Affected Components

This fix affects all `z-link-blue` instances across Zanichelli applications, including:
- Help buttons in contact forms ("Non trovi il codice ISBN?", "Non trovi il codice di attivazione?")
- Blue link buttons throughout the design system

## Test Plan

- [x] Identified WCAG 1.4.1 violation in production contact form
- [x] Located source of issue in design-system CSS
- [x] Applied fix: added underline to `.z-link-blue` class
- [x] Verified fix with browser testing - links now have underline decoration
- [x] Confirmed visual distinction works without color perception

## Evidence

Screenshots showing before/after comparison available at: https://app.workback.ai/dashboard/issue/2924/

## WCAG Reference

[1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)