### PR TITLE
fix(z-modal): catch escaped focus in modal focus trap

### DIFF
--- a/src/components/z-modal/index.tsx
+++ b/src/components/z-modal/index.tsx
@@ -157,14 +157,30 @@ export class ZModal implements ComponentInterface {
     const activeElement = this.host.ownerDocument.activeElement;
     const firstFocusableElement = focusableElements[0];
     const lastFocusableElement = focusableElements[focusableElements.length - 1];
-    if (e.shiftKey && (shadowActiveElement == firstFocusableElement || activeElement == firstFocusableElement)) {
-      // shift + tab was pressed and current active element is the first focusable element
+
+    const focusIsOnFirst = shadowActiveElement == firstFocusableElement || activeElement == firstFocusableElement;
+    const focusIsOnLast = shadowActiveElement == lastFocusableElement || activeElement == lastFocusableElement;
+    const focusIsInList =
+      focusIsOnFirst ||
+      focusIsOnLast ||
+      focusableElements.includes(shadowActiveElement as HTMLElement) ||
+      focusableElements.includes(activeElement as HTMLElement);
+
+    if (e.shiftKey && focusIsOnFirst) {
       e.preventDefault();
       lastFocusableElement.focus();
-    } else if (!e.shiftKey && (shadowActiveElement == lastFocusableElement || activeElement == lastFocusableElement)) {
-      // shift + tab was pressed and current active element is the first focusable element
+    } else if (!e.shiftKey && focusIsOnLast) {
       e.preventDefault();
       firstFocusableElement.focus();
+    } else if (!focusIsInList) {
+      // Focus has escaped to a non-focusable element (e.g., the host or dialog container).
+      // Redirect it back into the modal.
+      e.preventDefault();
+      if (e.shiftKey) {
+        lastFocusableElement.focus();
+      } else {
+        firstFocusableElement.focus();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.3 (Focus Order)** by catching escaped focus in the `<z-modal>` focus trap.

**Issue**: When tabbing through modal elements, focus escapes to the `<z-modal>` host element after the last interactive element, before cycling back into the modal inputs. This creates an unpredictable stop in the tab sequence that breaks focus order for keyboard and screen reader users.

**Solution**: Added a fallback in `handleKeyDown` that detects when the active element is not in the list of known focusable elements (i.e., focus has escaped to the host or dialog container) and redirects it back to the appropriate boundary element based on tab direction.

## Test Plan

- [x] Built the component successfully without errors
- [x] Linting (eslint, prettier, stylelint) passes
- [x] Verified focus escape behavior on production (my.zanichelli.it login modal)
- [x] Focus trap logic handles escaped focus by redirecting to first/last focusable element

## Evidence

View full audit details and evidence:
https://app.workback.ai/dashboard/issue/2773/

---

**WCAG Reference:**
[2.4.3 Focus Order (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)