### PR TITLE
fix(z-input): add focus-visible indicator for links in checkbox/radio labels

### DIFF
--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -117,6 +117,14 @@
   box-shadow: var(--shadow-focus-primary);
 }
 
+/* focus on links inside labels */
+.radio-wrapper .radio-label a:focus-visible,
+.checkbox-wrapper .checkbox-label a:focus-visible {
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
+  text-decoration: underline;
+}
+
 /* disabled */
 .radio-wrapper > input:disabled + .radio-label,
 .checkbox-wrapper > input:disabled + .checkbox-label {


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.7 (Focus Visible)** by adding visible focus indicators to links rendered inside checkbox and radio button labels in the `z-input` component.

**Issue**: Links embedded in checkbox labels (e.g., "Linee di condotta" in registration consent forms) had no visible focus indicator when navigated via keyboard, leaving keyboard users unable to determine their current focus position.

**Solution**: Added `:focus-visible` styles for `<a>` elements inside `.checkbox-label` and `.radio-label`, using the design system's existing `--shadow-focus-primary` box-shadow pattern (consistent with `z-link` focus styles) plus underline text decoration.

## Technical Changes

Added to `src/components/z-input/styles-checkbox-radio.css`:

```css
/* focus on links inside labels */
.radio-wrapper .radio-label a:focus-visible,
.checkbox-wrapper .checkbox-label a:focus-visible {
  box-shadow: var(--shadow-focus-primary);
  outline: none;
  text-decoration: underline;
}
```

## Test Plan

- [x] Focus indicator appears on links inside checkbox labels when navigating with Tab key
- [x] Focus style uses the design system's standard `--shadow-focus-primary` pattern
- [x] No focus indicator appears on mouse click (`:focus-visible` only triggers for keyboard)
- [x] Stylelint passes
- [x] Prettier formatting passes

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/9x6s6n2wbona9iqwds3kioixrg/

---

**WCAG Reference:**
[2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)