### PR TITLE
fix(z-stepper-item): add non-color visual indicators for step states

### DIFF
--- a/src/components/z-stepper-item/styles.css
+++ b/src/components/z-stepper-item/styles.css
@@ -83,6 +83,7 @@
 :host([pressed]:not([disabled])) .indicator {
   border-color: var(--color-hover-primary);
   background: var(--color-hover-primary);
+  box-shadow: 0 0 0 3px var(--color-surface01), 0 0 0 5px var(--color-hover-primary);
   color: var(--color-text-inverse);
 }
 
@@ -96,6 +97,7 @@
 }
 
 :host([disabled]) .indicator {
+  border-style: dashed;
   border-color: var(--color-disabled02);
   background: var(--color-disabled01);
   color: var(--color-disabled03);

--- a/src/components/z-stepper-item/styles.css
+++ b/src/components/z-stepper-item/styles.css
@@ -83,7 +83,9 @@
 :host([pressed]:not([disabled])) .indicator {
   border-color: var(--color-hover-primary);
   background: var(--color-hover-primary);
-  box-shadow: 0 0 0 3px var(--color-surface01), 0 0 0 5px var(--color-hover-primary);
+  box-shadow:
+    0 0 0 3px var(--color-surface01),
+    0 0 0 5px var(--color-hover-primary);
   color: var(--color-text-inverse);
 }
 


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.4.1 (Use of Color)** by adding non-color visual indicators to the `z-stepper-item` component.

**Issue**: The stepper component relies on color alone to distinguish between active, completed, and disabled step states. Users with color vision deficiencies cannot determine their progress through multi-step flows (e.g., registration).

**Solution**: Two CSS-only additions that give each state a distinct shape/style beyond color:
- **Active step** (`pressed`): double-ring box-shadow around the indicator circle
- **Disabled/future steps** (`disabled`): dashed border style on the indicator circle
- **Completed steps** (`checked`): already have a checkmark icon (no change needed)

This is a minimal, non-breaking change (2 lines of CSS). No markup, JS, or visual layout changes.

## Test Plan

- [x] `yarn test` passes (333 tests, 69 suites)
- [x] `yarn lint.stylelint` passes with no errors
- [x] `yarn build` succeeds
- [x] Verified stepper states render correctly in registration flow on staging

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/8yt3y2teqejku4qfk8raffc5aq/

---

**WCAG Reference:**
[1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)