### PR TITLE
fix(z-logo): add visible focus indicator to logo link

### DIFF
--- a/src/components/z-logo/styles.css
+++ b/src/components/z-logo/styles.css
@@ -19,6 +19,11 @@ a {
   height: 100%;
 }
 
+a:focus-visible {
+  box-shadow: var(--shadow-focus-primary);
+  outline: none;
+}
+
 :host(.mobile) {
   width: 31px;
   height: 40px;


### PR DESCRIPTION
## Summary

Fixes **WCAG 2.4.7 (Focus Visible)** by adding a visible focus indicator to the `z-logo` component when it contains a link.

**Issue**: The `z-logo` element receives keyboard focus (via its internal `<a>` tag in the shadow DOM) but provides no visual feedback. Keyboard users cannot tell when focus is on the logo, breaking navigation flow.

**Solution**: Added `a:focus-visible` styles inside the shadow DOM using the design system's standard `--shadow-focus-primary` pattern, consistent with `z-link`, `z-book-card`, and other interactive components.

## Technical Details

The `z-logo` component uses `shadow: true`, so focus styles must live in the component's own CSS. The `<a>` element inside the shadow DOM is the actual focus target. CSS custom properties (`--shadow-focus-primary`) inherit through the shadow boundary, so the focus ring adapts to the host page's theme.

```css
a:focus-visible {
  box-shadow: var(--shadow-focus-primary);
  outline: none;
}
```

On zanichelli.it, `--shadow-focus-primary` resolves to `0 0 0 2px #fff, 0 0 2px 5px #121212` (white inner ring + dark outer ring), which is clearly visible against the dark header background.

## Test Plan

- [x] Keyboard navigation: Tab to logo and verify focus ring appears
- [x] Verified `--shadow-focus-primary` resolves correctly on zanichelli.it
- [x] Existing spec tests pass (`z-logo/index.spec.ts`)
- [x] Stylelint and Prettier pass

## Evidence

View before/after screenshots and full audit details:
- https://app.workback.ai/issues/97md36jmo7reinyoyxhdoy3v83/
- https://app.workback.ai/issues/r28brphnj778ygv5otwet73vus/

---

**WCAG Reference:**
[2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)