### PR TITLE
fix - z-notification - content width

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1618,8 +1618,8 @@ export namespace Components {
     /**
      * Notification bar component.
      * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
-     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
+     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%. Note: the content is automatically centered, so if you want to limit the width only for the slotted content, you can wrap it in a container with the desired width and leave the `z-notification` width to 100%.
+     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful to align the content when the `--z-notification--content-max-width` is set. Default: calc(var(--space-unit) * 2).
      */
     interface ZNotification {
         /**
@@ -3448,8 +3448,8 @@ declare global {
     /**
      * Notification bar component.
      * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
-     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
+     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%. Note: the content is automatically centered, so if you want to limit the width only for the slotted content, you can wrap it in a container with the desired width and leave the `z-notification` width to 100%.
+     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful to align the content when the `--z-notification--content-max-width` is set. Default: calc(var(--space-unit) * 2).
      */
     interface HTMLZNotificationElement extends Components.ZNotification, HTMLStencilElement {
         addEventListener<K extends keyof HTMLZNotificationElementEventMap>(type: K, listener: (this: HTMLZNotificationElement, ev: ZNotificationCustomEvent<HTMLZNotificationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5751,8 +5751,8 @@ declare namespace LocalJSX {
     /**
      * Notification bar component.
      * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
-     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
+     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%. Note: the content is automatically centered, so if you want to limit the width only for the slotted content, you can wrap it in a container with the desired width and leave the `z-notification` width to 100%.
+     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful to align the content when the `--z-notification--content-max-width` is set. Default: calc(var(--space-unit) * 2).
      */
     interface ZNotification {
         /**
@@ -6946,8 +6946,8 @@ declare module "@stencil/core" {
             /**
              * Notification bar component.
              * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-             * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
-             * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
+             * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%. Note: the content is automatically centered, so if you want to limit the width only for the slotted content, you can wrap it in a container with the desired width and leave the `z-notification` width to 100%.
+             * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful to align the content when the `--z-notification--content-max-width` is set. Default: calc(var(--space-unit) * 2).
              */
             "z-notification": LocalJSX.ZNotification & JSXBase.HTMLAttributes<HTMLZNotificationElement>;
             /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1618,7 +1618,8 @@ export namespace Components {
     /**
      * Notification bar component.
      * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-     * @cssprop --z-notification--content-max-width - The max width of the notification content.
+     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
+     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
      */
     interface ZNotification {
         /**
@@ -3447,7 +3448,8 @@ declare global {
     /**
      * Notification bar component.
      * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-     * @cssprop --z-notification--content-max-width - The max width of the notification content.
+     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
+     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
      */
     interface HTMLZNotificationElement extends Components.ZNotification, HTMLStencilElement {
         addEventListener<K extends keyof HTMLZNotificationElementEventMap>(type: K, listener: (this: HTMLZNotificationElement, ev: ZNotificationCustomEvent<HTMLZNotificationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -5749,7 +5751,8 @@ declare namespace LocalJSX {
     /**
      * Notification bar component.
      * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-     * @cssprop --z-notification--content-max-width - The max width of the notification content.
+     * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
+     * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
      */
     interface ZNotification {
         /**
@@ -6943,7 +6946,8 @@ declare module "@stencil/core" {
             /**
              * Notification bar component.
              * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
-             * @cssprop --z-notification--content-max-width - The max width of the notification content.
+             * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
+             * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
              */
             "z-notification": LocalJSX.ZNotification & JSXBase.HTMLAttributes<HTMLZNotificationElement>;
             /**

--- a/src/components/z-breadcrumb/index.spec.ts
+++ b/src/components/z-breadcrumb/index.spec.ts
@@ -20,7 +20,7 @@ describe("Suite test ZBreadcrumb", () => {
               <a href="http://testing.stenciljs.com/link1">
                 <z-icon name="home"></z-icon>
               </a>
-              <z-icon class="separator" name="chevron-right"></z-icon>
+              <z-icon aria-hidden="true" class="separator" name="chevron-right"></z-icon>
             </li>
             <li>
               <a href="http://testing.stenciljs.com/link2">

--- a/src/components/z-notification/index.stories.css
+++ b/src/components/z-notification/index.stories.css
@@ -3,8 +3,8 @@
   align-items: center;
 }
 
-.banner-notification-demo z-notification {
-  --z-notification--top-offset: calc(var(--space-unit) * 6);
+.z-notification-demo-page {
+  margin: 0 auto;
 }
 
 .inline-notification-demo {
@@ -14,16 +14,21 @@
   border: 1px solid var(--gray300);
 }
 
-.inline-notification-demo z-notification {
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
 .inline-notification-demo .content {
-  padding: var(--grid-margin);
+  padding: calc(var(--space-unit) * 2);
 }
 
-.inline-notification-demo .content h2 {
-  margin-top: 0;
+.z-notification-border-position-demo {
+  position: relative;
+  width: 100%;
+  height: 600px;
+  border: 1px solid black;
+  background-color: var(--color-background);
+}
+
+.z-notification-border-position-demo z-notification {
+  position: absolute;
+  top: auto;
+  bottom: 0;
+  max-width: 100%;
 }

--- a/src/components/z-notification/index.stories.ts
+++ b/src/components/z-notification/index.stories.ts
@@ -6,9 +6,11 @@ import {CSSVarsArguments} from "../../utils/storybook-utils";
 import "./index";
 import "./index.stories.css";
 
-type ZNotificationStoriesArgs = ZNotification & {
-  notificationText: string;
-} & CSSVarsArguments<"--z-notification--content-max-width">;
+const DEMO_LONG_TEXT =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus magna imperdiet malesuada interdum. Curabitur volutpat mi purus, in maximus nisl volutpat quis. Suspendisse sed vestibulum magna. Quisque molestie, justo non pretium egestas, lorem elit malesuada turpis, et malesuada sapien nunc a urna. Curabitur sagittis augue turpis, eu consectetur purus consectetur vitae. Sed bibendum nisl diam, eget egestas enim elementum eget. Donec quis magna lobortis, tristique nunc in, fringilla lacus. Duis ac porta turpis. Aenean aliquam tortor sed felis interdum aliquet dignissim vel ligula. Donec auctor risus vitae nisi finibus, sed suscipit tellus fringilla. Sed malesuada gravida tincidunt. Duis tincidunt orci at magna egestas fermentum. Nulla laoreet ante felis, non molestie mi venenatis sit amet. Nullam sollicitudin tempus lacus ac maximus. Suspendisse erat magna, pellentesque ut lectus sit amet, aliquet scelerisque augue. In at felis facilisis, sodales tortor euismod, tincidunt tellus. Quisque vulputate dolor vitae nibh pharetra, a auctor turpis mattis. Nulla facilisi. Vivamus a facilisis ex. Vestibulum ultricies scelerisque sapien eu pharetra. Etiam ut porttitor lorem, id ullamcorper risus. Donec sed sollicitudin metus. Sed sapien lectus, bibendum quis lorem efficitur, pellentesque maximus lectus. Quisque quis lectus quis dolor ultrices facilisis placerat finibus nulla. Donec laoreet urna id varius facilisis. Nulla facilisi. Pellentesque dignissim aliquam interdum. Fusce ante mauris, blandit nec imperdiet mattis, dictum non sapien. Donec aliquet feugiat quam quis cursus. Curabitur et rutrum nunc. Phasellus ut lorem posuere, eleifend felis sed, lobortis arcu. Nam efficitur purus non dolor tincidunt, nec euismod lectus hendrerit. Sed eget rutrum odio, ac maximus lacus. Etiam rutrum purus diam, eu pellentesque elit vulputate eget. Donec nulla augue, euismod non mollis congue, laoreet vel orci. Cras eget suscipit felis. Phasellus eget erat eu nisl suscipit pulvinar. Nunc ullamcorper orci sit amet dui placerat, at vulputate libero finibus. Quisque dignissim risus dolor, a porta erat cursus vel. Sed cursus pellentesque magna fringilla varius. Proin sit amet posuere massa. Proin nisl massa, hendrerit non congue mattis, tincidunt in turpis. Etiam pharetra posuere est, non mollis sapien malesuada non. Quisque metus lectus, hendrerit vel accumsan et, ornare a eros. Donec tempor, elit ut pulvinar auctor, sapien velit consectetur justo, interdum lobortis risus ligula vitae nunc. Praesent quam felis, posuere et consequat consectetur, tempus non sem. Phasellus in ligula enim. Donec gravida, felis vitae elementum mattis, velit ipsum aliquam ipsum, a cursus nisi nisl nec sapien. Ut et orci nulla. Donec fringilla magna non risus imperdiet euismod. Sed viverra eget turpis et faucibus. Sed ante orci, interdum in ligula in, tincidunt feugiat arcu. In viverra efficitur urna laoreet tristique. Phasellus hendrerit, urna et condimentum aliquet, ex urna condimentum dui, vitae vestibulum mauris risus sit amet nunc. Quisque egestas est vel lorem commodo, eget vestibulum enim cursus. Cras lectus velit, fermentum eget mauris id, interdum cursus massa. Maecenas quis dui vehicula mauris condimentum finibus. Sed et magna velit. Duis eleifend dolor at sagittis ornare. Aenean commodo massa enim, ac varius augue varius quis.";
+
+type ZNotificationStoriesArgs = ZNotification &
+  CSSVarsArguments<"--z-notification--top-offset" | "--z-notification--content-max-width">;
 
 const StoryMeta = {
   title: "ZNotification",
@@ -30,6 +32,7 @@ const StoryMeta = {
   args: {
     "--z-notification--content-max-width": "100%",
     "contenticonname": "checkmark-circle-filled",
+    "borderposition": "bottom",
     "actiontext": "Annulla",
     "showclose": false,
     "sticky": false,
@@ -56,28 +59,6 @@ export const Default = {
   `,
 } satisfies Story;
 
-/**
- * The position of the border can be changed to correctly display the notification on the bottom of the screen.
- */
-export const BorderPosition = {
-  args: {
-    borderposition: "top",
-  },
-  render: (args) => html`
-    <z-notification
-      .contenticonname=${args.contenticonname}
-      .actiontext=${args.actiontext}
-      .type=${args.type}
-      .showclose=${args.showclose}
-      .sticky=${args.sticky}
-      .borderposition=${args.borderposition}
-      style="--z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
-    >
-      <div class="notification-container"><strong>NOVITÀ</strong>: Testo che descrive le novità.</div>
-    </z-notification>
-  `,
-} satisfies Story;
-
 export const LongText = {
   render: (args) => html`
     <z-notification
@@ -88,20 +69,19 @@ export const LongText = {
       .sticky=${args.sticky}
       style="--z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
     >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus magna imperdiet malesuada interdum.
-      Curabitur volutpat mi purus, in maximus nisl volutpat quis. Suspendisse sed vestibulum magna. Quisque molestie,
-      justo non pretium egestas, lorem elit malesuada turpis, et malesuada sapien nunc a urna. Curabitur sagittis augue
-      turpis, eu consectetur purus consectetur vitae.
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus magna imperdiet malesuada interdum.
+        Curabitur volutpat mi purus, in maximus nisl volutpat quis. Suspendisse sed vestibulum magna. Quisque molestie,
+        justo non pretium egestas, lorem elit malesuada turpis, et malesuada sapien nunc a urna. Curabitur sagittis
+        augue turpis, eu consectetur purus consectetur vitae.
+      </div>
     </z-notification>
   `,
 } satisfies Story;
 
-/**
- * To use the banner variant set the `sticky` property to `true`.
- */
-export const BannerVariant = {
+export const StickyBanner = {
   args: {
-    notificationText: "Questo è il testo della notifica",
+    "--z-notification--top-offset": "0",
   },
   parameters: {
     controls: {
@@ -115,56 +95,52 @@ export const BannerVariant = {
         .actiontext=${args.actiontext}
         .type=${args.type}
         .showclose=${args.showclose}
-        sticky="true"
-        style="--z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
+        .sticky="true"
+        style="--z-notification--top-offset: ${args[
+          "--z-notification--top-offset"
+        ]}; --z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
       >
-        ${args.notificationText}
+        Questo è il testo della notifica
       </z-notification>
-      <h2 class="heading-1-sb">Titolo della pagina</h2>
-      <div class="body-1">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus magna imperdiet malesuada interdum.
-        Curabitur volutpat mi purus, in maximus nisl volutpat quis. Suspendisse sed vestibulum magna. Quisque molestie,
-        justo non pretium egestas, lorem elit malesuada turpis, et malesuada sapien nunc a urna. Curabitur sagittis
-        augue turpis, eu consectetur purus consectetur vitae. Sed bibendum nisl diam, eget egestas enim elementum eget.
-        Donec quis magna lobortis, tristique nunc in, fringilla lacus. Duis ac porta turpis. Aenean aliquam tortor sed
-        felis interdum aliquet dignissim vel ligula. Donec auctor risus vitae nisi finibus, sed suscipit tellus
-        fringilla. Sed malesuada gravida tincidunt. Duis tincidunt orci at magna egestas fermentum. Nulla laoreet ante
-        felis, non molestie mi venenatis sit amet. Nullam sollicitudin tempus lacus ac maximus. Suspendisse erat magna,
-        pellentesque ut lectus sit amet, aliquet scelerisque augue. In at felis facilisis, sodales tortor euismod,
-        tincidunt tellus. Quisque vulputate dolor vitae nibh pharetra, a auctor turpis mattis. Nulla facilisi. Vivamus a
-        facilisis ex. Vestibulum ultricies scelerisque sapien eu pharetra. Etiam ut porttitor lorem, id ullamcorper
-        risus. Donec sed sollicitudin metus. Sed sapien lectus, bibendum quis lorem efficitur, pellentesque maximus
-        lectus. Quisque quis lectus quis dolor ultrices facilisis placerat finibus nulla. Donec laoreet urna id varius
-        facilisis. Nulla facilisi. Pellentesque dignissim aliquam interdum. Fusce ante mauris, blandit nec imperdiet
-        mattis, dictum non sapien. Donec aliquet feugiat quam quis cursus. Curabitur et rutrum nunc. Phasellus ut lorem
-        posuere, eleifend felis sed, lobortis arcu. Nam efficitur purus non dolor tincidunt, nec euismod lectus
-        hendrerit. Sed eget rutrum odio, ac maximus lacus. Etiam rutrum purus diam, eu pellentesque elit vulputate eget.
-        Donec nulla augue, euismod non mollis congue, laoreet vel orci. Cras eget suscipit felis. Phasellus eget erat eu
-        nisl suscipit pulvinar. Nunc ullamcorper orci sit amet dui placerat, at vulputate libero finibus. Quisque
-        dignissim risus dolor, a porta erat cursus vel. Sed cursus pellentesque magna fringilla varius. Proin sit amet
-        posuere massa. Proin nisl massa, hendrerit non congue mattis, tincidunt in turpis. Etiam pharetra posuere est,
-        non mollis sapien malesuada non. Quisque metus lectus, hendrerit vel accumsan et, ornare a eros. Donec tempor,
-        elit ut pulvinar auctor, sapien velit consectetur justo, interdum lobortis risus ligula vitae nunc. Praesent
-        quam felis, posuere et consequat consectetur, tempus non sem. Phasellus in ligula enim. Donec gravida, felis
-        vitae elementum mattis, velit ipsum aliquam ipsum, a cursus nisi nisl nec sapien. Ut et orci nulla. Donec
-        fringilla magna non risus imperdiet euismod. Sed viverra eget turpis et faucibus. Sed ante orci, interdum in
-        ligula in, tincidunt feugiat arcu. In viverra efficitur urna laoreet tristique. Phasellus hendrerit, urna et
-        condimentum aliquet, ex urna condimentum dui, vitae vestibulum mauris risus sit amet nunc. Quisque egestas est
-        vel lorem commodo, eget vestibulum enim cursus. Cras lectus velit, fermentum eget mauris id, interdum cursus
-        massa. Maecenas quis dui vehicula mauris condimentum finibus. Sed et magna velit. Duis eleifend dolor at
-        sagittis ornare. Aenean commodo massa enim, ac varius augue varius quis.
-      </div>
+      <div class="heading-1-sb">Titolo della pagina</div>
+      <div class="body-1">${DEMO_LONG_TEXT}</div>
     </div>
   `,
 } satisfies Story;
 
-/**
- * To use the inline variant set the `sticky` property to `false`.
- */
-export const InlineVariant = {
+export const CenteredContent = {
   args: {
-    notificationText: "Questo è il testo della notifica",
+    "--z-notification--content-max-width": "768px",
   },
+  render: (args) => html`
+    <z-notification
+      .contenticonname=${args.contenticonname}
+      .actiontext=${args.actiontext}
+      .type=${args.type}
+      .showclose=${args.showclose}
+      .sticky=${args.sticky}
+      .borderposition=${args.borderposition}
+      style="--z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
+    >
+      <div>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus magna imperdiet malesuada interdum.
+        Curabitur volutpat mi purus, in maximus nisl volutpat quis.
+      </div>
+    </z-notification>
+    <div
+      class="z-notification-demo-page"
+      style="max-width: ${args["--z-notification--content-max-width"]}"
+    >
+      <div class="heading-1">Titolo della pagina</div>
+      <div class="body-1">${DEMO_LONG_TEXT}</div>
+    </div>
+  `,
+};
+
+/**
+ * To have an inline notification keep the `sticky` property set to `false`.
+ */
+export const Inline = {
   parameters: {
     controls: {
       exclude: ["sticky"],
@@ -173,22 +149,46 @@ export const InlineVariant = {
   render: (args) => html`
     <div class="inline-notification-demo">
       <z-notification
-        contenticonname=${args.contenticonname}
-        actiontext=${args.actiontext}
-        type=${args.type}
-        showclose=${args.showclose}
-        sticky="false"
+        .contenticonname=${args.contenticonname}
+        .actiontext=${args.actiontext}
+        .type=${args.type}
+        .showclose=${args.showclose}
+        .sticky="false"
         style="--z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
       >
-        ${args.notificationText}
+        Questo è il testo della notifica
       </z-notification>
       <div class="content">
-        <h2 class="heading-1">Titolo della scheda</h2>
+        <div class="heading-1">Titolo della scheda</div>
         <div class="body-1">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent rhoncus magna imperdiet malesuada interdum.
           Curabitur volutpat mi purus, in maximus nisl volutpat quis. Suspendisse sed vestibulum magna.
         </div>
       </div>
+    </div>
+  `,
+} satisfies Story;
+
+/**
+ * The position of the border can be changed to correctly display the notification when put on the bottom of the screen.
+ */
+export const BorderPosition = {
+  args: {
+    borderposition: "top",
+  },
+  render: (args) => html`
+    <div class="z-notification-border-position-demo">
+      <z-notification
+        .contenticonname=${args.contenticonname}
+        .actiontext=${args.actiontext}
+        .type=${args.type}
+        .showclose=${args.showclose}
+        .sticky=${args.sticky}
+        .borderposition=${args.borderposition}
+        style="--z-notification--content-max-width: ${args["--z-notification--content-max-width"]}"
+      >
+        <div class="notification-container"><strong>NOVITÀ</strong>: Testo che descrive le novità.</div>
+      </z-notification>
     </div>
   `,
 } satisfies Story;

--- a/src/components/z-notification/index.stories.ts
+++ b/src/components/z-notification/index.stories.ts
@@ -20,6 +20,12 @@ const StoryMeta = {
       },
       options: Object.values(NotificationType),
     },
+    borderposition: {
+      control: {
+        type: "inline-radio",
+      },
+      options: ["top", "bottom"],
+    },
   },
   args: {
     "--z-notification--content-max-width": "100%",
@@ -51,9 +57,9 @@ export const Default = {
 } satisfies Story;
 
 /**
- * To use the border top variant set the `borderposition` property to `top`.
+ * The position of the border can be changed to correctly display the notification on the bottom of the screen.
  */
-export const BorderTop = {
+export const BorderPosition = {
   args: {
     borderposition: "top",
   },

--- a/src/components/z-notification/index.tsx
+++ b/src/components/z-notification/index.tsx
@@ -5,8 +5,8 @@ import {NotificationType} from "../../beans";
  * Notification bar component.
  * @slot - The text of the notification.
  * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
- * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
- * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
+ * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%. Note: the content is automatically centered, so if you want to limit the width only for the slotted content, you can wrap it in a container with the desired width and leave the `z-notification` width to 100%.
+ * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful to align the content when the `--z-notification--content-max-width` is set. Default: calc(var(--space-unit) * 2).
  */
 @Component({
   tag: "z-notification",

--- a/src/components/z-notification/index.tsx
+++ b/src/components/z-notification/index.tsx
@@ -5,7 +5,8 @@ import {NotificationType} from "../../beans";
  * Notification bar component.
  * @slot - The text of the notification.
  * @cssprop --z-notification--top-offset - The top offset of the notification. Use it when `sticky` prop is set to `true` and you need the notification to stay under other sticky elements. Default: 0px.
- * @cssprop --z-notification--content-max-width - The max width of the notification content.
+ * @cssprop --z-notification--content-max-width - The max width of the notification content. Useful to align the content with other elements on the page, keeping the colored background full width. Default: 100%.
+ * @cssprop --z-notification--inline-padding - The inline padding of the notification content. It can be useful for aligning the content when the notification is not full width. Default: calc(var(--space-unit) * 2).
  */
 @Component({
   tag: "z-notification",

--- a/src/components/z-notification/styles.css
+++ b/src/components/z-notification/styles.css
@@ -1,6 +1,7 @@
 :host {
   --z-notification--top-offset: 0;
   --z-notification--content-max-width: 100%;
+  --z-notification--inline-padding: ;
 
   display: block;
   width: 100%;
@@ -10,7 +11,7 @@
   display: flex;
   max-width: var(--z-notification--content-max-width);
   align-items: flex-start;
-  padding: calc(var(--space-unit) * 2);
+  padding: calc(var(--space-unit) * 2) var(--z-notification--inline-padding, calc(var(--space-unit) * 2));
   margin: 0 auto;
   background-color: transparent;
   font-family: var(--font-family-sans);
@@ -90,6 +91,7 @@ button {
 }
 
 .content-text {
+  width: 100%;
   color: var(--color-default-text);
   font-size: var(--font-size-2);
   font-weight: var(--font-rg);

--- a/src/components/z-notification/styles.css
+++ b/src/components/z-notification/styles.css
@@ -96,7 +96,7 @@ button {
   font-size: var(--font-size-2);
   font-weight: var(--font-rg);
   letter-spacing: 0.16px;
-  line-height: 20px;
+  line-height: 1.4;
 }
 
 .action-button {
@@ -104,12 +104,12 @@ button {
   font-size: var(--font-size-1);
   font-weight: var(--font-sb);
   letter-spacing: 0.32px;
-  line-height: 16px;
+  line-height: 1.333;
+  outline: none;
 }
 
-.action-button:focus {
+.action-button:focus-visible {
   box-shadow: var(--shadow-focus-primary);
-  outline: none !important;
 }
 
 .content-container + .close-button {
@@ -121,7 +121,7 @@ button {
 }
 
 /* Tablet breakpoint */
-@media only screen and (min-width: 768px) {
+@media (min-width: 768px) {
   .content-container {
     flex-wrap: nowrap;
   }


### PR DESCRIPTION
## Motivation and Context
This PR fixes the width of the content's container expanding it, and adds the `--z-notification--inline-padding` css prop to change the right and left padding. This is needed when `content-max-width` is set to override the fixed `16px` padding and correctly align the content of the notification with the content of the page.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Indicate the product reference if applicable -->

## Priority

<!--- Please describe the priority following the scale, put an `x` only in the box that apply: -->
<!--- from 1 (highest) to 5 (lowest) or 6 (not a priority) -->

- [ ] 1 - Highest
- [ ] 2 - High
- [x] 3 - Medium
- [ ] 4 - Low
- [ ] 5 - Lowest
- [ ] 6 - Not a Priority

## Types of changes

<!--- Same as Title tag. Please describe the PR type -->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Component (add a Component as approved by Design System)
- [ ] Docs (add documentation)
- [ ] Chore (changes that adds small enhancement)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)