### PR TITLE
fix(z-input-message): move id to host element for aria-describedby accessibility

### DIFF
--- a/src/components/z-input-message/index.spec.ts
+++ b/src/components/z-input-message/index.spec.ts
@@ -10,9 +10,9 @@ describe("Suite test ZInputMessage", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <z-input-message html-id="esempio_vuoto" aria-label="">
+      <z-input-message html-id="esempio_vuoto" aria-label="" id="esempio_vuoto">
         <mock:shadow-root>
-          <span id="esempio_vuoto"></span>
+          <span></span>
         </mock:shadow-root>
       </z-input-message>
     `);
@@ -25,9 +25,9 @@ describe("Suite test ZInputMessage", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message">
+      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" id="esempio">
         <mock:shadow-root>
-          <span id="esempio">message</span>
+          <span>message</span>
         </mock:shadow-root>
       </z-input-message>
     `);
@@ -40,10 +40,10 @@ describe("Suite test ZInputMessage", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" status="success" role="alert">
+      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" status="success" role="alert" id="esempio">
         <mock:shadow-root>
           <z-icon name="checkmark-circle"></z-icon>
-          <span id="esempio">message</span>
+          <span>message</span>
         </mock:shadow-root>
       </z-input-message>
     `);
@@ -56,10 +56,10 @@ describe("Suite test ZInputMessage", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" status="success"  html-role="status" role="status">
+      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" status="success" html-role="status" role="status" id="esempio">
         <mock:shadow-root>
           <z-icon name="checkmark-circle"></z-icon>
-          <span id="esempio">message</span>
+          <span>message</span>
         </mock:shadow-root>
       </z-input-message>
     `);
@@ -72,10 +72,10 @@ describe("Suite test ZInputMessage", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" status="success" html-role="">
+      <z-input-message html-id="esempio" tabindex="0" aria-label="message" message="message" status="success" html-role="" id="esempio">
         <mock:shadow-root>
           <z-icon name="checkmark-circle"></z-icon>
-          <span id="esempio">message</span>
+          <span>message</span>
         </mock:shadow-root>
       </z-input-message>
     `);

--- a/src/components/z-input-message/index.tsx
+++ b/src/components/z-input-message/index.tsx
@@ -50,12 +50,12 @@ export class ZInputMessage implements ComponentInterface {
 
   render(): HTMLZInputMessageElement {
     return (
-      <Host {...this.statusRole}>
+      <Host
+        id={this.htmlId}
+        {...this.statusRole}
+      >
         {this.statusIcons[this.status] && this.message && <z-icon name={this.statusIcons[this.status]}></z-icon>}
-        <span
-          id={this.htmlId}
-          innerHTML={this.message}
-        />
+        <span innerHTML={this.message} />
       </Host>
     );
   }


### PR DESCRIPTION
## Summary

Fixes **WCAG 1.3.1 (Info and Relationships)** by moving the `id` attribute in `z-input-message` from a `<span>` inside shadow DOM to the host element in the light DOM.

**Issue**: When `z-input-message` is used alongside `z-input` (e.g., in `license-activation-form`), the error message cannot be programmatically associated with the input field via `aria-describedby`. The `id` attribute was on a `<span>` inside the component's shadow root, which is unreachable from the light DOM where `aria-describedby` references are resolved. Screen reader users cannot determine which error message belongs to which input field.

**Solution**: Set the `id` on the `<Host>` element (the `<z-input-message>` custom element tag) instead of the inner `<span>`. The host element lives in the light DOM, making it a valid target for `aria-describedby`. This also fixes the existing z-input internal plumbing: `renderMessage()` already sets `aria-describedby="${htmlid}-message"` and passes `html-id="${htmlid}-message"` to z-input-message, but the reference was broken because the target id was inside shadow DOM.

## Test Plan

- [x] All z-input-message unit tests updated and passing
- [x] All z-input unit tests passing (no changes needed)
- [x] Full test suite (69 suites, 333 tests) passing
- [x] Lint clean (0 errors)
- [x] Verified on production site that the current id is inside shadow DOM and unreachable

## Evidence

View before/after screenshots and full audit details:
https://app.workback.ai/issues/9myjfhvnaavwvpwii6d6672794/

---

**WCAG Reference:**
[1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)