### PR TITLE
fix(z-combobox): add aria-label to header for selected filter count (WCAG 2.4.6)

### DIFF
--- a/src/components/z-combobox/index.spec.ts
+++ b/src/components/z-combobox/index.spec.ts
@@ -59,7 +59,7 @@ describe("Suite test ZCombobox", () => {
           <mock:shadow-root>
             <div class="fixed" id="combobox" data-action="combo-combobox">
               <div aria-controls="combobox_list" aria-expanded="false" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-                <span class="body-3" aria-label="label">
+                <span class="body-3" >
                   label
                   <span></span>
                 </span>
@@ -87,8 +87,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]' inputid="combobox" label="label">
           <mock:shadow-root>
             <div data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="false" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-                <span class="body-3" aria-label="label - 1 selezionati">
+              <div aria-controls="combobox_list" aria-expanded="false" aria-activedescendant="" aria-label="label: 1 elemento selezionato" class="header" role="combobox" tabindex="0">
+                <span class="body-3">
                   label
                   <span>(1)</span>
                 </span>
@@ -163,8 +163,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" aria-label="combo: 1 elemento selezionato" class="header" role="combobox" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -208,8 +208,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="open-combo-data" aria-expanded="true" class="header" role="button" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="open-combo-data" aria-expanded="true" aria-label="combo: 1 elemento selezionato" class="header" role="button" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -255,8 +255,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="open-combo-data" aria-expanded="true" class="header" role="button" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="open-combo-data" aria-expanded="true" aria-label="combo: 1 elemento selezionato" class="header" role="button" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -294,8 +294,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" hassearch=true searchlabel="cerca" searchplaceholder="placeholder" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]' noresultslabel='non ci sono risultati'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="open-combo-data" aria-expanded="true" class="header" role="button" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="open-combo-data" aria-expanded="true" aria-label="combo: 1 elemento selezionato" class="header" role="button" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -323,8 +323,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" aria-label="combo: 1 elemento selezionato" class="header" role="combobox" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -374,8 +374,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":true}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-              <span class="body-3" aria-label="combo - 2 selezionati">combo<span>(2)</span></span>
+              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" aria-label="combo: 2 elementi selezionati" class="header" role="combobox" tabindex="0">
+              <span class="body-3">combo<span>(2)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -425,8 +425,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" maxcheckableitems="1" items='[{"id":"item_1","name":"primo elemento","checked":false},{"id":"item_2","name":"secondo elemento","checked":true}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" aria-label="combo: 1 elemento selezionato" class="header" role="combobox" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -470,8 +470,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" maxcheckableitems="3" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":false}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" aria-label="combo: 1 elemento selezionato" class="header" role="combobox" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">
@@ -521,8 +521,8 @@ describe("Suite test ZCombobox", () => {
         <z-combobox inputid="combobox" label="combo" maxcheckableitems="1" hascheckall="true" checkalltext="CHECK" uncheckalltext="UNCHECK" items='[{"id":"item_1","name":"primo elemento","checked":true},{"id":"item_2","name":"secondo elemento","checked":false}]'>
           <mock:shadow-root>
             <div class="open" data-action="combo-combobox" id="combobox">
-              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" class="header" role="combobox" tabindex="0">
-              <span class="body-3" aria-label="combo - 1 selezionati">combo<span>(1)</span></span>
+              <div aria-controls="combobox_list" aria-expanded="true" aria-activedescendant="" aria-label="combo: 1 elemento selezionato" class="header" role="combobox" tabindex="0">
+              <span class="body-3">combo<span>(1)</span></span>
                 <z-icon class="big" name="caret-down" />
               </div>
               <div class="open-combo-data" id="open-combo-data">

--- a/src/components/z-combobox/index.tsx
+++ b/src/components/z-combobox/index.tsx
@@ -316,9 +316,18 @@ export class ZCombobox implements ComponentInterface {
     this.isopen = !this.isopen;
   }
 
+  private getHeaderAriaLabel(): string | undefined {
+    if (!this.label || this.selectedCounter <= 0) {
+      return undefined;
+    }
+
+    const suffix = this.selectedCounter === 1 ? "elemento selezionato" : "elementi selezionati";
+
+    return `${this.label}: ${this.selectedCounter} ${suffix}`;
+  }
+
   private getComboboxA11yAttributes(isZInput: boolean): Record<string, string> {
     const role = "combobox";
-    const ariaLabel = this.htmlAriaLabel;
     const ariaExpanded = this.isopen ? "true" : "false";
     const ariaActivedescendant = this.isopen ? this.focusedItemId : "";
     const ariaControls = `${this.inputid}_list`;
@@ -326,7 +335,7 @@ export class ZCombobox implements ComponentInterface {
     if (isZInput) {
       return {
         "role": role,
-        "aria-label": ariaLabel,
+        "aria-label": this.htmlAriaLabel,
         "html-aria-expanded": ariaExpanded,
         "html-aria-activedescendant": ariaActivedescendant,
         "html-aria-controls": ariaControls,
@@ -335,7 +344,6 @@ export class ZCombobox implements ComponentInterface {
 
     return {
       "role": role,
-      "aria-label": ariaLabel,
       "aria-expanded": ariaExpanded,
       "aria-activedescendant": ariaActivedescendant,
       "aria-controls": ariaControls,
@@ -354,16 +362,10 @@ export class ZCombobox implements ComponentInterface {
         tabindex={0}
         aria-controls="open-combo-data"
         aria-expanded={this.isopen ? "true" : "false"}
+        aria-label={this.getHeaderAriaLabel()}
         {...comboboxA11yAttributes}
       >
-        <span
-          class="body-3"
-          aria-label={
-            this.label
-              ? `${this.label}${this.selectedCounter > 0 ? ` - ${this.selectedCounter} selezionati` : ``}`
-              : undefined
-          }
-        >
+        <span class="body-3">
           {this.label}
           <span>{this.selectedCounter > 0 && ` (${this.selectedCounter})`}</span>
         </span>


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.6 (Headings and Labels)** by moving the descriptive `aria-label` from an inner `<span>` (which has no semantic role) to the header `<div>` (which has `role="combobox"` or `role="button"`).

**Issue**: When filters are selected, the button text changes from "Materia" to "Materia (1)". Screen readers announce "Materia (1)" without clarifying what "(1)" means — it could be "1 filter applied", "1 option available", or "1 result". The existing `aria-label` on the inner span is not used by assistive technology for the button's accessible name.

**Solution**: The header `<div>` now receives `aria-label="Materia: 1 elemento selezionato"` (or plural `"N elementi selezionati"`), providing clear context for screen reader users. Uses correct Italian singular/plural forms.

**Note**: This PR follows up on the approach from #647, which was closed pending #646 (ZCombobox/ZSelect accessibility restructuring). That prerequisite has since been merged.

## Test Plan

- [x] All 15 z-combobox unit tests pass
- [x] Full test suite passes (69 suites, 334 tests)
- [x] Build completes successfully (`yarn build`)
- [x] Verified on production that the issue exists (header div has no `aria-label`)
- [ ] Verify screen reader announces "Materia: 1 elemento selezionato" after filter selection

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/xs9rtj7krbbgyffhmp3vuymgbg/

---

**WCAG Reference:**
[2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)