### PR TITLE
fix(z-input): reflect required prop to host element attribute

### DIFF
--- a/src/components/z-input/index.tsx
+++ b/src/components/z-input/index.tsx
@@ -80,7 +80,7 @@ export class ZInput implements ComponentInterface {
   readonly?: boolean = false;
 
   /** the input is required (optional): available for text, password, number, email, textarea, checkbox */
-  @Prop()
+  @Prop({reflect: true})
   required?: boolean = false;
 
   /** checked: available for checkbox, radio */

--- a/src/components/z-input/test-text.spec.ts
+++ b/src/components/z-input/test-text.spec.ts
@@ -134,6 +134,28 @@ describe("Suite test ZInput - text", () => {
     `);
   });
 
+  it("Test render ZInput con attributo required", async () => {
+    const page = await newSpecPage({
+      components: [ZInput],
+      html: `<z-input message="false" type="text" htmlid="test" placeholder="placeholder" value="value" label="label" required></z-input>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <z-input message="false" type="text" htmlid="test" placeholder="placeholder" size="big" value="value" label="label" required>
+          <div class="text-wrapper">
+            <label class="body-5-sb z-label" for="test" id="test_label">label</label>
+            <div>
+              <input required class="has-clear-icon" type="text" id="test" placeholder="placeholder" value="value" />
+              <span class="icons-wrapper">
+                <button type="button" class="input-icon reset-icon" aria-label="cancella il contenuto dell'input">
+                  <z-icon class="big" name="multiply"></z-icon>
+                </button>
+              </span>
+            </div>
+          </div>
+      </z-input>
+    `);
+  });
+
   it("Test render ZInput con attributi readonly", async () => {
     const page = await newSpecPage({
       components: [ZInput],


### PR DESCRIPTION
## Summary

Fixes **WCAG 3.3.2 (Labels or Instructions)** by adding `{reflect: true}` to the `required` prop on the `z-input` component.

**Issue**: The `required` prop on `z-input` was defined with `@Prop()` (no reflection), while `disabled` used `@Prop({reflect: true})`. In React 17 applications (like `myzanichelli_signup`), this caused the `required` attribute to never reach the native `<input>` element. React 17 sets attributes on custom elements, not properties, and without `reflect: true`, Stencil did not properly sync the attribute to its internal state or the native input.

**Solution**: Add `{reflect: true}` to the `required` `@Prop()` decorator, matching the existing pattern used by `disabled`. This ensures the `required` attribute is reflected bidirectionally between the host element and the component's internal state, so the native `<input>` correctly receives the `required` attribute regardless of whether the consumer sets it via attribute or property.

**Root cause analysis**: A previous PR ([myzanichelli_signup #405](https://bitbucket.org/zanichelli/myzanichelli_signup/pull-requests/405)) correctly added `required={true}` to `z-input` components in the signup app, but this had no effect because the design-system component did not reflect the prop. The fix belongs here in the design-system, not in the consuming application.

## Test Plan

- [x] Verified on staging (testmy.zanichelli.it) that the native `<input>` does NOT have `required` attribute (before fix)
- [x] Confirmed `disabled` prop (which already uses `{reflect: true}`) correctly reflects to the host element attribute
- [x] Change is minimal: single line, matching existing `disabled` prop pattern

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/gxj2f3783rx4onvtikp829ksf7/

---

**WCAG Reference:**
[3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html)