### PR TITLE
fix(z-input): enforce 24px minimum target size on checkbox and radio wrapper and icon

### DIFF
--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -46,8 +46,6 @@
 
 .radio-wrapper .radio-label z-icon,
 .checkbox-wrapper .checkbox-label z-icon {
-  min-width: 24px;
-  min-height: 24px;
   cursor: pointer;
   fill: inherit;
 }

--- a/src/components/z-input/styles-checkbox-radio.css
+++ b/src/components/z-input/styles-checkbox-radio.css
@@ -2,6 +2,7 @@
 .checkbox-wrapper {
   position: relative;
   display: inline-flex;
+  min-height: 24px;
   flex-direction: row;
   align-items: center;
   color: var(--color-default-text);
@@ -45,6 +46,8 @@
 
 .radio-wrapper .radio-label z-icon,
 .checkbox-wrapper .checkbox-label z-icon {
+  min-width: 24px;
+  min-height: 24px;
   cursor: pointer;
   fill: inherit;
 }


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.5.8 (Target Size Minimum)** by enforcing 24px minimum dimensions on checkbox and radio wrapper, label, and icon elements.

**Issue**: The previous fix (PR #608) added `min-height: 24px` only to the `.checkbox-label` / `.radio-label`, but the wrapper and icon remained undersized. In production, the checkbox target was still 18px tall, making it difficult for users with motor impairments to accurately click.

**Solution**: Apply `min-height: 24px` at three levels:
1. **Wrapper** (`.checkbox-wrapper` / `.radio-wrapper`): ensures the outermost container meets the minimum
2. **Label** (already present from PR #608): preserved
3. **Icon** (`z-icon`): add `min-width: 24px` and `min-height: 24px` so the visual checkbox/radio indicator itself meets the 24x24px target

## Test Plan

- [x] Stylelint passes (idiomatic order verified)
- [x] All spec tests pass (69/69 suites, 333/333 tests)
- [x] Build succeeds
- [x] Compiled output includes `min-height:24px` on wrapper, label, and icon

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/u4ha2d5hsk7868ghfauv3gmn4p/

---

**WCAG Reference:**
[2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)