### PR TITLE
fix(z-carousel): add status announcements for carousel navigation

### DIFF
--- a/src/components/z-carousel/index.tsx
+++ b/src/components/z-carousel/index.tsx
@@ -69,6 +69,10 @@ export class ZCarousel {
   @State()
   canNavigateNext: boolean;
 
+  /** Status message for screen reader announcements. */
+  @State()
+  statusMessage = "";
+
   /** Reference for the items container element. */
   protected itemsContainer: HTMLUListElement;
 
@@ -88,6 +92,9 @@ export class ZCarousel {
   @Watch("current")
   onIndexChange(): void {
     this.indexChange.emit({currentItem: this.current});
+    if (this.single && this.items) {
+      this.statusMessage = `Elemento ${this.current + 1} di ${this.items.length}`;
+    }
   }
 
   @Watch("single")
@@ -158,6 +165,7 @@ export class ZCarousel {
           : -this.itemsContainer.clientWidth / 2,
       behavior: "smooth",
     });
+    this.statusMessage = "Elementi precedenti visualizzati";
   }
 
   private onNext(): void {
@@ -178,6 +186,7 @@ export class ZCarousel {
           : this.itemsContainer.clientWidth / 2,
       behavior: "smooth",
     });
+    this.statusMessage = "Elementi successivi visualizzati";
   }
 
   /**
@@ -276,6 +285,14 @@ export class ZCarousel {
           aria-label={this.label || "Carousel"}
         >
           {this.label && <div class="z-carousel-title heading-3-sb">{this.label}</div>}
+          <div
+            class="z-carousel-status"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {this.statusMessage}
+          </div>
           <div class="z-carousel-wrapper">
             <z-button
               class="z-carousel-navigation-arrow"

--- a/src/components/z-carousel/styles.css
+++ b/src/components/z-carousel/styles.css
@@ -27,6 +27,19 @@
   margin-bottom: calc(var(--space-unit) * 2);
 }
 
+.z-carousel-status {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: 0 -1px -1px 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 .z-carousel-wrapper {
   position: relative;
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 4.1.3 (Status Messages)** by adding screen reader announcements when carousel content changes.

**Issue**: When users click the carousel navigation buttons (next/previous), no status message is announced. Screen reader users receive no feedback about what content is now displayed, violating WCAG 4.1.3.

**Solution**: Added a visually-hidden live region (`role="status"` with `aria-live="polite"`) inside the carousel shadow DOM that announces navigation changes:
- **Single mode**: Announces current item position (e.g., "Elemento 2 di 8")
- **Multi-item mode**: Announces navigation direction (e.g., "Elementi successivi visualizzati" / "Elementi precedenti visualizzati")

## Changes

- Added `statusMessage` state property to track the current announcement text
- Added a visually-hidden `<div role="status" aria-live="polite" aria-atomic="true">` element in the render output
- Updated `onIndexChange` watcher to set position-based status messages in single mode
- Updated `onPrev()` and `onNext()` to set direction-based status messages in multi-item mode
- Added `.z-carousel-status` CSS class with standard visually-hidden styling

## Test Plan

- [x] Multi-item carousel announces "Elementi successivi visualizzati" when clicking next
- [x] Multi-item carousel announces "Elementi precedenti visualizzati" when clicking previous
- [x] Single-item carousel announces "Elemento X di Y" on index change
- [x] Status element is visually hidden but accessible to screen readers
- [x] All linters pass (prettier, eslint, stylelint)

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/mh9avfu4bpvwvrf3jhkr4ifyvn/

---

**WCAG Reference:**
[4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)
