### PR TITLE
fix(z-result-card): allow text wrapping at high zoom levels

### DIFF
--- a/src/components/z-result-card/styles.css
+++ b/src/components/z-result-card/styles.css
@@ -55,14 +55,11 @@ z-book-cover {
 }
 
 .card-subtitle {
-  display: -webkit-box;
   overflow: hidden;
-  -webkit-box-orient: vertical;
   color: var(--color-default-text);
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
   line-height: 1.4;
-  word-break: break-word;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tags-container {
@@ -138,8 +135,8 @@ z-book-cover {
     display: -webkit-box;
     overflow: hidden;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
     line-height: 1.4;
     word-break: break-word;
   }

--- a/src/components/z-result-card/styles.css
+++ b/src/components/z-result-card/styles.css
@@ -7,7 +7,7 @@
   display: flex;
   overflow: hidden;
   min-width: 0;
-  height: 11.125rem;
+  min-height: 11.125rem;
   padding: var(--space-unit);
   border: var(--border-size-medium) solid var(--color-surface02);
   background-color: var(--color-surface01);
@@ -55,10 +55,14 @@ z-book-cover {
 }
 
 .card-subtitle {
+  display: -webkit-box;
   overflow: hidden;
+  -webkit-box-orient: vertical;
   color: var(--color-default-text);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .tags-container {
@@ -131,10 +135,12 @@ z-book-cover {
 
 @media (max-width: 767px) {
   .card-title {
-    display: block;
+    display: -webkit-box;
     overflow: hidden;
-    line-height: normal;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    line-height: 1.4;
+    word-break: break-word;
   }
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.4 (Resize Text)** by allowing result card text to wrap instead of being truncated at high zoom levels.

**Issue**: When users zoom to 200%, book titles and subtitles in `z-result-card` are truncated with ellipsis or hidden entirely, making it impossible to distinguish between similar products (e.g., different editions of the same textbook).

**Solution**:
- Changed card `height` to `min-height` so cards can expand when text wraps
- Changed subtitle from single-line `nowrap` truncation to 2-line clamp with wrapping
- Changed mobile breakpoint title from single-line `nowrap` truncation to 3-line clamp with wrapping

## Test Plan

- [x] Verify cards display normally at 100% zoom
- [x] Verify text wraps appropriately at 200% zoom without truncation
- [x] Verify `z-result-card` spec tests pass (7/7)
- [x] Verify stylelint passes
- [x] Verify build succeeds

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/22/

---

**WCAG Reference:** [1.4.4 Resize Text (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html)