### PR TITLE
fix(z-link): add persistent underline to links for WCAG 1.4.1

### DIFF
--- a/src/components/css-components/z-link/styles.css
+++ b/src/components/css-components/z-link/styles.css
@@ -11,7 +11,8 @@ button.z-link {
   cursor: pointer;
   font-family: var(--font-family-sans);
   line-height: inherit;
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }
 
 a.z-link.z-link-icon,
@@ -40,6 +41,7 @@ button.z-link:focus-visible,
 a.z-link:active,
 button.z-link:active {
   text-decoration: underline;
+  text-decoration-thickness: 0.125em;
 }
 
 a.z-link:focus-visible,


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding persistent underlines to all `z-link` elements in their default state.

**Issue**: Hyperlinks throughout Zanichelli applications (login modal, footer, registration forms) are distinguished from regular text primarily by color. Users with color vision deficiencies cannot reliably identify these as clickable links.

**Solution**: Modified the `z-link` CSS component to display underlines by default, with `text-underline-offset` for readability and thicker underlines on hover/focus/active states for enhanced visual feedback.

## Changes

- Changed default `text-decoration` from `none` to `underline`
- Added `text-underline-offset: 0.15em` for better readability
- Added `text-decoration-thickness: 0.125em` on hover/focus/active states

## Test Plan

- [x] Links have visible underlines in default state
- [x] Underlines become thicker on hover/focus for additional feedback
- [x] Disabled links correctly retain `text-decoration: none`
- [x] Stylelint passes

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/ck6mnfq3o5afa6e29cptu8oxwx/

---

**WCAG Reference:**
[1.4.1 Use of Color (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)